### PR TITLE
cairo backend: MeasureString line wrap fix

### DIFF
--- a/src/text-cairo.c
+++ b/src/text-cairo.c
@@ -397,6 +397,16 @@ MeasureString (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, int *length
 #ifdef DRAWSTRING_DEBUG
 		printf("[%3d] X: %3d, Y:%3d, '%c'  | ", i, (int)CursorX, (int)CursorY, CleanString[i]>=32 ? CleanString[i] : '?');
 #endif
+		CurrentDetail->PosX=CursorX;
+		CurrentDetail->PosY=CursorY;
+
+		/* Advance cursor */
+		CursorX+=CurrentDetail->Width;
+		if (MaxX<CursorX) {
+			MaxX=CursorX;
+			MaxXatY=CursorY;
+		}
+
 		/* Remember where to wrap next, but only if wrapping allowed */
 		if (((format->formatFlags & StringFormatFlagsNoWrap)==0) && (CurrentDetail->Flags & STRING_DETAIL_BREAK)) {
 			if (CleanString[i] == ' ') {
@@ -418,16 +428,6 @@ MeasureString (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, int *length
 		/* New line voids any previous wrap point */
 		if (CurrentDetail->Flags & STRING_DETAIL_LINESTART) {
 			WrapPoint=-1;
-		}
-
-		CurrentDetail->PosX=CursorX;
-		CurrentDetail->PosY=CursorY;
-
-		/* Advance cursor */
-		CursorX+=CurrentDetail->Width;
-		if (MaxX<CursorX) {
-			MaxX=CursorX;
-			MaxXatY=CursorY;
 		}
 
 		/* Time for a new line? Go back to last WrapPoint and wrap */


### PR DESCRIPTION
I can produce and attach sample code if needed, but the gist is that CursorX should be updated before WrapX is noted. Otherwise, MaxX may later be updated from WrapX, causing the bounding rectangle given by MeasureString to be too narrow by the width of the last character of the longest wrapped line. If the bounding rectangle is then used in a DrawString, the wrap results can be different between the first MeasureString and the subsequent DrawString, which should not happen if the calculated bounding rectangle is passed on without modification.

There are a number of bugs on the xamarin and novell bugzillas relating to line wrapping with the cairo backend which, though none exactly matching this problem, have been put off with, "this will work with the pango backend." I needed this to work today with the cairo backend on OSX for a text-heavy application, however.
