### PR TITLE
tests: fix build

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,7 @@
 ## Makefile.am for libgdiplus/tests
 
+LIBS = $(GDIPLUS_LIBS)
+
 INCLUDES =					\
 	-I$(top_srcdir)				\
 	-I$(top_builddir)/src			\


### PR DESCRIPTION
Build was failing this way:

/bin/bash ../libtool --tag=CC   --mode=link gcc  -g -O2 -pthread   -o testgdi testgdi.o ../src/libgdiplus.la -lpthread -lfontconfig
libtool: link: gcc -g -O2 -pthread -o .libs/testgdi testgdi.o  ../src/.libs/libgdiplus.so -lpthread -lfontconfig -pthread
/usr/bin/ld: testgdi.o: undefined reference to symbol 'g_print'
/usr/bin/ld: note: 'g_print' is defined in DSO /lib/x86_64-linux-gnu/libglib-2.0.so.0 so try adding it to the linker command line
/lib/x86_64-linux-gnu/libglib-2.0.so.0: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
make[2]: **\* [testgdi] Error 1
make[2]: Leaving directory `/home/knocte/Documents/Code/libgdiplus/tests'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory`/home/knocte/Documents/Code/libgdiplus'
make: **\* [all] Error 2
