### PR TITLE
Use FreeType macros for tttables.h inclusion

### DIFF
--- a/src/gdiplus-private.h
+++ b/src/gdiplus-private.h
@@ -30,7 +30,8 @@
 #include <stdio.h>
 #include <math.h>
 #include <glib.h>
-#include <freetype/tttables.h>
+#include <ft2build.h>
+#include FT_TRUETYPE_TABLES_H
 #include <pthread.h>
 #include <unistd.h>
 


### PR DESCRIPTION
As of FreeType 2.1.6 (November 2003), using #include to include Freetype libraries directly is not supported.

This has come to a head, as in FreeType 2.5.0, the location of headers has been moved around, breaking building of libgdiplus.

This slight change uses the "official" way to include the required header file, without breaking building on older versions of the library.
