### PR TITLE
Fix testgdi

### DIFF
--- a/tests/testgdi.c
+++ b/tests/testgdi.c
@@ -130,6 +130,10 @@ int
   main(int argc, char *argv[])
 {
 	win_t win;
+	GdiplusStartupInput gdiplusStartupInput;
+	ULONG_PTR gdiplusToken;
+
+	GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
 
 	win.dpy = XOpenDisplay(0);
 
@@ -148,6 +152,7 @@ int
 
 	XCloseDisplay(win.dpy);
 
+	GdiplusShutdown(gdiplusToken);
 	return 0;
 }
 


### PR DESCRIPTION
The testgdi program makes GDI+ calls without invoking
GdiplusStartup().

This fixes the following errors:

got st: 3 expected Okgot st: 2 expected Okjpg drawn
got st: 3 expected Okgot st: 2 expected Oktif drawn
got st: 3 expected Okgot st: 2 expected Okgif drawn
got st: 3 expected Okgot st: 2 expected Okpng drawn
got st: 3 expected Okgot st: 2 expected Okbmp drawn
