### PR TITLE
Removed pen adjustment for Cairo >= 1.12

### DIFF
--- a/src/graphics-cairo-private.h
+++ b/src/graphics-cairo-private.h
@@ -42,9 +42,9 @@
 /*
  * Handling of pens with a width greater than 1 is not identical between GDI+ and Cairo
  *
- * On apple pen adjustment is not required or tons of tests senstive to this break.
+ * On cairo >= 1.12 pen adjustment is not required or tons of tests senstive to this break.
  */
-#ifdef __APPLE__
+#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 12, 0)
 #define gdip_cairo_pen_width_needs_adjustment(pen)	(0)
 #else
 #define gdip_cairo_pen_width_needs_adjustment(pen)	(((int)(pen->width) & 1) == 0)


### PR DESCRIPTION
Modern systems have a Cairo library where pen adjustment is no longer necessary.
This fixes errors in the Mono System.Drawing testsuite caused by wrong adjustment.

The change should have no effect on Mac OSX, as the Mono bockbuild there uses a modern version of cairo and pen adjustment was disabled already with b2fd6394f5604f2f6de66f07935b64ed575af48c.

As discussed in #monodev.
