### PR TITLE
Workaround GCC 4.7+ optimizer bug by disabling optimization for the affected function

### DIFF
--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -1267,7 +1267,7 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 
 /* MonoTODO - same limitations as GdipAddString */
 GpStatus
-GdipAddPathStringI (GpPath *path, GDIPCONST WCHAR *string, int length,
+__attribute__ ((optimize("-O0"))) GdipAddPathStringI (GpPath *path, GDIPCONST WCHAR *string, int length,
 	GDIPCONST GpFontFamily *family, int style, float emSize,
 	GDIPCONST GpRect *layoutRect, GDIPCONST GpStringFormat *format)
 {


### PR DESCRIPTION
GCC 4.7+ incorrectly optimizes the GdipAddPathStringI() function, resulting in the value of r->Y being incorrect in the called GdipAddPathString() function.
By compiling with -O0 or adding a printf("Test") after r = &rect this doesn't happen.

I can provide gcc assembler output if someone who has more insight into this than me wants to have a look at what exactly is optimized incorrectly.
