### PR TITLE
Add missing -lm for linking test detected by ld.gold

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,7 +13,8 @@ DEPS =						\
 
 
 LDADDS =					\
-	$(top_builddir)/src/libgdiplus.la
+	$(top_builddir)/src/libgdiplus.la \
+	-lm
 
 noinst_PROGRAMS =			\
 	testgdi testbits testclip testreversepath


### PR DESCRIPTION
https://bugs.gentoo.org/367345

Signed-off-by: Justin Lecher <jlec@gentoo.org>