### PR TITLE
correctly resolve the variable of jpeg library prefix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ AC_ARG_WITH([libjpeg],
         jpeg_ok=no)
       AC_MSG_RESULT($jpeg_ok)
       if test "$jpeg_ok" = yes; then
-        JPEG='jpeg'; LIBJPEG='-L${libjpeg_prefix}/lib -ljpeg'
+        JPEG='jpeg'; LIBJPEG="-L${libjpeg_prefix}/lib -ljpeg"
       else
         AC_MSG_WARN(*** JPEG loader will not be built (JPEG header file not found) ***)
       fi


### PR DESCRIPTION
The resulting string is later exported (as part of GDIPLUS_LIBS) to the
generated pkg-config file and this file shouldn't contain
-L${libjpeg_prefix}/lib -ljpeg as libjpeg_prefix is unknown in this context...