### PR TITLE
Remove redundant transformations set on image load which cause failur…

### DIFF
--- a/src/pngcodec.c
+++ b/src/pngcodec.c
@@ -433,25 +433,6 @@ gdip_load_png_image_from_file_or_stream (FILE *fp, GetBytesDelegate getBytesFunc
 
 		interlace = png_get_interlace_type (png_ptr, info_ptr);
 
-		/* NB: none of these png_set_* methods actually do anything after png_read_png() is called! */
-		/* According to the libpng manual, this sequence is equivalent to
-		* using the PNG_TRANSFORM_EXPAND flag in png_read_png. */
-		if (color_type == PNG_COLOR_TYPE_PALETTE) {
-			png_set_palette_to_rgb (png_ptr);
-		}
-
-		if ((color_type == PNG_COLOR_TYPE_GRAY) && (bit_depth < 8)) {
-#if PNG_LIBPNG_VER > 10399
-			png_set_expand_gray_1_2_4_to_8 (png_ptr);
-#else
-			png_set_gray_1_2_4_to_8(png_ptr);
-#endif
-		}
-
-		if (png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS)) {
-			png_set_tRNS_to_alpha(png_ptr);
-		}
-
 		stride = (width * 4);
 		gdip_align_stride (stride);
 


### PR DESCRIPTION
Remove redundant transformations set on image load which cause failures with latest libpng

The transformations are set after PNG file is already loaded through png_read_png(). The code below handles actual bits per pixel, and the transformation been set had no effect. But transormations set after image read were causing failures (err msg "invalid after png_start_read_image or png_read_update_info" followed by image load abort) with latest libpng, making PngCodecTest failing in Mono, as well as loading all the images with bpp < 8 and paletted images.
