### PR TITLE
support RGBA in HatchBrush

### DIFF
--- a/src/hatchbrush-private.h
+++ b/src/hatchbrush-private.h
@@ -52,6 +52,7 @@ typedef struct _Hatch {
 	ARGB		foreColor;
 	ARGB		backColor;
 	cairo_pattern_t	*pattern;
+	BOOL		alpha;
 } Hatch;
 
 #include "hatchbrush.h"


### PR DESCRIPTION
if use a brush HatchBrush with a transparent background that background was not transparent
![hatchbrush_before](https://cloud.githubusercontent.com/assets/8424077/16890480/dfd3947e-4b10-11e6-941e-9f28e21f6e43.png)

After
![hatchbrush_after](https://cloud.githubusercontent.com/assets/8424077/16889836/2e79d65c-4b0b-11e6-918b-be2e206ee01c.png)
