### PR TITLE
Do not zero RGB pixels if A == 0

### DIFF
--- a/src/pngcodec.c
+++ b/src/pngcodec.c
@@ -465,16 +465,12 @@ gdip_load_png_image_from_file_or_stream (FILE *fp, GetBytesDelegate getBytesFunc
 				for (i = 0; i < height; i++) {
 					png_bytep rowp = row_pointers[i];
 					for (j = 0; j < width; j++) {
+						BYTE b = rowp[2];
+						BYTE g = rowp[1];
+						BYTE r = rowp[0];
 						BYTE a = rowp[3];
-						if (a == 0) {
-							set_pixel_bgra (rawptr, 0, 0, 0, 0, 0);
-						} else {
-							BYTE b = rowp[2];
-							BYTE g = rowp[1];
-							BYTE r = rowp[0];
 
-							set_pixel_bgra (rawptr, 0, b, g, r, a);
-						}
+						set_pixel_bgra (rawptr, 0, b, g, r, a);
 						rowp += 4;
 						rawptr += 4;
 					}


### PR DESCRIPTION
This fixes a problem introduced by 5ed200d5d73edc54969b34c708d18728d38c070b.
