### PR TITLE
Include pkg-config check for libpng16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -313,41 +313,49 @@ else
 fi
 
 dnl Test for libpng
-    AC_MSG_CHECKING(for libpng14)
-    if $PKG_CONFIG --exists libpng14 ; then
+    AC_MSG_CHECKING(for libpng16)
+    if $PKG_CONFIG --exists libpng16 ; then
       AC_MSG_RESULT(yes)
       PNG='png'
-      PNG_DEP_CFLAGS_PACKAGES=libpng14
-      LIBPNG=`$PKG_CONFIG --libs libpng14`
+      PNG_DEP_CFLAGS_PACKAGES=libpng16
+      LIBPNG=`$PKG_CONFIG --libs libpng16`
     else
-      AC_MSG_CHECKING(for libpng12)
-      if $PKG_CONFIG --exists libpng12 ; then
-        AC_MSG_RESULT(yes)
-        PNG='png'
-        PNG_DEP_CFLAGS_PACKAGES=libpng12
-        LIBPNG=`$PKG_CONFIG --libs libpng12`
-      else
-        AC_MSG_RESULT(no)
-        AC_CHECK_LIB(png, png_read_info,
-          [AC_CHECK_HEADER(png.h, png_ok=yes, png_ok=no)],
-          AC_MSG_ERROR(*** libpng12 not found. See http://www.libpng.org/pub/png/libpng.html.), -lz -lm)
-        if test "$png_ok" = yes; then
-          AC_MSG_CHECKING([for png_structp in png.h])
-          AC_TRY_COMPILE([#include <png.h>],
-            [png_structp pp; png_infop info; png_colorp cmap; png_create_read_struct;],
-            png_ok=yes,
-            png_ok=no)
-          AC_MSG_RESULT($png_ok)
-          if test "$png_ok" = yes; then
-            PNG='png'; LIBPNG='-lpng -lz'
-          else
-            AC_MSG_ERROR(*** libpng12 found, but it is too old. See http://www.libpng.org/pub/png/libpng.html.)
-          fi
+        AC_MSG_CHECKING(for libpng14)
+        if $PKG_CONFIG --exists libpng14 ; then
+          AC_MSG_RESULT(yes)
+          PNG='png'
+          PNG_DEP_CFLAGS_PACKAGES=libpng14
+          LIBPNG=`$PKG_CONFIG --libs libpng14`
         else
-            AC_MSG_ERROR(*** libpng12 not found. See http://www.libpng.org/pub/png/libpng.html.)
+          AC_MSG_CHECKING(for libpng12)
+          if $PKG_CONFIG --exists libpng12 ; then
+            AC_MSG_RESULT(yes)
+            PNG='png'
+            PNG_DEP_CFLAGS_PACKAGES=libpng12
+            LIBPNG=`$PKG_CONFIG --libs libpng12`
+          else
+            AC_MSG_RESULT(no)
+            AC_CHECK_LIB(png, png_read_info,
+              [AC_CHECK_HEADER(png.h, png_ok=yes, png_ok=no)],
+              AC_MSG_ERROR(*** libpng12 not found. See http://www.libpng.org/pub/png/libpng.html.), -lz -lm)
+            if test "$png_ok" = yes; then
+              AC_MSG_CHECKING([for png_structp in png.h])
+              AC_TRY_COMPILE([#include <png.h>],
+                [png_structp pp; png_infop info; png_colorp cmap; png_create_read_struct;],
+                png_ok=yes,
+                png_ok=no)
+              AC_MSG_RESULT($png_ok)
+              if test "$png_ok" = yes; then
+                PNG='png'; LIBPNG='-lpng -lz'
+              else
+                AC_MSG_ERROR(*** libpng12 found, but it is too old. See http://www.libpng.org/pub/png/libpng.html.)
+              fi
+            else
+                AC_MSG_ERROR(*** libpng12 not found. See http://www.libpng.org/pub/png/libpng.html.)
+            fi
+          fi
         fi
       fi
-    fi
 
 
 GDIPLUS_LIBS="$GDIPLUS_LIBS $LIBPNG"


### PR DESCRIPTION
Otherwise, weird side-effects can occur, such as libgdiplus
linking to multiple png versions, when e.g. png-1.6 and png-1.2 are
both available.

Ultimately this should be fixed more generic and use something like `PKG_CHECK_MODULES([PNG], [libpng >= 1.6])`, picking the _latest_ libpng always. Also see the [pkg-config manpage](https://linux.die.net/man/1/pkg-config) explaining those proper macros. For now, I just kept the logic.