### PR TITLE
Property retrieve PropertyItem entries from PNG tEXt chunks

### DIFF
--- a/src/pngcodec.c
+++ b/src/pngcodec.c
@@ -225,11 +225,33 @@ gdip_load_png_properties (png_structp png_ptr, png_infop info_ptr, png_infop end
 	{
 		int		num_text;
 		png_textp	text_ptr;
+		int		i;
+		PROPID 		prop_id;
 
 		if (png_get_text(png_ptr, info_ptr, &text_ptr, &num_text)) {
-			if (num_text > 0) {
-				gdip_bitmapdata_property_add_ASCII(bitmap_data, PropertyTagExifUserComment, (BYTE*)text_ptr[0].text);
-			}
+			for (i = 0; i < num_text; i++) {
+				prop_id = 0;
+
+				if (strcmp(text_ptr[i].key, "Author") == 0) {
+					prop_id = PropertyTagArtist;
+				} else if (strcmp(text_ptr[i].key, "Comment") == 0) {
+					prop_id = PropertyTagExifUserComment;
+				} else if (strcmp(text_ptr[i].key, "Copyright") == 0) {
+					prop_id = PropertyTagCopyright;
+				} else if (strcmp(text_ptr[i].key, "Description") == 0) {
+					prop_id = PropertyTagImageDescription;
+				} else if (strcmp(text_ptr[i].key, "Software") == 0) {
+					prop_id = PropertyTagSoftwareUsed;
+				} else if (strcmp(text_ptr[i].key, "Source") == 0) {
+					prop_id = PropertyTagEquipModel;
+				} else if (strcmp(text_ptr[i].key, "Title") == 0) {
+					prop_id = PropertyTagImageTitle;
+				}
+
+				if (prop_id != 0) {
+					gdip_bitmapdata_property_add_ASCII(bitmap_data, prop_id, (BYTE*)text_ptr[i].text);
+				}
+			}		
 		}
 	}
 #endif


### PR DESCRIPTION
Previously only the first tEXt chunk would be added as a PropertyItem, with the type of ExifUserComment, regardless of the actual number or keys of the tEXt chunks.

Now multiple tEXt chunks may be added as a PropertyItem, and the author/comment/copyright/description/software/source/title keys are properly mapped to PropertyItem types. This behaves closer to the standard GDI+.

------
Test image with multiple tEXt chunks: 
![rain2](https://cloud.githubusercontent.com/assets/6509348/22358309/1e268b26-e492-11e6-8e9c-77a152e1e599.png)

**Note: I am not that experienced with C, so this code may be flawed.**