### PR TITLE
Support building on macOS with optional X11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,12 @@ AC_ARG_WITH([libjpeg],
         jpeg_ok=no)
       AC_MSG_RESULT($jpeg_ok)
       if test "$jpeg_ok" = yes; then
-        JPEG='jpeg'; LIBJPEG="-L${libjpeg_prefix}/lib -ljpeg"
+        JPEG='jpeg'; LIBJPEG="-ljpeg"
+
+        if test "$libjpeg_prefix" != "NONE"; then
+          LIBJPEG="$LIBJPEG -L$libjpeg_prefix"
+        fi
+
       else
         AC_MSG_WARN(*** JPEG loader will not be built (JPEG header file not found) ***)
       fi
@@ -348,6 +353,37 @@ dnl Test for libpng
 GDIPLUS_LIBS="$GDIPLUS_LIBS $LIBPNG"
 AC_DEFINE(HAVE_LIBPNG, 1, Define if png support is available. Always defined.)
 
+dnl
+dnl Test for X11. Allow compiling without x11 support using the disable-x11
+dnl flag
+dnl
+
+AC_ARG_WITH(x11, 
+	[AC_HELP_STRING([--without-x11], [Disable X11 support])],
+	[disable_x11=yes])
+
+if test x$disable_x11 != xyes; then
+  AC_MSG_CHECKING(X11 support)
+  AC_TRY_COMPILE(
+    [#include <X11/Xlib.h>],
+    [],
+    [x11_available=yes],
+    [x11_available=no])
+
+  if test "x$x11_available" != "xyes"; then
+    AC_MSG_ERROR( [ Failed to compile with X11/Xlib.h include. You must fix your compiler paths ])
+  else
+    AC_MSG_RESULT(yes)
+  fi
+else
+  x11_available=no
+fi
+
+AS_IF(
+	[test x$x11_available = xyes],
+	[AC_DEFINE([HAS_X11], [1], [Define X11 support])],
+	[AC_DEFINE([HAS_X11], [0], [Skip X11 support])])
+
 dnl Test for libexif
 if test x$with_libexif != xno && test -z "$LIBEXIF"; then
   PKG_CHECK_MODULES(LIBEXIF, libexif, [libexif_pkgconfig=yes], libexif_pkgconfig=no])
@@ -387,6 +423,7 @@ echo "   * Installation prefix = $prefix"
 echo "   * Cairo = $cairo_info"
 echo "   * Text = $text_v"
 echo "   * EXIF tags = $libexif_pkgconfig"
+echo "   * X11 = $x11_available"
 echo "   * Codecs supported:"
 echo ""
 echo "      - TIFF: $tiff_ok"

--- a/configure.ac
+++ b/configure.ac
@@ -19,8 +19,8 @@ fi
 GLIB_REQUIRED_VERSION="2.2.3"
 PKG_CHECK_MODULES(BASE_DEPENDENCIES, glib-2.0 >= $GLIB_REQUIRED_VERSION)
 
-GDIPLUS_LIBS="`pkg-config --libs glib-2.0 `"
-GDIPLUS_CFLAGS="`pkg-config --cflags glib-2.0 `"
+GDIPLUS_LIBS="`$PKG_CONFIG --libs glib-2.0 `"
+GDIPLUS_CFLAGS="`$PKG_CONFIG --cflags glib-2.0 `"
 
 CAIRO_REQUIRED_VERSION="1.6.4"
 PKG_CHECK_MODULES(CAIRO, cairo >= $CAIRO_REQUIRED_VERSION)
@@ -122,8 +122,8 @@ esac
 
 # Add xrender here so that we don't fail to find glib if we won't have xrender.pc
 if test "x$no_x" != "xyes"; then
-   GDIPLUS_LIBS="$GDIPLUS_LIBS `pkg-config --libs xrender `"
-   GDIPLUS_CFLAGS="$GDIPLUS_CFLAGS `pkg-config --cflags xrender `"
+   GDIPLUS_LIBS="$GDIPLUS_LIBS `$PKG_CONFIG --libs xrender `"
+   GDIPLUS_CFLAGS="$GDIPLUS_CFLAGS `$PKG_CONFIG --cflags xrender `"
 fi
 
 # Apparently for BSD special handling needs to happen
@@ -362,15 +362,6 @@ else
 	libexif_pkgconfig="No. You disabled it."
 fi
 AM_CONDITIONAL(HAVE_LIBEXIF, test x$libexif_pkgconfig = xyes)
-
-dnl
-dnl Produce a diagnostic, to reduce support time
-dnl
-AC_TRY_COMPILE([#include <X11/Xlib.h>],
-			 [],[x11_failed=false],[x11_failed=true])
-if $x11_failed; then
-   AC_ERROR("Failed to compile with X11/Xlib.h include.  You must fix your compiler paths")
-fi
 
 GDIPLUS_PKG_LIBS="$GDIPLUS_LIBS"
 GDIPLUS_PKG_CFLAGS="$GDIPLUS_CFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -120,12 +120,6 @@ case "$host" in
 		;;
 esac
 
-# Add xrender here so that we don't fail to find glib if we won't have xrender.pc
-if test "x$no_x" != "xyes"; then
-   GDIPLUS_LIBS="$GDIPLUS_LIBS `$PKG_CONFIG --libs xrender `"
-   GDIPLUS_CFLAGS="$GDIPLUS_CFLAGS `$PKG_CONFIG --cflags xrender `"
-fi
-
 # Apparently for BSD special handling needs to happen
 # See http://archives/neohapsis.com/archives/openbsd/2001-11/2142.html
 # by Miod Vallat <miod@online.fr>
@@ -383,6 +377,13 @@ AS_IF(
 	[test x$x11_available = xyes],
 	[AC_DEFINE([HAS_X11], [1], [Define X11 support])],
 	[AC_DEFINE([HAS_X11], [0], [Skip X11 support])])
+AM_CONDITIONAL([HAS_X11], [test x$x11_available = xyes])
+
+# Add xrender here so that we don't fail to find glib if we won't have xrender.pc
+if test "x$no_x" != "xyes" && "x$x11_available" = "xyes"; then
+   GDIPLUS_LIBS="$GDIPLUS_LIBS `$PKG_CONFIG --libs xrender `"
+   GDIPLUS_CFLAGS="$GDIPLUS_CFLAGS `$PKG_CONFIG --cflags xrender `"
+fi
 
 dnl Test for libexif
 if test x$with_libexif != xno && test -z "$LIBEXIF"; then

--- a/configure.ac
+++ b/configure.ac
@@ -348,7 +348,7 @@ GDIPLUS_LIBS="$GDIPLUS_LIBS $LIBPNG"
 AC_DEFINE(HAVE_LIBPNG, 1, Define if png support is available. Always defined.)
 
 dnl
-dnl Test for X11. Allow compiling without x11 support using the disable-x11
+dnl Test for X11. Allow compiling without x11 support using the without-x11
 dnl flag
 dnl
 

--- a/src/gdiplus-private.h
+++ b/src/gdiplus-private.h
@@ -64,7 +64,7 @@
 	#endif
 #endif
 
-#ifdef HAS_X11
+#if HAS_X11
 #include <X11/Xlib.h>
 #endif
 

--- a/src/gdiplus-private.h
+++ b/src/gdiplus-private.h
@@ -51,17 +51,22 @@
 		#include "cairo-ft.h"
 	#endif
 
+        #if HAS_X11
 	#ifdef CAIRO_HAS_XLIB_SURFACE
 		#include "cairo-xlib.h"
 	#endif
+        #endif
 #else
 	#include <cairo/cairo.h>
 	#ifdef CAIRO_HAS_FT_FONT
 		#include <cairo/cairo-ft.h>
 	#endif
+
+        #if HAS_X11
 	#ifdef CAIRO_HAS_XLIB_SURFACE
 		#include <cairo/cairo-xlib.h>
 	#endif
+        #endif
 #endif
 
 #if HAS_X11

--- a/src/gdiplus-private.h
+++ b/src/gdiplus-private.h
@@ -40,7 +40,7 @@
 #if HAVE_VISIBILITY_HIDDEN
 	#define GDIP_INTERNAL __attribute__((visibility ("hidden")))
 #else
-	#define GDIP_INTERNAL 
+	#define GDIP_INTERNAL
 #endif
 
 #ifdef USE_INCLUDED_CAIRO
@@ -51,22 +51,22 @@
 		#include "cairo-ft.h"
 	#endif
 
-        #if HAS_X11
+	#if HAS_X11
 	#ifdef CAIRO_HAS_XLIB_SURFACE
 		#include "cairo-xlib.h"
 	#endif
-        #endif
+	#endif
 #else
 	#include <cairo/cairo.h>
 	#ifdef CAIRO_HAS_FT_FONT
 		#include <cairo/cairo-ft.h>
 	#endif
 
-        #if HAS_X11
+	#if HAS_X11
 	#ifdef CAIRO_HAS_XLIB_SURFACE
 		#include <cairo/cairo-xlib.h>
 	#endif
-        #endif
+	#endif
 #endif
 
 #if HAS_X11

--- a/src/gdiplus-private.h
+++ b/src/gdiplus-private.h
@@ -64,7 +64,9 @@
 	#endif
 #endif
 
+#ifdef HAS_X11
 #include <X11/Xlib.h>
+#endif
 
 #include "win32structs.h"
 #include "gdipenums.h"

--- a/src/general.c
+++ b/src/general.c
@@ -132,7 +132,7 @@ gdip_get_display_dpi ()
 
 		dpis = h_dpi;
 		return dpis;
-#elif CAIRO_HAS_XLIB_SURFACE
+#elif HAS_X11 && CAIRO_HAS_XLIB_SURFACE
 		char *val;
 
 		Display* display;

--- a/src/general.c
+++ b/src/general.c
@@ -23,6 +23,7 @@
  *   Alexandre Pigolkine(pigolkine@gmx.de)
  *   Duncan Mak (duncan@ximian.com)
  *   Sebastien Pouliot  <sebastien@ximian.com>
+ *   Frederik Carlier <frederik.carlier@quamotion.mobi>
  */
 
 #include "general-private.h"
@@ -123,7 +124,6 @@ float
 gdip_get_display_dpi ()
 {
 	static float dpis = 0;
-	Display* display;
 
 	if (dpis == 0) {
 #if __APPLE__
@@ -132,9 +132,10 @@ gdip_get_display_dpi ()
 
 		dpis = h_dpi;
 		return dpis;
-#else
+#elif CAIRO_HAS_XLIB_SURFACE
 		char *val;
 
+		Display* display;
 		display = XOpenDisplay (0);
 		/* If the display is openable lets try to read dpi from it; otherwise use a default of 96.0f */
 		if (display) {
@@ -148,6 +149,8 @@ gdip_get_display_dpi ()
 		} else {
 			dpis = 96.0f;
 		}
+#else
+		dpis = 96.0f;
 #endif
 	}
 

--- a/src/graphics-private.h
+++ b/src/graphics-private.h
@@ -106,9 +106,11 @@ typedef struct _Graphics {
 	cairo_t			*ct;
 	GpMatrix		*copy_of_ctm;
 	cairo_matrix_t		previous_matrix;
+#if HAS_X11
 #ifdef CAIRO_HAS_XLIB_SURFACE
 	Display			*display;
 	Drawable		drawable;
+#endif
 #endif
 	void			*image;
 	int			type; 

--- a/src/graphics-private.h
+++ b/src/graphics-private.h
@@ -24,6 +24,7 @@
  *	Geoff Norton (gnorton@customerdna.com)
  *      Jonathan Gilbert (logic@deltaq.org)
  *	Sebastien Pouliot  <sebastien@ximian.com>
+ *	Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * Copyright (C) 2003-2007 Novell, Inc (http://www.novell.com)
  */
@@ -105,8 +106,10 @@ typedef struct _Graphics {
 	cairo_t			*ct;
 	GpMatrix		*copy_of_ctm;
 	cairo_matrix_t		previous_matrix;
+#ifdef CAIRO_HAS_XLIB_SURFACE
 	Display			*display;
 	Drawable		drawable;
+#endif
 	void			*image;
 	int			type; 
 	GpPen*			last_pen;	/* caching pen and brush to avoid unnecessary sets */

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -23,6 +23,7 @@
  *   Alexandre Pigolkine (pigolkine@gmx.de)
  *   Duncan Mak (duncan@ximian.com)
  *   Sebastien Pouliot  <sebastien@ximian.com>
+ *   Frederik Carlier <frederik.carlier@quamotion.mobi>
  */
 
 #include "graphics-private.h"
@@ -151,8 +152,10 @@ gdip_graphics_common_init (GpGraphics *graphics)
 	graphics->render_origin_y = 0;
 	graphics->dpi_x = graphics->dpi_y = 0;
 
+#if CAIRO_HAS_XLIB_SURFACE
 	graphics->display = NULL;
 	graphics->drawable = NULL;
+#endif
 
 	gdip_graphics_reset (graphics);
 }

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -152,7 +152,7 @@ gdip_graphics_common_init (GpGraphics *graphics)
 	graphics->render_origin_y = 0;
 	graphics->dpi_x = graphics->dpi_y = 0;
 
-#if CAIRO_HAS_XLIB_SURFACE
+#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
 	graphics->display = NULL;
 	graphics->drawable = NULL;
 #endif
@@ -219,7 +219,6 @@ GdipCreateFromHDC (void *hDC, GpGraphics **graphics)
 	cairo_surface_t *surface;
 	int x, y;
 	unsigned int w, h, border_w, depth;
-	Window root;
 
 	if (!hDC)
 		return OutOfMemory;
@@ -235,7 +234,8 @@ GdipCreateFromHDC (void *hDC, GpGraphics **graphics)
 	if (clone->type == gtMemoryBitmap)
 		return GdipGetImageGraphicsContext (clone->image, graphics);
 
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
+	Window root;
 	XGetGeometry (clone->display, clone->drawable, &root,
 		      &x, &y, &w, &h, &border_w, &depth);
 	
@@ -295,7 +295,7 @@ GdipCreateFromContext_macosx (void *ctx, int width, int height, GpGraphics **gra
 
 #endif
 
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
 
 // coverity[+alloc : arg-*2]
 GpStatus
@@ -332,7 +332,7 @@ GdipCreateFromXDrawable_linux(Drawable d, Display *dpy, GpGraphics **graphics)
 
 #endif
 
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
 static int
 ignore_error_handler (Display *dpy, XErrorEvent *event)
 {
@@ -363,7 +363,7 @@ GdipDeleteGraphics (GpGraphics *graphics)
 	}
 
 	if (graphics->ct) {
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
 		int (*old_error_handler)(Display *dpy, XErrorEvent *ev) = NULL;
 		if (graphics->type == gtX11Drawable)
 			old_error_handler = XSetErrorHandler (ignore_error_handler);
@@ -372,7 +372,7 @@ GdipDeleteGraphics (GpGraphics *graphics)
 		cairo_destroy (graphics->ct);
 		graphics->ct = NULL;
 
-#ifdef CAIRO_HAS_XLIB_SURFACE
+#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
 		if (graphics->type == gtX11Drawable)
 			XSetErrorHandler (old_error_handler);
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,13 +17,18 @@ LDADDS =					\
 	-lm
 
 noinst_PROGRAMS =			\
-	testgdi testbits testclip testreversepath
+	testbits testclip testreversepath
+
+if HAS_X11
+noinst_PROGRAMS =
+	testgdi ${noinst_PROGRAMS}
 
 testgdi_DEPENDENCIES = $(TEST_DEPS)
 testgdi_LDADD = $(LDADDS)
 
 testgdi_SOURCES =		\
 	testgdi.c
+endif HAS_X11
 
 testbits_DEPENDENCIES = $(TEST_DEPS)
 testbits_LDADD = $(LDADDS)


### PR DESCRIPTION
X11 no longer ships with macOS, so building libgdiplus over there fails. This PR makes x11 integration optional, by adding a `--without-x11` flag.

This will also enable adoption of libgdiplus in homebrew.

Related issues: Homebrew/legacy-homebrew#45393, #13, #35