### PR TITLE
Visual C++ compatibility fixes

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -24,6 +24,10 @@
  *	Jeffrey Stedfast <fejj@novell.com>
  */
 
+#ifdef WIN32
+#include "win32_io.h"
+#endif
+
 #include <cairo-features.h>
 #include "gdiplus-private.h"
 #include "font-private.h"
@@ -1074,9 +1078,13 @@ GdipPrivateAddMemoryFont(GpFontCollection *fontCollection, GDIPCONST void *memor
 	if (!memory)
 		return InvalidParameter;
 
+#ifdef WIN32
+	f = CreateTempFile (fontfile);
+#else
 	strcpy((char *) fontfile, "/tmp/ffXXXXXX");
-
 	f = mkstemp((char*)fontfile);
+#endif
+
 	if (f == -1)
 		return FileNotFound;
 

--- a/src/gdiplus-private.h
+++ b/src/gdiplus-private.h
@@ -28,14 +28,20 @@
 #define __LIBGDIPLUS_H__
 
 #include <stdio.h>
+
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #include <glib.h>
 #include <ft2build.h>
 #include FT_TRUETYPE_TABLES_H
+#ifndef _MSC_VER
 #include <pthread.h>
 #include <unistd.h>
 
 #include "config.h"
+#endif
 
 #if HAVE_VISIBILITY_HIDDEN
 	#define GDIP_INTERNAL __attribute__((visibility ("hidden")))

--- a/src/general-private.h
+++ b/src/general-private.h
@@ -52,8 +52,13 @@
 #define MAKE_ARGB_RGB(r,g,b)		(((r&0xff) << 16) | ((g&0xff) <<  8) | (b&0xff))
 #define MAKE_ARGB_ARGB(a,r,g,b)		(((a&0xff) << 24) | ((r&0xff) << 16) | ((g&0xff) << 8) | (b&0xff))
 
+#if !defined(min)
 #define min(a,b)			(a < b ? a : b)
+#endif
+
+#if !defined(max)
 #define max(a,b)			(a > b ? a : b)
+#endif
 
 /* avoid direct floating point comparison */
 #define gdip_near_zero(value)		((value >= -0.0001f) && (value <= 0.0001f))

--- a/src/pngcodec.c
+++ b/src/pngcodec.c
@@ -364,15 +364,18 @@ gdip_load_png_image_from_file_or_stream (FILE *fp, GetBytesDelegate getBytesFunc
 				}
 
 				for (i=0; i < num_trans; i++) {
+					png_bytep alpha =
+#if (PNG_LIBPNG_VER > 10399)
+						trans_alpha[i];
+#else
+						info_ptr->trans[i];
+#endif
+
 					set_pixel_bgra(&palette->Entries[i], 0,
 							png_palette[i].blue,
 							png_palette[i].green,
 							png_palette[i].red,
-#if PNG_LIBPNG_VER > 10399
-							trans_alpha [i]); /* alpha */
-#else
-							info_ptr->trans[i]); /* alpha */
-#endif
+							alpha);
 				}
 			}
 		}

--- a/src/win32_io.c
+++ b/src/win32_io.c
@@ -1,0 +1,45 @@
+/*
+* Copyright (c) 2017 Quamotion bvba
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+* and associated documentation files (the "Software"), to deal in the Software without restriction,
+* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+* subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all copies or substantial
+* portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+* NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+* OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* Authors:
+*	Frederik Carlier <frederik.carlier@quamotion.mobi>
+*/
+
+#include "win32_io.h"
+
+#include <windows.h>
+#include <stdio.h>
+#include "gdipenums.h"
+
+int CreateTempFile (char *filename)
+{
+	TCHAR temppath[MAX_PATH];
+	DWORD ret = 0;
+	
+	ret = GetTempPath (MAX_PATH, temppath);
+	if (ret > MAX_PATH || ret == 0) {
+		return FileNotFound;
+	}
+
+	ret = GetTempFileName (temppath, "ff", 0, (LPSTR)filename);
+	if (ret == 0) {
+		return FileNotFound;
+	}
+
+	return (int)fopen (filename, "w");
+}

--- a/src/win32_io.h
+++ b/src/win32_io.h
@@ -1,0 +1,25 @@
+/*
+* Copyright (c) 2017 Quamotion bvba
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+* and associated documentation files (the "Software"), to deal in the Software without restriction,
+* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+* subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all copies or substantial
+* portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+* NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+* OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* Authors:
+*	Frederik Carlier <frederik.carlier@quamotion.mobi>
+*/
+
+// Creates a temporary file. Saves the value of the temporary file in filename,
+// and returns a handle to the temp file.
+int CreateTempFile (char *filename);


### PR DESCRIPTION
Enables building libgdiplus using Visual C++:

A couple of minor fixes which allow building libgdiplus natively on Visual C++ (Windows)]
- use `tmpfile` instead of `mkstemp` to get generate a temporary file
- Define `_USE_MATH_DEFINES` so `M_PI` is defined
- Don't `#include` Unix-only headers
- Don't redefine `max` and `min`
- Fix macro expansion