### PR TITLE
Add Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,24 +11,26 @@ install:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y git autoconf libtool automake build-essential gettext cmake; fi
 
 script:
-# Build libgdiplus
+- echo "travis_fold:start:build_libgdiplus"
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./autogen.sh --prefix=/usr/local/; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./autogen.sh --without-x11 --prefix=/usr/local/; fi
 - make -j4
+- echo "travis_fold:end:build_libgdiplus"
 - make check
 - sudo make install
 
-# Build Mono
+- echo "travis_fold:start:build_mono"
 - cd ..
 - git clone --depth 1 https://github.com/mono/mono
 - cd mono
 - ./autogen.sh --prefix=/usr/local/
-- make -j4 > /dev/null
+- make -j4
+- make -C mcs/class/System.Drawing test
+- make -C mcs/class/System.Windows.Forms test
+- echo "travis_fold:end:build_mono"
 
 # Run the System.Drawing and System.Windows.Forms tests.
 # System.Windows.Forms test don't currently pass on macOS.
 - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
-- cd mcs/class/System.Drawing
-- make check
-- cd ../System.Windows.Forms
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run make check; fi
+- make -C mcs/class/System.Drawing run-test
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run make -C mcs/class/System.Windows.Forms run-test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
 
 # Run the System.Drawing and System.Windows.Forms tests.
 # System.Windows.Forms test don't currently pass on macOS.
+- export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 - cd mcs/class/System.Drawing
 - make check
 - cd ../System.Windows.Forms

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install glib cairo libexif; fi
 
 script:
+- export CFLAGS="-ggdb3 -O2"
 - echo "travis_fold:start:build_libgdiplus"
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./autogen.sh --prefix=/tmp/mono-dev; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./autogen.sh --without-x11 --prefix=/tmp/mono-dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,12 @@ install:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y git autoconf libtool automake build-essential gettext cmake; fi
 
 script:
-- echo "travis_fold:start:build_libgdiplus"
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./autogen.sh --prefix=/usr/local/; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./autogen.sh --without-x11 --prefix=/usr/local/; fi
 - make -j4
-- echo "travis_fold:end:build_libgdiplus"
 - make check
 - sudo make install
 
-- echo "travis_fold:start:build_mono"
 - cd ..
 - git clone --depth 1 https://github.com/mono/mono
 - cd mono
@@ -27,7 +24,6 @@ script:
 - make -j4
 - make -C mcs/class/System.Drawing test
 - make -C mcs/class/System.Windows.Forms test
-- echo "travis_fold:end:build_mono"
 
 # Run the System.Drawing and System.Windows.Forms tests.
 # System.Windows.Forms test don't currently pass on macOS.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
 - make check
 - make install
 
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; exit 0; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then exit 0; fi
 - echo "travis_fold:start:build_mono"
 - cd ..
 - git clone --depth 1 https://github.com/mono/mono

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
 - cd ..
 - git clone --depth 1 https://github.com/mono/mono
 - cd mono
-- ./autogen.sh --prefix=/tmp/mono-dev --with-libgdiplus=/tmp/mono-dev/lib/libgdiplus.so
+- ./autogen.sh --prefix=/tmp/mono-dev --with-libgdiplus=/tmp/mono-dev/lib/libgdiplus.so --disable-boehm
 - make -j4
 - make -C mcs/class/System.Drawing test
 - make -C mcs/class/System.Windows.Forms test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,47 @@
+language: c
 dist: trusty
+sudo: false
 
-matrix:
-  include:
-    - os: osx
-    - os: linux
+os:
+  - linux
+  - osx
 
+addons:
+  apt:
+    packages:
+    - libgif-dev
+    - xvfb
+    - autoconf
+    - libtool
+    - automake
+    - build-essential
+    - gettext
+    - cmake
+    - git
+    
 install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install glib cairo libexif; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libgif-dev xvfb; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y git autoconf libtool automake build-essential gettext cmake; fi
 
 script:
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./autogen.sh --prefix=/usr/local/; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./autogen.sh --without-x11 --prefix=/usr/local/; fi
+- echo "travis_fold:start:build_libgdiplus"
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./autogen.sh --prefix=/tmp/mono-dev; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./autogen.sh --without-x11 --prefix=/tmp/mono-dev; fi
 - make -j4
+- echo "travis_fold:end:build_libgdiplus"
 - make check
-- sudo make install
+- make install
 
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; exit 0; fi
+- echo "travis_fold:start:build_mono"
 - cd ..
 - git clone --depth 1 https://github.com/mono/mono
 - cd mono
-- ./autogen.sh --prefix=/usr/local/
+- ./autogen.sh --prefix=/tmp/mono-dev --with-libgdiplus=/tmp/mono-dev/lib/libgdiplus.so
 - make -j4
 - make -C mcs/class/System.Drawing test
 - make -C mcs/class/System.Windows.Forms test
+- echo "travis_fold:end:build_mono"
 
 # Run the System.Drawing and System.Windows.Forms tests.
-# System.Windows.Forms test don't currently pass on macOS.
-- export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 - make -C mcs/class/System.Drawing run-test
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run make -C mcs/class/System.Windows.Forms run-test; fi
+- xvfb-run make -C mcs/class/System.Windows.Forms run-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,21 @@
 dist: trusty
-sudo: true
 
 matrix:
   include:
     - os: osx
-      env: TARGET=x86_64-apple-darwin RID=osx-x64
     - os: linux
-      env: TARGET=x86_64-unknown-linux-gnu RID=linux-x64
 
 install:
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install glib cairo libexif; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libgif-dev xvfb; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y git autoconf libtool automake build-essential mono-devel gettext cmake; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y git autoconf libtool automake build-essential gettext cmake; fi
 
 script:
 # Build libgdiplus
 - cd $HOME/build/CoreCompat/libgdiplus
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./autogen.sh --prefix=/usr/; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./autogen.sh --without-x11 --prefix=/usr/; fi
-- make
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./autogen.sh --prefix=/usr/local/; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./autogen.sh --without-x11 --prefix=/usr/local/; fi
+- make -j4
 - make check
 - sudo make install
 
@@ -26,8 +23,8 @@ script:
 - cd $HOME/build/
 - git clone --depth 1 https://github.com/mono/mono
 - cd $HOME/build/mono
-- ./autogen.sh
-- make > /dev/null
+- ./autogen.sh --prefix=/usr/local/
+- make -j4 > /dev/null
 
 # Run the System.Drawing and System.Windows.Forms tests.
 # System.Windows.Forms test don't currently pass on macOS.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
 
 script:
 # Build libgdiplus
-- cd $HOME/build/CoreCompat/libgdiplus
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./autogen.sh --prefix=/usr/local/; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./autogen.sh --without-x11 --prefix=/usr/local/; fi
 - make -j4
@@ -20,9 +19,9 @@ script:
 - sudo make install
 
 # Build Mono
-- cd $HOME/build/
+- cd ..
 - git clone --depth 1 https://github.com/mono/mono
-- cd $HOME/build/mono
+- cd mono
 - ./autogen.sh --prefix=/usr/local/
 - make -j4 > /dev/null
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+dist: trusty
+sudo: true
+
+matrix:
+  include:
+    - os: osx
+      env: TARGET=x86_64-apple-darwin RID=osx-x64
+    - os: linux
+      env: TARGET=x86_64-unknown-linux-gnu RID=linux-x64
+
+install:
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install glib cairo libexif; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libgif-dev xvfb; fi
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y git autoconf libtool automake build-essential mono-devel gettext cmake; fi
+
+script:
+# Build libgdiplus
+- cd $HOME/build/CoreCompat/libgdiplus
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./autogen.sh --prefix=/usr/; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./autogen.sh --without-x11 --prefix=/usr/; fi
+- make
+- make check
+- sudo make install
+
+# Build Mono
+- cd $HOME/build/
+- git clone --depth 1 https://github.com/mono/mono
+- cd $HOME/build/mono
+- ./autogen.sh
+- make > /dev/null
+
+# Run the System.Drawing and System.Windows.Forms tests.
+# System.Windows.Forms test don't currently pass on macOS.
+- cd mcs/class/System.Drawing
+- make check
+- cd ../System.Windows.Forms
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run make check; fi


### PR DESCRIPTION
Build libgdiplus on Linux and macOS, and run the System.Drawing and System.Windows.Forms unit tests using the updated libgdiplus.