### PR TITLE
Visual C++ Compatibility: Use BYTE* instead of void*

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -1111,7 +1111,7 @@ GdipCloneBitmapArea (float x, float y, float w, float h, PixelFormat format,
 }
 
 static void
-gdip_copy_strides (void *dst, int dstStride, void *src, int srcStride, int realBytes, int height)
+gdip_copy_strides (BYTE *dst, int dstStride, BYTE *src, int srcStride, int realBytes, int height)
 {
 	int i;
 	for (i = 0; i < height; i++) {

--- a/src/dstream.c
+++ b/src/dstream.c
@@ -126,7 +126,7 @@ fill_buffer (dstream_private *loader)
 }
 
 int
-dstream_read (dstream_t *st, void *buffer, int size, char peek)
+dstream_read (dstream_t *st, BYTE *buffer, int size, char peek)
 {
 	int nbytes;
 	int offset;

--- a/src/dstream.h
+++ b/src/dstream.h
@@ -31,7 +31,7 @@ struct _dstream {
 };
 
 dstream_t *dstream_input_new (GetBytesDelegate read, SeekDelegate seek) GDIP_INTERNAL;
-int dstream_read (dstream_t *loader, void *buffer, int size, char peek) GDIP_INTERNAL;
+int dstream_read (dstream_t *loader, BYTE *buffer, int size, char peek) GDIP_INTERNAL;
 void dstream_skip (dstream_t *loader, int nbytes) GDIP_INTERNAL;
 void dstream_free (dstream_t *loader) GDIP_INTERNAL;
 void dstream_keep_exif_buffer (dstream_t *loader) GDIP_INTERNAL;

--- a/src/metafile.c
+++ b/src/metafile.c
@@ -1232,7 +1232,7 @@ gdip_get_metafileheader_from (void *pointer, MetafileHeader *header, ImageSource
 	case ALDUS_PLACEABLE_METAFILE_KEY:
 		aldus_header.Key = key;
 		size = sizeof (WmfPlaceableFileHeader) - size;
-		if (gdip_read_wmf_data (pointer, (void*)(&aldus_header) + sizeof (DWORD), size, source) != size)
+		if (gdip_read_wmf_data(pointer, (BYTE*)(&aldus_header) + sizeof(DWORD), size, source) != size)
 			return InvalidParameter;
 #if FALSE
 g_warning ("ALDUS_PLACEABLE_METAFILE key %d, hmf %d, L %d, T %d, R %d, B %d, inch %d, reserved %d, checksum %d", 
@@ -1241,7 +1241,7 @@ g_warning ("ALDUS_PLACEABLE_METAFILE key %d, hmf %d, L %d, T %d, R %d, B %d, inc
 	aldus_header.Checksum);
 #endif
 		size = sizeof (METAHEADER);
-		if (gdip_read_wmf_data (pointer, (void*)&header->WmfHeader, size, source) != size)
+		if (gdip_read_wmf_data (pointer, (BYTE*)&header->WmfHeader, size, source) != size)
 			return InvalidParameter;
 
 		WmfPlaceableFileHeaderLE (&aldus_header);
@@ -1252,7 +1252,7 @@ g_warning ("ALDUS_PLACEABLE_METAFILE key %d, hmf %d, L %d, T %d, R %d, B %d, inc
 		memcpy (&header->WmfHeader, &key, size);
 
 		size = sizeof (METAHEADER) - size;
-		if (gdip_read_wmf_data (pointer, (void*)(&header->WmfHeader) + sizeof (DWORD), size, source) != size)
+		if (gdip_read_wmf_data (pointer, (BYTE*)(&header->WmfHeader) + sizeof(DWORD), size, source) != size)
 			return InvalidParameter;
 
 		MetafileHeaderLE (header);
@@ -1262,7 +1262,7 @@ g_warning ("ALDUS_PLACEABLE_METAFILE key %d, hmf %d, L %d, T %d, R %d, B %d, inc
 		emf = &(header->EmfHeader);
 		emf->iType = key;
 		size = sizeof (ENHMETAHEADER3) - size;
-		if (gdip_read_emf_data (pointer, (void*)(&header->EmfHeader) + sizeof (DWORD), size, source) != size)
+		if (gdip_read_emf_data (pointer, (BYTE*)(&header->EmfHeader) + sizeof (DWORD), size, source) != size)
 			return InvalidParameter;
 		EnhMetaHeaderLE (&header->EmfHeader);
 #if FALSE


### PR DESCRIPTION
`sizeof(void*)` is defined by gcc only, and Visual C++ will not let you increment the value of `void*`-typed pointers. To enable compilation with Visual C++, use the underlying data type - which is `BYTE *`.