### PR TITLE
Add Visual C++ project, AppVeyor script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,10 @@ test-driver
 compile
 tests/*.trs
 tests/*.log
-
+.vs/
+Debug/
+Release/
+*.user
+gtk/
+*.7z
+packages/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+platform:
+  - Win32
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+environment:
+  LIBGDIPLUS_VERSION_PREFIX: 4.2
+
+before_build:
+  - cmd: choco install -y wget
+  - cmd: wget "https://dl.hexchat.net/gtk-win32/vc14/x86/gtk-Win32.7z" -O gtk-Win32.7z
+  - cmd: 7z x gtk-Win32.7z -ogtk
+  - cmd: wget "https://dl.hexchat.net/gtk-win32/vc14/x64/gtk-x64.7z" -O gtk-x64.7z
+  - cmd: 7z x gtk-x64.7z -ogtk
+  - cmd: nuget restore
+
+build:
+  project: libgdiplus.sln
+
+on_success:
+  - cmd: 7z a -tzip "libgdiplus-%LIBGDIPLUS_VERSION_PREFIX%.%APPVEYOR_BUILD_NUMBER%-windows-%PLATFORM%-%CONFIGURATION%.zip" .\%PLATFORM%\%CONFIGURATION%\*.dll
+  - cmd: appveyor PushArtifact libgdiplus-%LIBGDIPLUS_VERSION_PREFIX%.%APPVEYOR_BUILD_NUMBER%-windows-%PLATFORM%-%CONFIGURATION%.zip

--- a/libgdiplus.sln
+++ b/libgdiplus.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libgdiplus", "src\libgdiplus.vcxproj", "{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}.Debug|Win32.ActiveCfg = Debug|Win32
+		{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}.Debug|Win32.Build.0 = Debug|Win32
+		{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}.Debug|x64.ActiveCfg = Debug|x64
+		{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}.Debug|x64.Build.0 = Debug|x64
+		{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}.Release|Win32.ActiveCfg = Release|Win32
+		{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}.Release|Win32.Build.0 = Release|Win32
+		{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}.Release|x64.ActiveCfg = Release|x64
+		{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/libgdiplus.vcxproj
+++ b/src/libgdiplus.vcxproj
@@ -1,0 +1,166 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}</ProjectGuid>
+    <RootNamespace>libgdiplus</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\gtk\$(Platform)\include;$(ProjectDir)\..\gtk\$(Platform)\include\glib-2.0;$(ProjectDir)\..\gtk\$(Platform)\lib\glib-2.0\include;$(ProjectDir)\..\gtk\$(Platform)\include\cairo;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_LIBJPEG;HAVE_LIBTIFF;HAVE_LIBPNG;_WINDLL;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- FIXME: To align with the GDI+ calling convention, this should be StdCall. Only relevant on x86 -->
+      <CallingConvention>Cdecl</CallingConvention>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>libpng16.lib;freetype.lib;fontconfig.lib;glib-2.0.lib;cairo.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(ProjectDir)\..\gtk\$(Platform)\lib</AdditionalLibraryDirectories>
+    </Link>
+    <PostBuildEvent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">copy $(ProjectDir)..\gtk\$(Platform)\bin\cairo.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\fontconfig.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\glib-2.0.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\iconv.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\libpng16.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\libxml2.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\zlib1.* $(OutDir)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">copy $(ProjectDir)..\gtk\$(Platform)\bin\cairo.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\fontconfig.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\glib-2.0.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\iconv.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\libpng16.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\libxml2.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\zlib1.* $(OutDir)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">copy $(ProjectDir)..\gtk\$(Platform)\bin\cairo.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\fontconfig.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\glib-2.0.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\iconv.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\libpng16.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\libxml2.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\zlib1.* $(OutDir)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">copy $(ProjectDir)..\gtk\$(Platform)\bin\cairo.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\fontconfig.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\glib-2.0.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\iconv.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\libpng16.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\libxml2.* $(OutDir)
+copy $(ProjectDir)..\gtk\$(Platform)\bin\zlib1.* $(OutDir)</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="*.c" Exclude="test.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="*.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="*.inc" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\libtiff.redist.4.0.6.2\build\native\libtiff.redist.targets" Condition="Exists('..\packages\libtiff.redist.4.0.6.2\build\native\libtiff.redist.targets')" />
+    <Import Project="..\packages\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.targets" Condition="Exists('..\packages\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.targets')" />
+    <Import Project="..\packages\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.targets" Condition="Exists('..\packages\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" />
+    <Import Project="..\packages\libtiff.4.0.6.2\build\native\libtiff.targets" Condition="Exists('..\packages\libtiff.4.0.6.2\build\native\libtiff.targets')" />
+    <Import Project="..\packages\libjpeg.redist.9.2.0.1\build\native\libjpeg.redist.targets" Condition="Exists('..\packages\libjpeg.redist.9.2.0.1\build\native\libjpeg.redist.targets')" />
+    <Import Project="..\packages\libjpeg.9.2.0.1\build\native\libjpeg.targets" Condition="Exists('..\packages\libjpeg.9.2.0.1\build\native\libjpeg.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\libtiff.redist.4.0.6.2\build\native\libtiff.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libtiff.redist.4.0.6.2\build\native\libtiff.redist.targets'))" />
+    <Error Condition="!Exists('..\packages\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v120.windesktop.msvcstl.dyn.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.dyn.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\libtiff.4.0.6.2\build\native\libtiff.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libtiff.4.0.6.2\build\native\libtiff.targets'))" />
+    <Error Condition="!Exists('..\packages\libjpeg.redist.9.2.0.1\build\native\libjpeg.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libjpeg.redist.9.2.0.1\build\native\libjpeg.redist.targets'))" />
+    <Error Condition="!Exists('..\packages\libjpeg.9.2.0.1\build\native\libjpeg.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libjpeg.9.2.0.1\build\native\libjpeg.targets'))" />
+  </Target>
+</Project>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="libjpeg" version="9.2.0.1" targetFramework="native" />
+  <package id="libjpeg.redist" version="9.2.0.1" targetFramework="native" />
+  <package id="libtiff" version="4.0.6.2" targetFramework="native" />
+  <package id="libtiff.redist" version="4.0.6.2" targetFramework="native" />
+  <package id="zlib" version="1.2.8.8" targetFramework="native" />
+  <package id="zlib.v120.windesktop.msvcstl.dyn.rt-dyn" version="1.2.8.8" targetFramework="native" />
+  <package id="zlib.v140.windesktop.msvcstl.dyn.rt-dyn" version="1.2.8.8" targetFramework="native" />
+</packages>


### PR DESCRIPTION
This completes the initial work to get libgdiplus compiling with Visual C++ and running on Windows.

Adds a Visual C++ project (and VS solution) which compiles libgdiplus. Most of the dependencies are sourced from HexChat's gtk-win32; others come from CoApp packages on NuGet.