### PR TITLE
Fix null pointer dereference in GdipPrivateAddMemoryFont

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -1075,7 +1075,7 @@ GdipPrivateAddMemoryFont(GpFontCollection *fontCollection, GDIPCONST void *memor
 	FcChar8 fontfile[256];
 	int	f;
 
-	if (!memory)
+	if (!fontCollection || !memory)
 		return InvalidParameter;
 
 #ifdef WIN32

--- a/src/font.c
+++ b/src/font.c
@@ -1077,6 +1077,8 @@ GdipPrivateAddMemoryFont(GpFontCollection *fontCollection, GDIPCONST void *memor
 
 	if (!fontCollection || !memory)
 		return InvalidParameter;
+	if (length <= 0)
+		return InvalidParameter;
 
 #ifdef WIN32
 	f = CreateTempFile (fontfile);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -5,6 +5,7 @@ Makefile
 Makefile.in
 testbits
 testclip
+testfont
 testgdi
 testreversepath
 testpng

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,7 +17,7 @@ LDADDS =					\
 	-lm
 
 noinst_PROGRAMS =			\
-	testbits testclip testreversepath testpng
+	testbits testclip testfont testreversepath testpng
 
 if HAS_X11
 noinst_PROGRAMS =

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,6 +42,12 @@ testclip_SOURCES =	\
 testclip_DEPENDENCIES = $(TEST_DEPS)
 testclip_LDADD = $(LDADDS)
 
+testfonts_DEPENDENCIES = $(TEST_DEPS)
+testfonts_LDADD = $(LDADDS)
+
+testfonts_SOURCES =		\
+	testfonts.c
+
 testreversepath_SOURCES =	\
 	testreversepath.c
 
@@ -58,12 +64,14 @@ EXTRA_DIST =			\
 	$(testgdi_SOURCES)	\
 	$(testbits_SOURCES)	\
 	$(testclip_SOURCES)	\
+	$(testfonts_SOURCES)	\
 	$(testpng_SOURCES)	\
 	$(testreversepath_SOURCES)
 
 TESTS = \
 	testbits \
 	testclip \
+	testfont \
 	testreversepath \
 	testpng \
 	$(NULL)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,11 +42,11 @@ testclip_SOURCES =	\
 testclip_DEPENDENCIES = $(TEST_DEPS)
 testclip_LDADD = $(LDADDS)
 
-testfonts_DEPENDENCIES = $(TEST_DEPS)
-testfonts_LDADD = $(LDADDS)
+testfont_DEPENDENCIES = $(TEST_DEPS)
+testfont_LDADD = $(LDADDS)
 
-testfonts_SOURCES =		\
-	testfonts.c
+testfont_SOURCES =		\
+	testfont.c
 
 testreversepath_SOURCES =	\
 	testreversepath.c
@@ -64,7 +64,7 @@ EXTRA_DIST =			\
 	$(testgdi_SOURCES)	\
 	$(testbits_SOURCES)	\
 	$(testclip_SOURCES)	\
-	$(testfonts_SOURCES)	\
+	$(testfont_SOURCES)	\
 	$(testpng_SOURCES)	\
 	$(testreversepath_SOURCES)
 

--- a/tests/testfont.c
+++ b/tests/testfont.c
@@ -1,0 +1,46 @@
+#ifdef WIN32
+#ifndef __cplusplus
+#error Please compile with a C++ compiler.
+#endif
+#include <windows.h>
+#include <GdiPlus.h>
+#else
+#include <GdiPlusFlat.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#ifdef WIN32
+using namespace Gdiplus;
+using namespace DllExports;
+#endif
+
+int
+main(int argc, char**argv)
+{
+	GdiplusStartupInput gdiplusStartupInput;
+	ULONG_PTR gdiplusToken;
+	GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
+	
+	GpFontCollection *collection;
+	int status = GdipNewPrivateFontCollection(&collection);
+	assert(status == 0);
+	
+	status = GdipNewPrivateFontCollection(NULL);
+	assert(status == 2);
+
+	int memory = 1;
+	status = GdipPrivateAddMemoryFont(NULL, &memory, 1);
+	assert(status == 2);
+	
+	status = GdipDeletePrivateFontCollection(NULL);
+	assert(status == 2);
+
+	status = GdipDeletePrivateFontCollection(&collection);
+	assert(status == 0);
+
+	GdiplusShutdown(gdiplusToken);
+	return 0;
+}

--- a/tests/testfont.c
+++ b/tests/testfont.c
@@ -37,6 +37,15 @@ main(int argc, char**argv)
 	
 	status = GdipDeletePrivateFontCollection(NULL);
 	assert(status == 2);
+	
+	status = GdipPrivateAddMemoryFont(collection, NULL, 1);
+	assert(status == 2);
+
+	status = GdipPrivateAddMemoryFont(collection, &memory, -1);
+	assert(status == 2);
+
+	status = GdipPrivateAddMemoryFont(collection, &memory, 0);
+	assert(status == 2);
 
 	status = GdipDeletePrivateFontCollection(&collection);
 	assert(status == 0);


### PR DESCRIPTION
This fixes the following C# tests (see https://github.com/dotnet/corefx/pull/21552)

```cs
[Fact]
public void AddMemoryFont_ZeroMemory_ThrowsArgumentException()
{
    using (var fontCollection = new PrivateFontCollection())
    {
        AssertExtensions.Throws<ArgumentException>(null, () => fontCollection.AddMemoryFont(IntPtr.Zero, 100));
    }
}

[Theory]
[InlineData(0)]
[InlineData(-1)]
public void AddMemoryFont_InvalidLength_ThrowsArgumentException(int length)
{
    using (var fontCollection = new PrivateFontCollection())
    {
        byte[] data = File.ReadAllBytes(Helpers.GetTestBitmapPath("CodeNewRoman.otf"));

        IntPtr fontBuffer = Marshal.AllocCoTaskMem(data.Length);
        try
        {
            Marshal.Copy(data, 0, fontBuffer, data.Length);
            AssertExtensions.Throws<ArgumentException>(null, () => fontCollection.AddMemoryFont(fontBuffer, length));
        }
        finally
        {
            Marshal.FreeCoTaskMem(fontBuffer);
        }
    }
}

[Fact]
public void AddMemoryFont_Disposed_ThrowsArgumentException()
{
    var fontCollection = new PrivateFontCollection();
    fontCollection.Dispose();

    AssertExtensions.Throws<ArgumentException>(null, () => fontCollection.AddMemoryFont((IntPtr)10, 100));
}
```