### PR TITLE
Fix MSVC warnings

### DIFF
--- a/src/jpegcodec.c
+++ b/src/jpegcodec.c
@@ -588,7 +588,7 @@ gdip_load_jpeg_image_from_file (FILE *fp, const char *filename, GpImage **image)
 	}
 
 	src->parent.init_source = _gdip_source_dummy_init;
-	src->parent.fill_input_buffer = _gdip_source_stdio_fill_input_buffer;
+	src->parent.fill_input_buffer = (boolean(*)(j_decompress_ptr))_gdip_source_stdio_fill_input_buffer;
 	src->parent.skip_input_data = _gdip_source_stdio_skip_input_data;
 	src->parent.resync_to_restart = jpeg_resync_to_restart;
 	src->parent.term_source = _gdip_source_dummy_term;
@@ -625,7 +625,7 @@ gdip_load_jpeg_image_from_stream_delegate (dstream_t *loader, GpImage **image)
 
 
 	src->parent.init_source = _gdip_source_dummy_init;
-	src->parent.fill_input_buffer = _gdip_source_stream_fill_input_buffer;
+	src->parent.fill_input_buffer = (boolean(*)(j_decompress_ptr))_gdip_source_stream_fill_input_buffer;
 	src->parent.skip_input_data = _gdip_source_stream_skip_input_data;
 	src->parent.resync_to_restart = jpeg_resync_to_restart;
 	src->parent.term_source = _gdip_source_dummy_init;
@@ -703,7 +703,7 @@ gdip_save_jpeg_image_internal (FILE *fp, PutBytesDelegate putBytesFunc, GpImage 
 	} else {
 		dest = GdipAlloc (sizeof (struct gdip_stream_jpeg_dest_mgr));
 		dest->parent.init_destination = _gdip_dest_stream_init;
-		dest->parent.empty_output_buffer = _gdip_dest_stream_empty_output_buffer;
+		dest->parent.empty_output_buffer = (boolean(*)(j_compress_ptr))_gdip_dest_stream_empty_output_buffer;
 		dest->parent.term_destination = _gdip_dest_stream_term;
 
 		dest->putBytesFunc = putBytesFunc;

--- a/src/libgdiplus.vcxproj
+++ b/src/libgdiplus.vcxproj
@@ -91,6 +91,7 @@
       <PreprocessorDefinitions>HAVE_LIBJPEG;HAVE_LIBTIFF;HAVE_LIBPNG;_WINDLL;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- FIXME: To align with the GDI+ calling convention, this should be StdCall. Only relevant on x86 -->
       <CallingConvention>Cdecl</CallingConvention>
+      <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>libpng16.lib;freetype.lib;fontconfig.lib;glib-2.0.lib;cairo.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/libgdiplus.vcxproj
+++ b/src/libgdiplus.vcxproj
@@ -91,7 +91,7 @@
       <PreprocessorDefinitions>HAVE_LIBJPEG;HAVE_LIBTIFF;HAVE_LIBPNG;_WINDLL;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- FIXME: To align with the GDI+ calling convention, this should be StdCall. Only relevant on x86 -->
       <CallingConvention>Cdecl</CallingConvention>
-      <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>libpng16.lib;freetype.lib;fontconfig.lib;glib-2.0.lib;cairo.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/pngcodec.c
+++ b/src/pngcodec.c
@@ -372,7 +372,7 @@ gdip_load_png_image_from_file_or_stream (FILE *fp, GetBytesDelegate getBytesFunc
 				for (i=0; i < num_trans; i++) {
 					png_bytep alpha =
 #if (PNG_LIBPNG_VER > 10399)
-						trans_alpha[i];
+						(png_bytep)trans_alpha[i];
 #else
 						info_ptr->trans[i];
 #endif
@@ -381,7 +381,7 @@ gdip_load_png_image_from_file_or_stream (FILE *fp, GetBytesDelegate getBytesFunc
 							png_palette[i].blue,
 							png_palette[i].green,
 							png_palette[i].red,
-							alpha);
+							(unsigned char)alpha);
 				}
 			}
 		}

--- a/src/win32_io.c
+++ b/src/win32_io.c
@@ -41,5 +41,5 @@ int CreateTempFile (char *filename)
 		return FileNotFound;
 	}
 
-	return (int)fopen (filename, "w");
+	return (int)(intptr_t)fopen (filename, "w");
 }


### PR DESCRIPTION
@qmfrederik 

> libgdiplus\src\pngcodec.c(384): warning C4047: '=': 'unsigned char' differs in levels of indirection from 'png_bytep'
> libgdiplus\src\pngcodec.c(373): warning C4047: 'initializing': 'png_bytep' differs in levels of indirection from 'png_byte'

> libgdiplus\src\jpegcodec.c(591): warning C4133: '=': incompatible types - from 'BOOL (__cdecl *)(j_decompress_ptr)' to 'boolean (__cdecl *)(j_decompress_ptr)'
> libgdiplus\src\jpegcodec.c(628): warning C4133: '=': incompatible types - from 'BOOL (__cdecl *)(j_decompress_ptr)' to 'boolean (__cdecl *)(j_decompress_ptr)'
> libgdiplus\src\jpegcodec.c(706): warning C4133: '=': incompatible types - from 'BOOL (__cdecl *)(j_compress_ptr)' to 'boolean (__cdecl *)(j_compress_ptr)'

> LINK : warning LNK4098: defaultlib 'MSVCRT' conflicts with use of other libs; use /NODEFAULTLIB:library