### PR TITLE
Fix missing APIs in GdiPlusFlat.h

### DIFF
--- a/src/GdiPlusFlat.h
+++ b/src/GdiPlusFlat.h
@@ -62,6 +62,7 @@ typedef void GpImage;
 typedef void GpImageAttributes;
 typedef void GpLineGradient;
 typedef void GpMatrix;
+typedef void GpMetafile;
 typedef void GpPath;
 typedef void GpPathIterator;
 typedef void GpPathGradient;
@@ -105,15 +106,20 @@ typedef struct {
 #include "fontfamily.h"
 #include "graphics.h"
 #include "graphics-path.h"
+#include "graphics-pathiterator.h"
 #include "hatchbrush.h"
 #include "image.h"
 #include "imageattributes.h"
-#include "pen.h"
+#include "lineargradientbrush.h"
 #include "matrix.h"
+#include "metafile.h"
+#include "pathgradientbrush.h"
+#include "pen.h"
 #include "region.h"
 #include "solidbrush.h"
 #include "stringformat.h"
 #include "text.h"
+#include "texturebrush.h"
 
 #ifdef __cplusplus
 }

--- a/src/lineargradientbrush.c
+++ b/src/lineargradientbrush.c
@@ -23,6 +23,7 @@
  *
  */
 
+#include "brush-private.h"
 #include "lineargradientbrush-private.h"
 #include "graphics-private.h"
 #include "matrix-private.h"

--- a/src/lineargradientbrush.h
+++ b/src/lineargradientbrush.h
@@ -26,8 +26,6 @@
 #ifndef __LINEAR_GRADIENT_H__
 #define __LINEAR_GRADIENT_H__
 
-#include "brush-private.h"
-
 typedef enum {
 	LinearGradientModeHorizontal		= 0,	/* angle = 0 deg    */
 	LinearGradientModeVertical		= 1,	/* angle = 90 deg   */

--- a/src/pathgradientbrush.c
+++ b/src/pathgradientbrush.c
@@ -25,6 +25,7 @@
  */
 
 #include "pathgradientbrush-private.h"
+#include "gdiplus-private.h"
 #include "graphics-private.h"
 #include "graphics-path-private.h"
 #include "matrix-private.h"

--- a/src/pathgradientbrush.h
+++ b/src/pathgradientbrush.h
@@ -25,9 +25,7 @@
 #ifndef __PATHGRADIENTBRUSH_H__
 #define __PATHGRADIENTBRUSH_H__
 
-#include "gdiplus-private.h"
 #include "brush.h"
-
 
 GpStatus WINGDIPAPI GdipCreatePathGradient (GDIPCONST GpPointF *points, INT count, GpWrapMode wrapMode, GpPathGradient **polyGradient);
 GpStatus WINGDIPAPI GdipCreatePathGradientI (GDIPCONST GpPoint *points, INT count, GpWrapMode wrapMode, GpPathGradient **polyGradient);


### PR DESCRIPTION
These are all present on Windows, but missing in libgdiplus.