### PR TITLE
Fix redefinition of non-GDI Windows basic types in win32structs.h

### DIFF
--- a/src/win32structs.h
+++ b/src/win32structs.h
@@ -83,15 +83,21 @@
 #define MWT_LEFTMULTIPLY	2
 #define MWT_RIGHTMULTIPLY	3
 
+typedef guint32 ARGB;
+typedef float REAL;
+
+#if defined(_WIN32)
+#define NOGDI
+#include <Windows.h>
+#else
+
 typedef int LANGID;
 typedef int INT;
 typedef guint16 WCHAR; /* 16-bits unicode */
 typedef guint32 UINT;
-typedef guint32 ARGB;
 typedef guint32 UINT32;
 typedef gint32 PROPID;
 typedef guint32 ULONG_PTR; /* not a pointer! */
-typedef float REAL;
 
 typedef gpointer HBITMAP;
 typedef gpointer HDC;
@@ -147,6 +153,7 @@ typedef struct {
 	WORD  Data3;
 	BYTE  Data4 [8];
 } GUID, Guid, CLSID;
+#endif
 
 typedef struct {
 	LONG lfHeight;
@@ -191,10 +198,12 @@ typedef struct {
 	float eDy;
 } XFORM;
 
+#if !defined(_WIN32)
 typedef struct {
 	LONG	x;
 	LONG	y;
 } POINT;
+#endif
 
 typedef DWORD COLORREF;
 
@@ -210,6 +219,7 @@ typedef struct {
 	LONG		lbHatch;
 } LOGBRUSH;
 
+#if !defined(_WIN32)
 typedef struct {
 	int	left;
 	int	top;
@@ -221,6 +231,7 @@ typedef struct {
 	int	cx;
 	int	cy; 
 } SIZE, SIZEL;
+#endif
 
 typedef struct {
 	SHORT	Left;

--- a/src/win32structs.h
+++ b/src/win32structs.h
@@ -86,12 +86,11 @@
 typedef guint32 ARGB;
 typedef float REAL;
 
-#if defined(_WIN32)
+#if defined(WIN32)
 #define NOGDI
-#include <Windows.h>
+#include <windows.h>
 #else
 
-typedef int LANGID;
 typedef int INT;
 typedef guint16 WCHAR; /* 16-bits unicode */
 typedef guint32 UINT;
@@ -147,6 +146,8 @@ typedef gpointer HRGN;
 
 #endif 		/* to avoid conflict with uglify.h */
 
+typedef WORD LANGID;
+
 typedef struct {
 	DWORD Data1;
 	WORD  Data2;
@@ -198,7 +199,7 @@ typedef struct {
 	float eDy;
 } XFORM;
 
-#if !defined(_WIN32)
+#if !defined(WIN32)
 typedef struct {
 	LONG	x;
 	LONG	y;
@@ -219,7 +220,7 @@ typedef struct {
 	LONG		lbHatch;
 } LOGBRUSH;
 
-#if !defined(_WIN32)
+#if !defined(WIN32)
 typedef struct {
 	int	left;
 	int	top;


### PR DESCRIPTION
This causes some of the unit tests to fail to compile on Windows:

> c:\users\hugh\documents\github\libgdiplus\src\win32structs.h(129): error C2371: 'TCHAR': redefinition; different basic types
> c:\program files (x86)\windows kits\10\include\10.0.15063.0\ucrt\tchar.h(180): note: see declaration of 'TCHAR'