### PR TITLE
[RFC] Add API for getting libgdiplus version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,4 +7,4 @@ pkgconfig_DATA= libgdiplus.pc
 
 DISTCLEANFILES= libgdiplus.pc
 
-EXTRA_DIST = libgdiplus.pc.in LICENSE
+EXTRA_DIST = libgdiplus.pc.in LICENSE libgdiplus.sln winconfig.h.in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -122,3 +122,5 @@ libgdiplus_la_SOURCES = \
 libgdiplus_la_LIBADD = $(GDIPLUS_LIBS)
 
 INCLUDES = $(GDIPLUS_CFLAGS) -Wall -Wno-unused -Wno-format
+
+EXTRA_DIST = libgdiplus.vcxproj packages.config

--- a/src/gdiplus-private.h
+++ b/src/gdiplus-private.h
@@ -40,8 +40,9 @@
 #include <pthread.h>
 #include <unistd.h>
 
-#include "config.h"
 #endif
+
+#include "config.h"
 
 #if HAVE_VISIBILITY_HIDDEN
 	#define GDIP_INTERNAL __attribute__((visibility ("hidden")))

--- a/src/general.c
+++ b/src/general.c
@@ -93,6 +93,13 @@ GdipFree (void *ptr)
 	free (ptr);
 }
 
+/* libgdiplus-specific API */
+WINGDIPAPI char*
+GetLibgdiplusVersion ()
+{
+	return g_strdup (VERSION);
+}
+
 /* Helpers */
 GpStatus 
 gdip_get_status (cairo_status_t status)

--- a/src/general.h
+++ b/src/general.h
@@ -45,4 +45,7 @@ void WINGDIPAPI GdiplusShutdown (ULONG_PTR token);
 WINGDIPAPI void*  GdipAlloc (size_t size);
 WINGDIPAPI void GdipFree (void *ptr);
 
+/* libgdiplus-specific API, useful for quirking buggy behavior in older versions */
+WINGDIPAPI char* GetLibgdiplusVersion ();
+
 #endif

--- a/src/gifcodec.c
+++ b/src/gifcodec.c
@@ -26,9 +26,7 @@
  *	Sebastien Pouliot  <sebastien@ximian.com>
  */
 
-#if HAVE_CONFIG_H
-#include <config.h>
-#endif
+#include "config.h"
 #include "gdiplus-private.h"
 
 GUID gdip_gif_image_format_guid = {0xb96b3cb0U, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};

--- a/src/jpegcodec.c
+++ b/src/jpegcodec.c
@@ -25,9 +25,7 @@
  *
  */
 
-#if HAVE_CONFIG_H
-#include <config.h>
-#endif
+#include "config.h"
 #include "gdiplus-private.h"
 
 GUID gdip_jpg_image_format_guid = {0xb96b3caeU, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};

--- a/src/libgdiplus.vcxproj
+++ b/src/libgdiplus.vcxproj
@@ -87,7 +87,7 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)\..\gtk\$(Platform)\include;$(ProjectDir)\..\gtk\$(Platform)\include\glib-2.0;$(ProjectDir)\..\gtk\$(Platform)\lib\glib-2.0\include;$(ProjectDir)\..\gtk\$(Platform)\include\cairo;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..;$(ProjectDir)\..\gtk\$(Platform)\include;$(ProjectDir)\..\gtk\$(Platform)\include\glib-2.0;$(ProjectDir)\..\gtk\$(Platform)\lib\glib-2.0\include;$(ProjectDir)\..\gtk\$(Platform)\include\cairo;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>HAVE_LIBJPEG;HAVE_LIBTIFF;HAVE_LIBPNG;_WINDLL;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- FIXME: To align with the GDI+ calling convention, this should be StdCall. Only relevant on x86 -->
       <CallingConvention>Cdecl</CallingConvention>
@@ -97,6 +97,9 @@
       <AdditionalDependencies>libpng16.lib;freetype.lib;fontconfig.lib;glib-2.0.lib;cairo.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ProjectDir)\..\gtk\$(Platform)\lib</AdditionalLibraryDirectories>
     </Link>
+    <PreBuildEvent>
+      <Command>%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -Command "(Get-Content $(ProjectDir)\..\winconfig.h.in) -replace '#LIBGDIPLUS_VERSION#', (Select-String -path $(ProjectDir)\..\configure.ac -pattern 'AC_INIT\(libgdiplus, \[(.*)\]').Matches[0].Groups[1].Value | Set-Content $(ProjectDir)\..\config.h" 2&gt;&amp;1</Command>
+    </PreBuildEvent>
     <PostBuildEvent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">copy $(ProjectDir)..\gtk\$(Platform)\bin\cairo.* $(OutDir)
 copy $(ProjectDir)..\gtk\$(Platform)\bin\fontconfig.* $(OutDir)
@@ -139,6 +142,7 @@ copy $(ProjectDir)..\gtk\$(Platform)\bin\zlib1.* $(OutDir)</Command>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="*.h" />
+    <ClInclude Include="..\config.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="*.inc" />

--- a/src/pngcodec.c
+++ b/src/pngcodec.c
@@ -25,9 +25,7 @@
  *
  */
 
-#if HAVE_CONFIG_H
-#include <config.h>
-#endif
+#include "config.h"
 #include "win32structs.h"
 
 GUID gdip_png_image_format_guid = {0xb96b3cafU, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};

--- a/src/tiffcodec.c
+++ b/src/tiffcodec.c
@@ -28,9 +28,7 @@
  * Copyright (C) Novell, Inc. 2003-2004.
  */
 
-#if HAVE_CONFIG_H
-#include <config.h>
-#endif
+#include "config.h"
 #include "gdiplus-private.h"
 
 GUID gdip_tif_image_format_guid = {0xb96b3cb1U, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};

--- a/winconfig.h.in
+++ b/winconfig.h.in
@@ -1,0 +1,4 @@
+/* winconfig.h.in.  Template used on Windows/MSVC and processed by libgdiplus.vcxproj PreBuildEvent.  */
+
+/* Version number of package */
+#define VERSION "#LIBGDIPLUS_VERSION#"


### PR DESCRIPTION
/cc @qmfrederik for feedback

This would simply return the libgdiplus version (e.g. `5.6`) as a string. It could be used like this:

```csharp

[DllImport("gdiplus")]
extern static string GetLibgdiplusVersion ();

Version LibgdiplusVersion {
    get {
        try {
            return new Version (GetLibgdiplusVersion ());
        } catch (EntryPointNotFoundException) {
            return null;  // in case of older libgdiplus or Windows GDI+
       }
   }
}
```

not sure if the string version is the best option or we should return major+minor as an int? or some other counter?