### PR TITLE
[Experiment/WIP] redefine wchar to be wchar_t

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -157,7 +157,7 @@ GdipPrivateAddFontFile (GpFontCollection *font_collection, GDIPCONST WCHAR *file
 	if (!font_collection || !filename)
 		return InvalidParameter;
     
-	file = (BYTE*) ucs2_to_utf8 ((const gunichar2 *)filename, -1);
+	file = (BYTE*) wchar_to_char (filename, -1);
 	if (!file)
 		return OutOfMemory;
 
@@ -486,7 +486,7 @@ GdipCreateFontFamilyFromName (GDIPCONST WCHAR *name, GpFontCollection *font_coll
 	if (!name || !fontFamily)
 		return InvalidParameter;
 
-	string = (char*)ucs2_to_utf8 ((const gunichar2 *)name, -1);
+	string = wchar_to_char (name, -1);
 	if (!string)
 		return OutOfMemory;
 
@@ -515,7 +515,7 @@ GdipGetFamilyName (GDIPCONST GpFontFamily *family, WCHAR name[LF_FACESIZE], LANG
 	if (status != Ok)
 		return status;
 
-	utf8_to_ucs2((const gchar *)fc_str, (gunichar2 *)name, LF_FACESIZE);
+	char_to_wchar ((const char *)fc_str, name, LF_FACESIZE);
 	return Ok;
 }
 
@@ -1017,7 +1017,7 @@ gdip_logfont_from_font (GpFont *font, GpGraphics *graphics, void *lf, BOOL ucs2)
 
 	logFont->lfPitchAndFamily = 0;
 	if (ucs2) {
-		utf8_to_ucs2((const gchar *)font->face, (gunichar2 *)logFont->lfFaceName, LF_FACESIZE);
+		char_to_wchar((const char *) font->face, (WCHAR *) logFont->lfFaceName, LF_FACESIZE);
 	} else {
 		int len = strlen ((char*)font->face);
 		memset (logFont->lfFaceName, 0, LF_FACESIZE);
@@ -1105,7 +1105,7 @@ gdip_create_font_from_logfont (void *hdc, void *lf, GpFont **font, BOOL ucs2)
 	}
 
 	if (ucs2) {
-		result->face = (BYTE*) ucs2_to_utf8 ((const gunichar2 *)logfont->lfFaceName, -1);
+		result->face = (unsigned char *) wchar_to_char ((const WCHAR *) logfont->lfFaceName, -1);
 		if (!result->face){
 			GdipFree (result);
 			return OutOfMemory;

--- a/src/general-private.h
+++ b/src/general-private.h
@@ -104,9 +104,9 @@ float gdip_get_display_dpi () GDIP_INTERNAL;
 GpStatus gdip_get_status (cairo_status_t status) GDIP_INTERNAL;
 GpStatus gdip_get_pattern_status (cairo_pattern_t *pat) GDIP_INTERNAL;
 
-gchar *ucs2_to_utf8 (const gunichar2 *ucs2, int length) GDIP_INTERNAL;
-BOOL utf8_to_ucs2 (const gchar *utf8, gunichar2 *ucs2, int ucs2_len) GDIP_INTERNAL;
-int utf8_encode_ucs2char (gunichar2 unichar, unsigned char *dest) GDIP_INTERNAL;
+char *wchar_to_char (const WCHAR *ucs2, int length) GDIP_INTERNAL;
+BOOL char_to_wchar (const char *utf8, WCHAR *ucs2, int ucs2_len) GDIP_INTERNAL;
+int utf8_encode_ucs2char (WCHAR unichar, unsigned char *dest) GDIP_INTERNAL;
 
 /* for drawing curves */
 GpPointF *convert_points (const GpPoint *points, int count) GDIP_INTERNAL;

--- a/src/general.c
+++ b/src/general.c
@@ -342,14 +342,13 @@ gdip_erf (float x, float std, float mean)
  convert a ucs2 string to utf8
  length = number of characters to convert, -1 to indicate the whole string
 */
-
-gchar *
-ucs2_to_utf8(const gunichar2 *ucs2, int length) {
-	const gunichar2	*ptr;
-	const gunichar2	*end;
-	gunichar	*dest;
-	gunichar	*uni;
-	gchar		*utf8;
+char *
+wchar_to_char (const WCHAR *ucs2, int length) {
+	const WCHAR	*ptr;
+	const WCHAR	*end;
+	gunichar *dest;
+	gunichar *uni;
+	char *utf8;
 
 	/* Count length */
 	if (length == -1) {
@@ -360,7 +359,6 @@ ucs2_to_utf8(const gunichar2 *ucs2, int length) {
 			length++;
 		}
 	}
-
 
 	uni = GdipAlloc((length + 1) * sizeof(gunichar));
 	if (uni == NULL) {
@@ -380,7 +378,7 @@ ucs2_to_utf8(const gunichar2 *ucs2, int length) {
 	*dest = 0;
 	dest++;
 	
-	utf8 = (gchar *) g_ucs4_to_utf8 ((const gunichar *)uni, -1, NULL, NULL, NULL);
+	utf8 = (char *) g_ucs4_to_utf8 ((const gunichar *)uni, -1, NULL, NULL, NULL);
 
 	GdipFree(uni);
 
@@ -388,12 +386,12 @@ ucs2_to_utf8(const gunichar2 *ucs2, int length) {
 }
 
 BOOL
-utf8_to_ucs2(const gchar *utf8, gunichar2 *ucs2, int ucs2_len) {
+char_to_wchar (const char *utf8, WCHAR *ucs2, int ucs2_len) {
 	int 		i;
 	glong		items_read;
 	glong		count;
 	gunichar	*ucs4;
-	gunichar2	*ptr;
+	WCHAR	*ptr;
 
 	items_read = 0;
 	count = 0;
@@ -405,10 +403,10 @@ utf8_to_ucs2(const gchar *utf8, gunichar2 *ucs2, int ucs2_len) {
 		return FALSE;
 	}
 
-	ptr = (gunichar2 *)ucs2;
+	ptr = (WCHAR *)ucs2;
 	for (i = 0; (i < count) && (i < ucs2_len); i++) {
 		if (ucs4[i] < 0x10000 && !(ucs4[i] >= 0xd800 && ucs4[i] < 0xe000)) {
-			*ptr = (gunichar2)ucs4[i];
+			*ptr = (WCHAR)ucs4[i];
 			ptr++;
 		}	/* we're simply ignoring any chars that don't fit into ucs2 */
 	}
@@ -421,7 +419,7 @@ utf8_to_ucs2(const gchar *utf8, gunichar2 *ucs2, int ucs2_len) {
 }
 
 int
-utf8_encode_ucs2char(gunichar2 unichar, BYTE *dest)
+utf8_encode_ucs2char (WCHAR unichar, BYTE *dest)
 {
 	if (unichar < 0x0080) {					/* 0000-007F */
 		dest[0] = (BYTE)(unichar);
@@ -438,29 +436,6 @@ utf8_encode_ucs2char(gunichar2 unichar, BYTE *dest)
 	dest[2] = (BYTE)(0x80 | (unichar & 0x003F));
 	return (3);	
 }
-
-/* re-enabled if/when required */
-#if FALSE
-/* This function only handles UCS-2 */
-int
-utf8_decode_ucs2char (const BYTE *src, gunichar2 *uchar)
-{
-	if (src[0] <= 0x7F) {			/* 0000-007F: one byte (0xxxxxxx) */
-		*uchar = (gunichar2)src[0];
-		return (1);
-	}
-	if (src[0] <= 0xDF) {			/* 0080-07FF: two bytes (110xxxxx 10xxxxxx) */
-		*uchar = ((((gunichar2)src[0]) & 0x001F) << 6) |
-			((((gunichar2)src[1]) & 0x003F) << 0);
-		return (2);
-	}
-						/* 0800-FFFF: three bytes (1110xxxx 10xxxxxx 10xxxxxx) */
-	*uchar = ((((gunichar2)src[0]) & 0x000F) << 12) |
-		((((gunichar2)src[1]) & 0x003F) << 6) |
-		((((gunichar2)src[2]) & 0x003F) << 0);
-	return (3);
-}
-#endif
 
 GpStatus
 gdip_get_pattern_status (cairo_pattern_t *pat)

--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -1182,7 +1182,7 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 		return OutOfMemory;
 	}
 
-	utf8 = (BYTE*) ucs2_to_utf8 ((const gunichar2 *)string, -1);
+	utf8 = (BYTE*) wchar_to_char (string, -1);
 	if (!utf8) {
 		cairo_destroy (cr);
 		cairo_surface_destroy (cs);

--- a/src/image.c
+++ b/src/image.c
@@ -1046,7 +1046,7 @@ GdipLoadImageFromFile (GDIPCONST WCHAR *file, GpImage **image)
 	if (!image || !file)
 		return InvalidParameter;
 	
-	file_name = (char *) ucs2_to_utf8 ((const gunichar2 *)file, -1);
+	file_name = wchar_to_char (file, -1);
 	if (!file_name) {
 		*image = NULL;
 		return InvalidParameter;
@@ -1160,7 +1160,7 @@ GdipSaveImageToFile (GpImage *image, GDIPCONST WCHAR *file, GDIPCONST CLSID *enc
 	if (format == INVALID)
 		return UnknownImageFormat;
 	
-	file_name = (char *) ucs2_to_utf8 ((const gunichar2 *)file, -1);
+	file_name = wchar_to_char (file, -1);
 	if (file_name == NULL)
 		return InvalidParameter;
 	

--- a/src/metafile.c
+++ b/src/metafile.c
@@ -1393,7 +1393,7 @@ GdipCreateMetafileFromFile (GDIPCONST WCHAR *file, GpMetafile **metafile)
 	if (!file || !metafile)
 		return InvalidParameter;
 
-	file_name = (char *) ucs2_to_utf8 ((const gunichar2 *)file, -1);
+	file_name = wchar_to_char (file, -1);
 	if (!file_name)
 		return InvalidParameter;
 	
@@ -1517,7 +1517,7 @@ GdipGetMetafileHeaderFromFile (GDIPCONST WCHAR *filename, MetafileHeader *header
 	if (!filename || !header)
 		return InvalidParameter;
 
-	file_name = (char *) ucs2_to_utf8 ((const gunichar2 *)filename, -1);
+	file_name = wchar_to_char (filename, -1);
 	if (!file_name)
 		return InvalidParameter;
 	
@@ -1705,7 +1705,7 @@ GdipRecordMetafileFileName (GDIPCONST WCHAR *fileName, HDC referenceHdc, EmfType
 	if (!fileName)
 		return InvalidParameter;
 
-	file_name = (char *) ucs2_to_utf8 ((const gunichar2 *)fileName, -1);
+	file_name = wchar_to_char (fileName, -1);
 	if (!file_name) {
 		*metafile = NULL;
 		return InvalidParameter;

--- a/src/text-cairo.c
+++ b/src/text-cairo.c
@@ -42,7 +42,7 @@
 #undef DRAWSTRING_DEBUG
 
 static int
-CalculateStringWidths (cairo_t *ct, GDIPCONST GpFont *gdiFont, GDIPCONST gunichar2 *stringUnicode, unsigned long StringDetailElements, GpStringDetailStruct *StringDetails)
+CalculateStringWidths (cairo_t *ct, GDIPCONST GpFont *gdiFont, GDIPCONST WCHAR *stringUnicode, unsigned long StringDetailElements, GpStringDetailStruct *StringDetails)
 {
 	size_t			i;
 	cairo_text_extents_t	ext;
@@ -324,7 +324,7 @@ MeasureString (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, int *length
 	}
 	
 	/* Convert string from Gdiplus format to UTF8, suitable for cairo */
-	String = (BYTE*) ucs2_to_utf8 ((const gunichar2 *)CleanString, -1);
+	String = (BYTE*) wchar_to_char (CleanString, -1);
 	if (!String)
 		return OutOfMemory;
 
@@ -822,7 +822,7 @@ DrawString (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, int length, GD
 
 			if (length > StringLen - i)
 				length = StringLen - i;
-			String = (BYTE*) ucs2_to_utf8 ((const gunichar2 *)(CleanString+i), length);
+			String = (BYTE*) wchar_to_char ((CleanString+i), length);
 #ifdef DRAWSTRING_DEBUG
 			printf("Displaying line >%s< (%d chars)\n", String, length);
 #endif

--- a/src/text-pango.c
+++ b/src/text-pango.c
@@ -173,7 +173,7 @@ gdip_pango_setup_layout (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, i
 	double clipy2;
 	int trimSpace;      /* whether or not to trim the space */
 
-	gchar *text = ucs2_to_utf8 (stringUnicode, length);
+	char *text = wchar_to_char (stringUnicode, length);
 	if (!text)
 		return NULL;
 	length = strlen(text);
@@ -717,7 +717,7 @@ utf8_length_for_ucs2_string (GDIPCONST WCHAR *stringUnicode, int offset, int len
 			utf8_length += 2;
 		else if (ch < 0xD800 || ch >= 0xE000)
 			utf8_length += 3;
-		/* ignore surrogate pairs as they are ignored in ucs2_to_utf8() */
+		/* ignore surrogate pairs as they are ignored in wchar_to_char () */
 	}
 	return utf8_length;
 }

--- a/src/win32structs.h
+++ b/src/win32structs.h
@@ -92,7 +92,7 @@ typedef float REAL;
 #else
 
 typedef int INT;
-typedef guint16 WCHAR; /* 16-bits unicode */
+typedef wchar_t WCHAR; /* 16-bits unicode */
 typedef guint32 UINT;
 typedef guint32 UINT32;
 typedef gint32 PROPID;

--- a/tests/testfont.c
+++ b/tests/testfont.c
@@ -35,6 +35,8 @@ static HDC getEmptyHDC ()
 
 static void assertStringEqual (WCHAR *actual, const char *expected)
 {
+printf("%c%c%c%c%c%c%c%c%c%c%c%c\n", (char)actual[0], (char)actual[1], (char)actual[2], (char)actual[3], (char)actual[4], (char)actual[5], (char)actual[6], (char)actual[7], (char)actual[8], (char)actual[9], (char)actual[10], (char)actual[11]);
+printf("%c%c%c%c%c%c%c%c%c%c%c%c\n", expected[0], expected[1], expected[2], expected[3], expected[4], expected[5], expected[6], expected[7], expected[8], expected[9], expected[10], expected[11]);
 	int i = 0;
 	while (TRUE) {
 		if (expected[i] == '\0') {
@@ -128,12 +130,11 @@ static void test_getFontCollectionFamilyCount ()
 static void test_getFontCollectionFamilyList ()
 {
 	GpStatus status;
-	WCHAR *fontFile;
+	WCHAR *fontFile = L"test.ttf";
 	GpFontCollection *collection;
 	GpFontFamily *families[2] = {NULL, NULL};
 	INT numFound;
 
-	fontFile = g_utf8_to_utf16 ("test.ttf", -1, NULL, NULL, NULL);
 	GdipNewPrivateFontCollection(&collection);
 
 	//Empty list.
@@ -174,20 +175,16 @@ static void test_privateAddFontFile ()
 {
 	GpStatus status;
 	GpFontCollection *collection;
-	WCHAR *ttfFile;
-	WCHAR *otfFile;
-	WCHAR *invalidFile;
-	WCHAR *noSuchFile;
+	WCHAR *ttfFile = L"test.ttf";
+	WCHAR *otfFile = L"test.otf";
+	WCHAR *invalidFile = L"test.bmp";
+	WCHAR *noSuchFile = L"noSuchFile.ttf";
 	INT count;
 	GpFontFamily *families[1];
 	INT numFound;
 	WCHAR name[LF_FACESIZE];
 
 	GdipNewPrivateFontCollection (&collection);
-	ttfFile = g_utf8_to_utf16 ("test.ttf", -1, NULL, NULL, NULL);
-	otfFile = g_utf8_to_utf16 ("test.otf", -1, NULL, NULL, NULL);
-	invalidFile = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	noSuchFile = g_utf8_to_utf16 ("noSuchFile.ttf", -1, NULL, NULL, NULL);
 
 	// Valid TTF file.
 	status = GdipPrivateAddFontFile (collection, ttfFile);
@@ -444,13 +441,12 @@ static void test_createFontFromLogfontW ()
 	GpStatus status;
 	GpFont *font;
 	LOGFONTW logfont;
-	WCHAR *fontName;
+	WCHAR *fontName = L"Times New Roman";
 	HDC hdc;
 	INT style;
 	Unit unit;
 	GpFontFamily *family;
 
-	fontName = g_utf8_to_utf16 ("Times New Roman", -1, NULL, NULL, NULL);
 	hdc = getEmptyHDC ();
 
 	logfont.lfHeight = 10;

--- a/tests/testgdi.c
+++ b/tests/testgdi.c
@@ -43,7 +43,6 @@ win_draw(win_t *win)
 	GpGraphics *gp;
 	GpStatus st;
 	GpImage *img;
-	gunichar2 *unis;
 
 	XClearWindow(win->dpy, win->win);
 
@@ -68,59 +67,46 @@ win_draw(win_t *win)
 //		return;
 	}
 
-	
-	
-	
-	unis = g_utf8_to_utf16 ("test.jpg", -1, NULL, NULL, NULL);
-	st = GdipLoadImageFromFile (unis, &img);
+	st = GdipLoadImageFromFile (L"test.jpg", &img);
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 0, 0);
 	CHECK_GDIP_ST(st);
-	g_free (unis);
 	GdipDisposeImage (img);
 	img = NULL;
 
 	printf("jpg drawn \n");
 
-	unis = g_utf8_to_utf16 ("test.tif", -1, NULL, NULL, NULL);
-	st = GdipLoadImageFromFile (unis, &img);
+	st = GdipLoadImageFromFile (L"test.tif", &img);
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 100, 0);
 	CHECK_GDIP_ST(st);
-	g_free (unis);
 	GdipDisposeImage (img);
 	img = NULL;
 
 	printf("tif drawn \n");
 
-	unis = g_utf8_to_utf16 ("test.gif", -1, NULL, NULL, NULL);
-	st = GdipLoadImageFromFile (unis, &img);
+	st = GdipLoadImageFromFile (L"test.gif", &img);
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 200, 0);
 	CHECK_GDIP_ST(st);
-	g_free (unis);
 	GdipDisposeImage (img);
 	img = NULL;
 
 	printf("gif drawn \n");
 
-	unis = g_utf8_to_utf16 ("test.png", -1, NULL, NULL, NULL);
-	st = GdipLoadImageFromFile (unis, &img);
+	st = GdipLoadImageFromFile (L"test.png", &img);
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 0, 100);
 	CHECK_GDIP_ST(st);
-	g_free (unis);
 	GdipDisposeImage (img);
 	img = NULL;
 
 	printf("png drawn \n");
 
-	unis = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	st = GdipLoadImageFromFile (unis, &img);
+	st = GdipLoadImageFromFile (L"test.bmp", &img);
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 200, 100);
 	CHECK_GDIP_ST(st);
-	g_free (unis);
 	GdipDisposeImage (img);
 	img = NULL;
 

--- a/tests/testgraphics.c
+++ b/tests/testgraphics.c
@@ -21,7 +21,6 @@
 
 static void test_createFromHDC()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphicsOriginal;
@@ -29,8 +28,7 @@ static void test_createFromHDC()
 	GpGraphics *graphicsFromHdc;
 	TextRenderingHint textRenderingHint;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext (image, &graphicsOriginal);
@@ -74,7 +72,6 @@ static void test_createFromHDC()
 
 static void test_createFromHDC2()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphicsOriginal;
@@ -82,8 +79,7 @@ static void test_createFromHDC2()
 	GpGraphics *graphicsFromHdc;
 	TextRenderingHint textRenderingHint;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext (image, &graphicsOriginal);
@@ -167,14 +163,12 @@ static void test_createFromHWNDICM()
 
 static void test_hdc ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	HDC hdc;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext (image, &graphics);
@@ -214,14 +208,12 @@ static void test_hdc ()
 
 static void test_compositingMode ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	CompositingMode mode;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext (image, &graphics);
@@ -260,14 +252,12 @@ static void test_compositingMode ()
 
 static void test_compositingQuality ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	CompositingQuality quality;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext (image, &graphics);
@@ -306,15 +296,13 @@ static void test_compositingQuality ()
 
 static void test_renderingOrigin ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	int x;
 	int y;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext(image, &graphics);
@@ -357,14 +345,12 @@ static void test_renderingOrigin ()
 
 static void test_textRenderingHint ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	TextRenderingHint textRenderingHint;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext (image, &graphics);
@@ -409,14 +395,12 @@ static void test_textRenderingHint ()
 
 static void test_textContrast ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	UINT textContrast;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext (image, &graphics);
@@ -461,14 +445,12 @@ static void test_textContrast ()
 
 static void test_smoothingMode ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	SmoothingMode smoothingMode;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext (image, &graphics);
@@ -541,14 +523,12 @@ static void test_smoothingMode ()
 
 static void test_pixelOffsetMode ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	PixelOffsetMode pixelOffsetMode;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext (image, &graphics);
@@ -610,14 +590,12 @@ static void test_pixelOffsetMode ()
 
 static void test_interpolationMode ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	InterpolationMode interpolationMode;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext(image, &graphics);
@@ -693,7 +671,6 @@ static void test_interpolationMode ()
 
 static void test_transform ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
@@ -701,8 +678,7 @@ static void test_transform ()
 	GpMatrix *setMatrix;
 	GpMatrix *nonInvertibleMatrix;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext(image, &graphics);
@@ -761,14 +737,12 @@ static void test_transform ()
 
 static void test_pageUnit ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	Unit pageUnit;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext(image, &graphics);
@@ -821,14 +795,12 @@ static void test_pageUnit ()
 
 static void test_pageScale ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	REAL pageScale;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext(image, &graphics);
@@ -889,14 +861,12 @@ static void test_pageScale ()
 }
 static void test_dpiX ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	float dpiX;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext(image, &graphics);
@@ -926,14 +896,12 @@ static void test_dpiX ()
 
 static void test_dpiY ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	REAL dpiY;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext(image, &graphics);
@@ -963,13 +931,11 @@ static void test_dpiY ()
 
 static void test_flush ()
 {
-	gunichar2 *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (L"test.bmp", &image);
 	assert (status == Ok);
 
 	status = GdipGetImageGraphicsContext (image, &graphics);
@@ -1004,12 +970,11 @@ static void test_flush ()
 
 static void test_delete ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath = L"test.bmp";
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
 	GdipLoadImageFromFile (filePath, &image);
 	GdipGetImageGraphicsContext (image, &graphics);
 	

--- a/tests/testpng.c
+++ b/tests/testpng.c
@@ -16,7 +16,6 @@ int
 main (int argc, char **argv)
 {
     GpImage *img;
-    gunichar2 *unis;
     GpBitmap *bitmap;
     GpStatus status;
     int original_palette_size;
@@ -33,10 +32,8 @@ main (int argc, char **argv)
     // PNG resave should preserve the palette transparency. Let's test it
     // by loading a PNG file and its palette, then resaving it and loading
     // it again for comparison.
-    unis = g_utf8_to_utf16 ("test-trns.png", -1, NULL, NULL, NULL);
-    status = GdipLoadImageFromFile (unis, &img);
+    status = GdipLoadImageFromFile (L"test-trns.png", &img);
     CHECK_STATUS(1);
-    g_free (unis);
 
     status = GdipGetImagePaletteSize (img, &original_palette_size);
     CHECK_STATUS(1);
@@ -45,13 +42,11 @@ main (int argc, char **argv)
     GdipGetImagePalette (img, original_palette, original_palette_size);
     CHECK_STATUS(1);
 
-    unis = g_utf8_to_utf16 ("test-trns-resave.png", -1, NULL, NULL, NULL);
-    status = GdipSaveImageToFile (img, unis, &png_clsid, NULL);
+    status = GdipSaveImageToFile (img, L"test-trns-resave.png", &png_clsid, NULL);
     CHECK_STATUS(1);
     GdipDisposeImage (img);
-    status = GdipLoadImageFromFile (unis, &img);
+    status = GdipLoadImageFromFile (L"test-trns-resave.png", &img);
     CHECK_STATUS(1);
-    g_free (unis);
 
     status = GdipGetImagePaletteSize (img, &reloaded_palette_size);
     CHECK_STATUS(1);
@@ -71,10 +66,8 @@ main (int argc, char **argv)
 
     // Test grayscale image with alpha channel. The image should be converted
     // into 32-bit ARGB format and the alpha channel should be preserved.
-    unis = g_utf8_to_utf16 ("test-gsa.png", -1, NULL, NULL, NULL);
-    status = GdipCreateBitmapFromFile (unis, &bitmap);
+    status = GdipCreateBitmapFromFile (L"test-gsa.png", &bitmap);
     CHECK_STATUS(1);
-    g_free (unis);
     status = GdipGetImagePixelFormat (bitmap, &pixel_format);
     CHECK_STATUS(1);
     CHECK_ASSERT(pixel_format == PixelFormat32bppARGB);    


### PR DESCRIPTION
I realised that you can’t compile the same code with libgdiplus than with GDI+ if it uses WCHAR.

The problem is that WCHAR is defined as `wchar_t` on Windows GDI+, but is defined as `gunichar` in libgdiplus.

These types are not compatible (I think). They are certainly not source compatible, but I'm not sure about binary compatible (or whether that even matters).

This means that the following code compiles against GDI+, but fails with libgdiplus:

```cpp
int
main (int argc, char**argv)
{
  GdiplusStartupInput gdiplusStartupInput;
  ULONG_PTR gdiplusToken;
  GdiplusStartup (&gdiplusToken, &gdiplusStartupInput, NULL);

  GpImage *image;
  GdipLoadImageFromFile(L"test.ttf", &image);

  GdiplusShutdown (gdiplusToken);
  return 0;
}
```

I’m marking this PR as an experiment/WIP as I’m not sure the wider impact of this and wanted to get some eyes on this.

I’m also not sure about whether there is a combat issue from changing `gunichar` -> `wchar_t`.

The aim of the PR is to match Windows behaviour. I think this is important for libgdiplus. I personally think that source compatibility between libgdiplus and GDI+ could be important, but I’m not sure whether it is worth the risk.

This could also get rid of the external-facing dependency on glib. 