### PR TITLE
Fix UB in various multiply transforms for pens/brushes

### DIFF
--- a/src/lineargradientbrush.c
+++ b/src/lineargradientbrush.c
@@ -1196,11 +1196,10 @@ GdipMultiplyLineTransform (GpLineGradient *brush, GpMatrix *matrix, GpMatrixOrde
 	if (!invertible || (status != Ok))
 		return InvalidParameter;
 
-	/* note: error handling is different from GdipMultiplyMatrix */
-	if (order == MatrixOrderAppend)
-		cairo_matrix_multiply (&brush->matrix, &brush->matrix, matrix);
+	if (order == MatrixOrderPrepend)
+		cairo_matrix_multiply (&brush->matrix, matrix, &brush->matrix);
 	else
-		cairo_matrix_multiply (&brush->matrix, matrix, &brush->matrix);        
+		cairo_matrix_multiply (&brush->matrix, &brush->matrix, matrix);       
 
 	brush->base.changed = TRUE;
 	return Ok;

--- a/src/pathgradientbrush.c
+++ b/src/pathgradientbrush.c
@@ -1237,7 +1237,7 @@ GdipMultiplyPathGradientTransform (GpPathGradient *brush, GDIPCONST GpMatrix *ma
 
 	if (order == MatrixOrderPrepend)
 		cairo_matrix_multiply (&mat, matrix, &brush->transform);
-	else if (order == MatrixOrderAppend)
+	else
 		cairo_matrix_multiply (&mat, &brush->transform, matrix);
 
 	gdip_cairo_matrix_copy (&brush->transform, &mat);

--- a/src/texturebrush.c
+++ b/src/texturebrush.c
@@ -830,7 +830,7 @@ GdipMultiplyTextureTransform (GpTexture *texture, GpMatrix *matrix, GpMatrixOrde
 
 	if (order == MatrixOrderPrepend)
 		cairo_matrix_multiply (&mat, matrix, &texture->matrix);
-	else if (order == MatrixOrderAppend)
+	else
 		cairo_matrix_multiply (&mat, &texture->matrix, matrix);
 
 	gdip_cairo_matrix_copy (&texture->matrix, &mat);

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -4,6 +4,12 @@
 
 int floatsEqual(float v1, float v2)
 {
+    if (isnan (v1))
+        return isnan (v2);
+
+    if (isinf (v1))
+        return isinf (v2);
+
     return fabs (v1 - v2) < 0.0001;
 }
 
@@ -12,13 +18,17 @@ void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5
     float elements[6];
     GdipGetMatrixElements (matrix, elements);
 
-    printf ("Actual:   %f, %f, %f, %f, %f, %f\n", e1, e2, e3, e4, e5, e6);
-    printf ("Expected: %f, %f, %f, %f, %f, %f\n\n", elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
+    if (!floatsEqual (elements[0], e1) ||
+        !floatsEqual (elements[1], e2) ||
+        !floatsEqual (elements[2], e3) ||
+        !floatsEqual (elements[3], e4) ||
+        !floatsEqual (elements[4], e5) ||
+        !floatsEqual (elements[5], e6)) {
 
-    assert (floatsEqual(elements[0], e1));
-    assert (floatsEqual(elements[1], e2));
-    assert (floatsEqual(elements[2], e3));
-    assert (floatsEqual(elements[3], e4));
-    assert (floatsEqual(elements[4], e5));
-    assert (floatsEqual(elements[5], e6));
+        printf ("Expected matrices to be equal\n");
+        printf ("Actual:   %f, %f, %f, %f, %f, %f\n", e1, e2, e3, e4, e5, e6);
+        printf ("Expected: %f, %f, %f, %f, %f, %f\n\n", elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
+
+        assert (FALSE);
+    }
 }

--- a/tests/testlineargradientbrush.c
+++ b/tests/testlineargradientbrush.c
@@ -165,13 +165,17 @@ static void test_createLineBrushFromRect ()
 
     GpRectF rect3 = { 1, 3, 0, 1 };
     status = GdipCreateLineBrushFromRect (&rect3, 10, 11, LinearGradientModeBackwardDiagonal, WrapModeTileFlipXY, &brush);
-    // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
-    assert (status == InvalidParameter);
+    // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing.
+#if defined(USE_WINDOWS_GDIPLUS)
+    assert (status == OutOfMemory);
+#endif
 
     GpRectF rect4 = { 1, 3, 1, 0 };
     status = GdipCreateLineBrushFromRect (&rect4, 10, 11, LinearGradientModeBackwardDiagonal, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
-    assert (status == InvalidParameter);
+#if defined(USE_WINDOWS_GDIPLUS)
+    assert (status == OutOfMemory);
+#endif
 
     status = GdipCreateLineBrushFromRect (&rect1, 10, 11, (LinearGradientMode)(LinearGradientModeHorizontal - 1), WrapModeTile, &brush);
     assert (status == OutOfMemory);
@@ -226,12 +230,16 @@ static void test_createLineBrushFromRectI ()
     GpRect rect3 = { 1, 3, 0, 1 };
     status = GdipCreateLineBrushFromRectI (&rect3, 10, 11, LinearGradientModeBackwardDiagonal, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
-    assert (status == InvalidParameter);
+#if defined(USE_WINDOWS_GDIPLUS)
+    assert (status == OutOfMemory);
+#endif
 
     GpRect rect4 = { 1, 3, 1, 0 };
     status = GdipCreateLineBrushFromRectI (&rect4, 10, 11, LinearGradientModeBackwardDiagonal, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
+#if defined(USE_WINDOWS_GDIPLUS)
     assert (status == InvalidParameter);
+#endif
 
     status = GdipCreateLineBrushFromRectI (&rect1, 10, 11, (LinearGradientMode)(LinearGradientModeHorizontal - 1), WrapModeTile, &brush);
     assert (status == OutOfMemory);
@@ -296,12 +304,16 @@ static void test_createLineBrushFromRectWithAngle ()
     GpRectF rect3 = { 1, 3, 0, 1 };
     status = GdipCreateLineBrushFromRectWithAngle (&rect3, 10, 11, 90, TRUE, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
-    assert (status == InvalidParameter);
+#if defined(USE_WINDOWS_GDIPLUS)
+    assert (status == OutOfMemory);
+#endif
 
     GpRectF rect4 = { 1, 3, 1, 0 };
     status = GdipCreateLineBrushFromRectWithAngle (&rect4, 10, 11, 90, TRUE, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
-    assert (status == InvalidParameter);
+#if defined(USE_WINDOWS_GDIPLUS)
+    assert (status == OutOfMemory);
+#endif
 
     status = GdipCreateLineBrushFromRectWithAngle (&rect1, 10, 11, 90, TRUE, WrapModeClamp, &brush);
     assert (status == InvalidParameter);
@@ -354,12 +366,16 @@ static void test_createLineBrushFromRectWithAngleI ()
     GpRect rect3 = { 1, 3, 0, 1 };
     status = GdipCreateLineBrushFromRectWithAngleI (&rect3, 10, 11, 90, TRUE, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
-    assert (status == InvalidParameter);
+#if defined(USE_WINDOWS_GDIPLUS)
+    assert (status == OutOfMemory);
+#endif
 
     GpRect rect4 = { 1, 3, 1, 0 };
     status = GdipCreateLineBrushFromRectWithAngleI (&rect4, 10, 11, 90, TRUE, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
-    assert (status == InvalidParameter);
+#if defined(USE_WINDOWS_GDIPLUS)
+    assert (status == OutOfMemory);
+#endif
 
     status = GdipCreateLineBrushFromRectWithAngleI (&rect1, 10, 11, 90, TRUE, WrapModeClamp, &brush);
     assert (status == InvalidParameter);
@@ -1058,14 +1074,23 @@ static void test_multiplyLineTransform ()
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
 
-    // Invalid MatrixOrder - this produces garbage data.
+    // Invalid MatrixOrder - negative.
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipMultiplyLineTransform (brush, matrix, (MatrixOrder)(MatrixOrderPrepend - 1));
     assert (status == Ok);
+    
+    GdipGetLineTransform (brush, transform);
+    verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
+
+    // Invalid MatrixOrder - positive.
+    GdipSetLineTransform (brush, originalTransform);
 
     status = GdipMultiplyLineTransform (brush, matrix, (MatrixOrder)(MatrixOrderAppend + 1));
     assert (status == Ok);
+    
+    GdipGetLineTransform (brush, transform);
+    verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
 
     // Negative tests.
     status = GdipMultiplyLineTransform (NULL, matrix, MatrixOrderAppend);

--- a/tests/testpathgradientbrush.c
+++ b/tests/testpathgradientbrush.c
@@ -21,29 +21,7 @@ using namespace DllExports;
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
-#include <float.h>
-
-static int floatsEqual(float v1, float v2)
-{
-    return fabs (v1 - v2) < 0.0001;
-}
-
-static void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5, REAL e6)
-{
-    float elements[6];
-    GdipGetMatrixElements (matrix, elements);
-
-    printf ("Expected: %f, %f, %f, %f, %f, %f\n", e1, e2, e3, e4, e5, e6);
-    printf ("Actual:   %f, %f, %f, %f, %f, %f\n\n", elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
-
-    assert (floatsEqual(elements[0], e1));
-    assert (floatsEqual(elements[1], e2));
-    assert (floatsEqual(elements[2], e3));
-    assert (floatsEqual(elements[3], e4));
-    assert (floatsEqual(elements[4], e5));
-    assert (floatsEqual(elements[5], e6));
-}
+#include "testhelpers.h"
 
 static void verifyPathGradientBrush (GpPathGradient *brush, REAL x, REAL y, REAL width, REAL height, ARGB centerColor, REAL centerX, REAL centerY, GpWrapMode expectedWrapMode)
 {

--- a/tests/testpathgradientbrush.c
+++ b/tests/testpathgradientbrush.c
@@ -41,10 +41,6 @@ static void verifyPathGradientBrush (GpPathGradient *brush, REAL x, REAL y, REAL
     assert (brushType == BrushTypePathGradient);
 
     status = GdipGetPathGradientRect (brush, &rect);
-    printf ("%f\n", rect.X);
-    printf ("%f\n", rect.Y);
-    printf ("%f\n", rect.Width);
-    printf ("%f\n\n", rect.Height);
     assert (status == Ok);
     assert (rect.X == x);
     assert (rect.Y == y);
@@ -57,14 +53,11 @@ static void verifyPathGradientBrush (GpPathGradient *brush, REAL x, REAL y, REAL
 
     status = GdipGetPathGradientCenterPoint (brush, &centerPoint);
     assert (status == Ok);
-    printf ("%f\n", centerPoint.X);
-    printf ("%f\n\n", centerPoint.Y);
     assert (centerPoint.X == centerX);
     assert (centerPoint.Y == centerY);
 
     status = GdipGetPathGradientWrapMode (brush, &wrapMode);
     assert (status == Ok);
-    printf ("%d\n\n\n\n", wrapMode);
     assert (wrapMode == expectedWrapMode);
 
     status = GdipGetPathGradientTransform (brush, brushTransform);
@@ -1306,14 +1299,23 @@ static void test_multiplyPathGradientTransform ()
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
 
-    // Invalid MatrixOrder - this produces garbage data.
+    // Invalid MatrixOrder - negative.
     GdipSetPathGradientTransform (brush, originalTransform);
 
     status = GdipMultiplyPathGradientTransform (brush, matrix, (MatrixOrder)(MatrixOrderPrepend - 1));
     assert (status == Ok);
 
+    GdipGetPathGradientTransform (brush, transform);
+    verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
+
+    // Invalid MatrixOrder - positive.
+    GdipSetPathGradientTransform (brush, originalTransform);
+    
     status = GdipMultiplyPathGradientTransform (brush, matrix, (MatrixOrder)(MatrixOrderAppend + 1));
     assert (status == Ok);
+
+    GdipGetPathGradientTransform (brush, transform);
+    verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
 
     // Negative tests.
     status = GdipMultiplyPathGradientTransform (NULL, matrix, MatrixOrderAppend);

--- a/tests/testpen.c
+++ b/tests/testpen.c
@@ -1112,14 +1112,23 @@ static void test_multiplyPenTransform ()
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
 
-    // Invalid MatrixOrder - this produces garbage data.
+    // Invalid MatrixOrder - negative.
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipMultiplyPenTransform (pen, matrix, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == Ok);
+		assert (status == Ok);
+
+    GdipGetPenTransform (pen, transform);
+    verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
+		
+    // Invalid MatrixOrder - positive.
+    GdipSetPenTransform (pen, originalTransform);
 
     status = GdipMultiplyPenTransform (pen, matrix, (MatrixOrder)(MatrixOrderAppend + 1));
     assert (status == Ok);
+
+    GdipGetPenTransform (pen, transform);
+    verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
 
     // Negative tests.
     status = GdipMultiplyPenTransform (NULL, matrix, MatrixOrderAppend);

--- a/tests/testtexturebrush.c
+++ b/tests/testtexturebrush.c
@@ -590,14 +590,23 @@ static void test_multiplyTextureTransform ()
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
 
-    // Invalid MatrixOrder - this produces garbage data.
+    // Invalid MatrixOrder - negative.
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipMultiplyTextureTransform (brush, matrix, (MatrixOrder)(MatrixOrderPrepend - 1));
     assert (status == Ok);
 
+    GdipGetTextureTransform (brush, transform);
+    verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
+
+    // Invalid MatrixOrder - positive.
+    GdipSetTextureTransform (brush, originalTransform);
+
     status = GdipMultiplyTextureTransform (brush, matrix, (MatrixOrder)(MatrixOrderAppend + 1));
     assert (status == Ok);
+
+    GdipGetTextureTransform (brush, transform);
+    verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
 
     // Negative tests.
     status = GdipMultiplyTextureTransform (NULL, matrix, MatrixOrderAppend);


### PR DESCRIPTION
Now matches Windows behaviour. The problem was that invalid MatrixOrder values could cause access to uninitialised memory - which is garbage data