### PR TITLE
Revert checks for if graphics are deleted

### DIFF
--- a/src/graphics-private.h
+++ b/src/graphics-private.h
@@ -102,8 +102,7 @@ typedef struct {
 
 typedef enum {
 	GraphicsStateValid = 0,
-	GraphicsStateBusy = 1,
-	GraphicsStateDeleted = 2
+	GraphicsStateBusy = 1
 } GraphicsState;
 
 typedef struct _Graphics {

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -432,7 +432,6 @@ GdipDeleteGraphics (GpGraphics *graphics)
 		graphics->saved_status = NULL;
 	}	
 
-	graphics->state = GraphicsStateDeleted;
 	GdipFree (graphics);
 	return Ok;
 }
@@ -440,7 +439,7 @@ GdipDeleteGraphics (GpGraphics *graphics)
 GpStatus WINGDIPAPI
 GdipGetDC (GpGraphics *graphics, HDC *hdc)
 {
-	if (!graphics || !hdc || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !hdc)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -584,7 +583,7 @@ GdipSetWorldTransform (GpGraphics *graphics, GpMatrix *matrix)
 	GpStatus status;
 	BOOL invertible;
 
-	if (!graphics || !matrix || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !matrix)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -618,7 +617,7 @@ GdipSetWorldTransform (GpGraphics *graphics, GpMatrix *matrix)
 GpStatus WINGDIPAPI
 GdipGetWorldTransform (GpGraphics *graphics, GpMatrix *matrix)
 {
-	if (!graphics || !matrix || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !matrix)
 		return InvalidParameter;
 	
 	if (graphics->state == GraphicsStateBusy)
@@ -1590,7 +1589,7 @@ GdipFillRegion (GpGraphics *graphics, GpBrush *brush, GpRegion *region)
 GpStatus WINGDIPAPI
 GdipSetRenderingOrigin (GpGraphics *graphics, INT x, INT y)
 {
-	if (!graphics || graphics->state == GraphicsStateDeleted)
+	if (!graphics)
 		return InvalidParameter;
 	
 	if (graphics->state == GraphicsStateBusy)
@@ -1612,7 +1611,7 @@ GdipSetRenderingOrigin (GpGraphics *graphics, INT x, INT y)
 GpStatus WINGDIPAPI
 GdipGetRenderingOrigin (GpGraphics *graphics, INT *x, INT *y)
 {
-	if (!graphics || !x || !y || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !x || !y)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1627,7 +1626,7 @@ GdipGetRenderingOrigin (GpGraphics *graphics, INT *x, INT *y)
 GpStatus WINGDIPAPI
 GdipGetDpiX (GpGraphics *graphics, REAL *dpi)
 {
-	if (!graphics || !dpi || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !dpi)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1640,7 +1639,7 @@ GdipGetDpiX (GpGraphics *graphics, REAL *dpi)
 GpStatus WINGDIPAPI
 GdipGetDpiY (GpGraphics *graphics, REAL *dpi)
 {
-	if (!graphics || !dpi || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !dpi)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1669,7 +1668,7 @@ GdipGraphicsClear (GpGraphics *graphics, ARGB color)
 GpStatus WINGDIPAPI
 GdipSetInterpolationMode (GpGraphics *graphics, InterpolationMode interpolationMode)
 {
-	if (!graphics || interpolationMode <= InterpolationModeInvalid || interpolationMode > InterpolationModeHighQualityBicubic || graphics->state == GraphicsStateDeleted)
+	if (!graphics || interpolationMode <= InterpolationModeInvalid || interpolationMode > InterpolationModeHighQualityBicubic)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1701,7 +1700,7 @@ GdipSetInterpolationMode (GpGraphics *graphics, InterpolationMode interpolationM
 GpStatus WINGDIPAPI
 GdipGetInterpolationMode (GpGraphics *graphics, InterpolationMode *imode)
 {
-	if (!graphics || !imode || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !imode)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1714,7 +1713,7 @@ GdipGetInterpolationMode (GpGraphics *graphics, InterpolationMode *imode)
 GpStatus WINGDIPAPI
 GdipSetTextRenderingHint (GpGraphics *graphics, TextRenderingHint mode)
 {
-	if (!graphics || mode < TextRenderingHintSystemDefault || mode > TextRenderingHintClearTypeGridFit || graphics->state == GraphicsStateDeleted)
+	if (!graphics || mode < TextRenderingHintSystemDefault || mode > TextRenderingHintClearTypeGridFit)
 		return InvalidParameter;
 	
 	if (graphics->state == GraphicsStateBusy)
@@ -1735,7 +1734,7 @@ GdipSetTextRenderingHint (GpGraphics *graphics, TextRenderingHint mode)
 GpStatus WINGDIPAPI
 GdipGetTextRenderingHint (GpGraphics *graphics, TextRenderingHint *mode)
 {
-	if (!graphics || !mode || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !mode)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1749,7 +1748,7 @@ GdipGetTextRenderingHint (GpGraphics *graphics, TextRenderingHint *mode)
 GpStatus WINGDIPAPI
 GdipSetPixelOffsetMode (GpGraphics *graphics, PixelOffsetMode pixelOffsetMode)
 {
-	if (!graphics || pixelOffsetMode <= PixelOffsetModeInvalid || pixelOffsetMode > PixelOffsetModeHalf || graphics->state == GraphicsStateDeleted)
+	if (!graphics || pixelOffsetMode <= PixelOffsetModeInvalid || pixelOffsetMode > PixelOffsetModeHalf)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1772,7 +1771,7 @@ GdipSetPixelOffsetMode (GpGraphics *graphics, PixelOffsetMode pixelOffsetMode)
 GpStatus WINGDIPAPI
 GdipGetPixelOffsetMode (GpGraphics *graphics, PixelOffsetMode *pixelOffsetMode)
 {
-	if (!graphics || !pixelOffsetMode || graphics-> state == GraphicsStateDeleted)
+	if (!graphics || !pixelOffsetMode)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1788,7 +1787,7 @@ GdipSetTextContrast (GpGraphics *graphics, UINT contrast)
 {
 	/** The gamma correction value must be between 0 and 12.
 	 * The default value is 4. */
-	if (!graphics || contrast > 12 || graphics->state == GraphicsStateDeleted)
+	if (!graphics || contrast > 12)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1810,7 +1809,7 @@ GdipSetTextContrast (GpGraphics *graphics, UINT contrast)
 GpStatus WINGDIPAPI
 GdipGetTextContrast (GpGraphics *graphics, UINT *contrast)
 {
-	if (!graphics || !contrast || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !contrast)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1823,7 +1822,7 @@ GdipGetTextContrast (GpGraphics *graphics, UINT *contrast)
 GpStatus WINGDIPAPI
 GdipSetSmoothingMode (GpGraphics *graphics, SmoothingMode mode)
 {
-	if (!graphics || mode <= SmoothingModeInvalid || mode > SmoothingModeAntiAlias || graphics->state == GraphicsStateDeleted)
+	if (!graphics || mode <= SmoothingModeInvalid || mode > SmoothingModeAntiAlias)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -1855,7 +1854,7 @@ GdipSetSmoothingMode (GpGraphics *graphics, SmoothingMode mode)
 GpStatus WINGDIPAPI
 GdipGetSmoothingMode (GpGraphics *graphics, SmoothingMode *mode)
 {
-	if (!graphics || !mode || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !mode)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -2374,7 +2373,7 @@ GdipIsVisibleRectI (GpGraphics *graphics, INT x, INT y, INT width, INT height, B
 GpStatus WINGDIPAPI
 GdipSetCompositingMode (GpGraphics *graphics, CompositingMode compositingMode)
 {
-	if (!graphics || graphics->state == GraphicsStateDeleted)
+	if (!graphics)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -2395,7 +2394,7 @@ GdipSetCompositingMode (GpGraphics *graphics, CompositingMode compositingMode)
 GpStatus WINGDIPAPI
 GdipGetCompositingMode (GpGraphics *graphics, CompositingMode *compositingMode)
 {
-	if (!graphics || !compositingMode || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !compositingMode)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -2408,7 +2407,7 @@ GdipGetCompositingMode (GpGraphics *graphics, CompositingMode *compositingMode)
 GpStatus WINGDIPAPI
 GdipSetCompositingQuality (GpGraphics *graphics, CompositingQuality compositingQuality)
 {
-	if (!graphics || graphics->state == GraphicsStateDeleted)
+	if (!graphics)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -2430,7 +2429,7 @@ GdipSetCompositingQuality (GpGraphics *graphics, CompositingQuality compositingQ
 GpStatus WINGDIPAPI
 GdipGetCompositingQuality (GpGraphics *graphics, CompositingQuality *compositingQuality)
 {
-	if (!graphics || !compositingQuality || graphics->state == GraphicsStateDeleted)
+	if (!graphics || !compositingQuality)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -2449,7 +2448,7 @@ GdipGetNearestColor (GpGraphics *graphics, ARGB *argb)
 GpStatus WINGDIPAPI
 GdipSetPageScale (GpGraphics *graphics, REAL scale)
 {
-	if (!graphics || scale <= 0.0 || scale > 1000000032 || graphics->state == GraphicsStateDeleted)
+	if (!graphics || scale <= 0.0 || scale > 1000000032)
 		return InvalidParameter;
 	
 	if (graphics->state == GraphicsStateBusy)
@@ -2471,7 +2470,7 @@ GdipSetPageScale (GpGraphics *graphics, REAL scale)
 GpStatus WINGDIPAPI
 GdipGetPageScale (GpGraphics *graphics, REAL *scale)
 {
-	if (!graphics | !scale || graphics->state == GraphicsStateDeleted)
+	if (!graphics | !scale)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -2484,7 +2483,7 @@ GdipGetPageScale (GpGraphics *graphics, REAL *scale)
 GpStatus WINGDIPAPI
 GdipSetPageUnit (GpGraphics *graphics, GpUnit unit)
 {
-	if (!graphics || unit <= UnitWorld || unit > UnitCairoPoint || graphics-> state == GraphicsStateDeleted)
+	if (!graphics || unit <= UnitWorld || unit > UnitCairoPoint)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)
@@ -2506,7 +2505,7 @@ GdipSetPageUnit (GpGraphics *graphics, GpUnit unit)
 GpStatus WINGDIPAPI
 GdipGetPageUnit (GpGraphics *graphics, GpUnit *unit)
 {
-	if (!graphics || !unit || graphics-> state == GraphicsStateDeleted)
+	if (!graphics || !unit)
 		return InvalidParameter;
 
 	if (graphics->state == GraphicsStateBusy)

--- a/tests/testgraphics.c
+++ b/tests/testgraphics.c
@@ -210,9 +210,6 @@ static void test_hdc ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetDC (graphics, &hdc);
-	assert (status == InvalidParameter);
 }
 
 static void test_compositingMode ()
@@ -259,12 +256,6 @@ static void test_compositingMode ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetCompositingMode (graphics, &mode);
-	assert (status == InvalidParameter);
-
-	status = GdipSetCompositingMode (graphics, CompositingModeSourceCopy);
-	assert (status == InvalidParameter);
 }
 
 static void test_compositingQuality ()
@@ -311,12 +302,6 @@ static void test_compositingQuality ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetCompositingQuality (graphics, &quality);
-	assert (status == InvalidParameter);
-
-	status = GdipSetCompositingQuality(graphics, CompositingQualityAssumeLinear);
-	assert(status == InvalidParameter);
 }
 
 static void test_renderingOrigin ()
@@ -368,12 +353,6 @@ static void test_renderingOrigin ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetRenderingOrigin(graphics, &x, &y);
-	assert (status == InvalidParameter);
-
-	status = GdipSetRenderingOrigin (graphics, 1, 2);
-	assert (status == InvalidParameter);
 }
 
 static void test_textRenderingHint ()
@@ -426,12 +405,6 @@ static void test_textRenderingHint ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetTextRenderingHint(graphics, &textRenderingHint);
-	assert (status == InvalidParameter);
-
-	status = GdipSetTextRenderingHint (graphics, TextRenderingHintClearTypeGridFit);
-	assert (status == InvalidParameter);
 }
 
 static void test_textContrast ()
@@ -484,12 +457,6 @@ static void test_textContrast ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetTextContrast (graphics, &textContrast);
-	assert (status == InvalidParameter);
-
-	status = GdipSetTextContrast (graphics, 1);
-	assert (status == InvalidParameter);
 }
 
 static void test_smoothingMode ()
@@ -570,12 +537,6 @@ static void test_smoothingMode ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-	
-	status = GdipGetSmoothingMode (graphics, &smoothingMode);
-	assert (status == InvalidParameter);
-
-	status = GdipSetSmoothingMode (graphics, SmoothingModeHighQuality);
-	assert (status == InvalidParameter);
 }
 
 static void test_pixelOffsetMode ()
@@ -645,12 +606,6 @@ static void test_pixelOffsetMode ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetPixelOffsetMode (graphics, &pixelOffsetMode);
-	assert (status == InvalidParameter);
-
-	status = GdipSetPixelOffsetMode (graphics, PixelOffsetModeDefault);
-	assert (status == InvalidParameter);
 }
 
 static void test_interpolationMode ()
@@ -734,12 +689,6 @@ static void test_interpolationMode ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetInterpolationMode (graphics, &interpolationMode);
-	assert (status == InvalidParameter);
-
-	status = GdipSetInterpolationMode (graphics, InterpolationModeBicubic);
-	assert (status == InvalidParameter);
 }
 
 static void test_transform ()
@@ -808,12 +757,6 @@ static void test_transform ()
 	GdipDeleteMatrix (nonInvertibleMatrix);
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetWorldTransform (graphics, matrix);
-	assert (status == InvalidParameter);
-
-	status = GdipSetWorldTransform (graphics, matrix);
-	assert (status == InvalidParameter);
 }
 
 static void test_pageUnit ()
@@ -874,12 +817,6 @@ static void test_pageUnit ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetPageUnit (graphics, &pageUnit);
-	assert (status == InvalidParameter);
-
-	status = GdipSetPageUnit (graphics, UnitDisplay);
-	assert (status == InvalidParameter);
 }
 
 static void test_pageScale ()
@@ -949,12 +886,6 @@ static void test_pageScale ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetPageScale (graphics, &pageScale);
-	assert (status == InvalidParameter);
-
-	status = GdipSetPageScale (graphics, 1);
-	assert (status == InvalidParameter);
 }
 static void test_dpiX ()
 {
@@ -991,9 +922,6 @@ static void test_dpiX ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetDpiX (graphics, &dpiX);
-	assert (status == InvalidParameter);
 }
 
 static void test_dpiY ()
@@ -1031,9 +959,6 @@ static void test_dpiY ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipGetDpiY (graphics, &dpiY);
-	assert (status == InvalidParameter);
 }
 
 static void test_flush ()
@@ -1075,9 +1000,6 @@ static void test_flush ()
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
-
-	status = GdipFlush (graphics, FlushIntentionSync);
-	assert (status == ObjectBusy);
 }
 
 static void test_delete ()
@@ -1101,12 +1023,11 @@ static void test_delete ()
 
 	status = GdipDeleteGraphics (graphics);
 	assert (status == Ok);
-
-	status = GdipDeleteGraphics (graphics);
-	assert (status == ObjectBusy);
+	
+	status = GdipDeleteGraphics (NULL);
+	assert (status == InvalidParameter);
 
 	GdipDisposeImage (image);
-	GdipDeleteGraphics (graphics);
 }
 
 int


### PR DESCRIPTION
Although this increases compat with GDI+, we’re backing this out because this is undefined behaviour.

See https://github.com/mono/libgdiplus/pull/95#discussion_r141030353