### PR TITLE
Define custom assertions with better error messages

### DIFF
--- a/tests/testadjustablearrowcap.c
+++ b/tests/testadjustablearrowcap.c
@@ -19,22 +19,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wchar.h>
+#include "testhelpers.h"
 
 #ifdef WIN32
 using namespace Gdiplus;
 using namespace DllExports;
 #endif
-
-static int floatsEqual (float v1, float v2)
-{
-	if (isnan (v1))
-		return isnan (v2);
-
-	if (isinf (v1))
-		return isinf (v2);
-
-	return fabs (v1 - v2) < 0.0001;
-}
 
 static void verifyArrowCap (GpAdjustableArrowCap *cap, REAL expectedHeight, REAL expectedWidth, BOOL expectedIsFilled)
 {
@@ -54,48 +44,48 @@ static void verifyArrowCap (GpAdjustableArrowCap *cap, REAL expectedHeight, REAL
 	REAL widthScale;
 
 	status = GdipGetAdjustableArrowCapHeight (cap, &height);
-	assert (status == Ok);
-	assert (floatsEqual (height, expectedHeight));
+	assertEqualInt (status, Ok);
+	assertEqualFloat (height, expectedHeight);
 
 	status = GdipGetAdjustableArrowCapWidth (cap, &width);
-	assert (status == Ok);
-	assert (floatsEqual (width, expectedWidth));
+	assertEqualInt (status, Ok);
+	assertEqualFloat (width, expectedWidth);
 
 	status = GdipGetAdjustableArrowCapFillState (cap, &isFilled);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isFilled == expectedIsFilled);
 
 	status = GdipGetAdjustableArrowCapMiddleInset (cap, &middleInset);
-	assert (status == Ok);
-	assert (middleInset == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (middleInset, 0);
 
 	status = GdipGetCustomLineCapType ((GpCustomLineCap *) cap, &capType);
-	assert (status == Ok);
-	assert (capType == CustomLineCapTypeAdjustableArrow);
+	assertEqualInt (status, Ok);
+	assertEqualInt (capType, CustomLineCapTypeAdjustableArrow);
 
 	status = GdipGetCustomLineCapBaseCap ((GpCustomLineCap *) cap, &baseCap);
-	assert (status == Ok);
-	assert (baseCap == LineCapTriangle);
+	assertEqualInt (status, Ok);
+	assertEqualInt (baseCap, LineCapTriangle);
 
 	status = GdipGetCustomLineCapBaseInset ((GpCustomLineCap *) cap, &baseInset);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	if (expectedWidth == 0)
-		assert (baseInset == 0);
+		assertEqualInt (baseInset, 0);
 	else
-		assert (floatsEqual (baseInset, (expectedHeight / expectedWidth)));
+		assertEqualFloat (baseInset, (expectedHeight / expectedWidth));
 
 	status = GdipGetCustomLineCapStrokeCaps ((GpCustomLineCap *) cap, &startCap, &endCap);
-	assert (status == Ok);
-	assert (startCap == LineCapFlat);
-	assert (endCap == LineCapFlat);
+	assertEqualInt (status, Ok);
+	assertEqualInt (startCap, LineCapFlat);
+	assertEqualInt (endCap, LineCapFlat);
 
 	status = GdipGetCustomLineCapStrokeJoin ((GpCustomLineCap *) cap, &strokeJoin);
-	assert (status == Ok);
-	assert (strokeJoin == LineJoinMiter);
+	assertEqualInt (status, Ok);
+	assertEqualInt (strokeJoin, LineJoinMiter);
 
 	status = GdipGetCustomLineCapWidthScale ((GpCustomLineCap *) cap, &widthScale);
-	assert (status == Ok);
-	assert (widthScale == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (widthScale, 1);
 
 	GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
 }
@@ -106,44 +96,44 @@ static void test_createAdjustableArrowCap ()
 	GpAdjustableArrowCap *cap;
 
 	status = GdipCreateAdjustableArrowCap (10, 11, TRUE, &cap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyArrowCap (cap, 10, 11, TRUE);
 
 	status = GdipCreateAdjustableArrowCap (0, 0, FALSE, &cap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyArrowCap (cap, 0, 0, FALSE);
 
 	status = GdipCreateAdjustableArrowCap (2, 0, FALSE, &cap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyArrowCap (cap, 2, 0, FALSE);
 
 	status = GdipCreateAdjustableArrowCap (0, 2, FALSE, &cap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyArrowCap (cap, 0, 2, FALSE);
 
 	status = GdipCreateAdjustableArrowCap (-1, -2, FALSE, &cap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyArrowCap (cap, -1, -2, FALSE);
 
 	status = GdipCreateAdjustableArrowCap (NAN, -2, FALSE, &cap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyArrowCap (cap, NAN, -2, FALSE);
 
 	status = GdipCreateAdjustableArrowCap (1, NAN, FALSE, &cap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyArrowCap (cap, 1, NAN, FALSE);
 
 	status = GdipCreateAdjustableArrowCap (-INFINITY, 1, FALSE, &cap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyArrowCap (cap, -INFINITY, 1, FALSE);
 
 	status = GdipCreateAdjustableArrowCap (1, INFINITY, FALSE, &cap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyArrowCap (cap, 1, INFINITY, FALSE);
 
 	// Negative tests.
 	status = GdipCreateAdjustableArrowCap (10, 11, TRUE, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 }
 
 static void test_cloneAdjustableArrowCap ()
@@ -155,18 +145,18 @@ static void test_cloneAdjustableArrowCap ()
 	GdipCreateAdjustableArrowCap (10, 11, TRUE, &cap);
 
 	status = GdipCloneCustomLineCap ((GpCustomLineCap *) cap, &clonedCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (clonedCap && clonedCap != cap);
 	verifyArrowCap ((GpAdjustableArrowCap *) clonedCap, 10, 11, TRUE);
 
 	// Negative tests.
 	status = GdipCloneCustomLineCap (NULL, &clonedCap);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// This causes a null pointer reference in GDI+.
 #if !defined(_WIN32)
 	status = GdipCloneCustomLineCap (cap, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #endif
 
 	GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
@@ -180,11 +170,11 @@ static void test_deleteAdjustableArrowCap ()
 	GdipCreateAdjustableArrowCap (10, 11, TRUE, &cap);
 
 	status = GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	// Negative tests.
 	status = GdipDeleteCustomLineCap (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 }
 
 static void test_setAdjustableArrowCapHeight ()
@@ -196,15 +186,15 @@ static void test_setAdjustableArrowCapHeight ()
 	GdipCreateAdjustableArrowCap (10, 11, TRUE, &cap);
 
 	status = GdipSetAdjustableArrowCapHeight (cap, 30);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetAdjustableArrowCapHeight (cap, &height);
-	assert (status == Ok);
-	assert (height == 30);
+	assertEqualInt (status, Ok);
+	assertEqualInt (height, 30);
 
 	// Negative tests.
 	status = GdipSetAdjustableArrowCapHeight (NULL, 30);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
 }
@@ -219,10 +209,10 @@ static void test_getAdjustableArrowCapHeight ()
 
 	// Negative tests.
 	status = GdipGetAdjustableArrowCapHeight (NULL, &height);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetAdjustableArrowCapHeight (cap, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
 }
@@ -236,15 +226,15 @@ static void test_setAdjustableArrowCapWidth ()
 	GdipCreateAdjustableArrowCap (10, 11, TRUE, &cap);
 
 	status = GdipSetAdjustableArrowCapWidth (cap, 30);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetAdjustableArrowCapWidth (cap, &width);
-	assert (status == Ok);
-	assert (width == 30);
+	assertEqualInt (status, Ok);
+	assertEqualInt (width, 30);
 
 	// Negative tests.
 	status = GdipSetAdjustableArrowCapWidth (NULL, 30);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
 }
@@ -259,10 +249,10 @@ static void test_getAdjustableArrowCapWidth ()
 
 	// Negative tests.
 	status = GdipGetAdjustableArrowCapWidth (NULL, &width);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetAdjustableArrowCapWidth (cap, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
 }
@@ -276,15 +266,15 @@ static void test_setAdjustableArrowCapMiddleInset ()
 	GdipCreateAdjustableArrowCap (10, 11, TRUE, &cap);
 
 	status = GdipSetAdjustableArrowCapMiddleInset (cap, 30);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetAdjustableArrowCapMiddleInset (cap, &middleInset);
-	assert (status == Ok);
-	assert (middleInset == 30);
+	assertEqualInt (status, Ok);
+	assertEqualInt (middleInset, 30);
 
 	// Negative tests.
 	status = GdipSetAdjustableArrowCapMiddleInset (NULL, 30);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
 }
@@ -299,10 +289,10 @@ static void test_getAdjustableArrowCapMiddleInset ()
 
 	// Negative tests.
 	status = GdipGetAdjustableArrowCapMiddleInset (NULL, &middleInset);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetAdjustableArrowCapMiddleInset (cap, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
 }
@@ -316,15 +306,15 @@ static void test_setAdjustableArrowCapFillState ()
 	GdipCreateAdjustableArrowCap (10, 11, TRUE, &cap);
 
 	status = GdipSetAdjustableArrowCapFillState (cap, FALSE);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetAdjustableArrowCapFillState (cap, &isFilled);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isFilled == FALSE);
 
 	// Negative tests.
 	status = GdipSetAdjustableArrowCapFillState (NULL, 30);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
 }
@@ -339,10 +329,10 @@ static void test_getAdjustableArrowCapFillState ()
 
 	// Negative tests.
 	status = GdipGetAdjustableArrowCapFillState (NULL, &isFilled);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetAdjustableArrowCapFillState (cap, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteCustomLineCap ((GpCustomLineCap *) cap);
 }

--- a/tests/testbrush.c
+++ b/tests/testbrush.c
@@ -32,10 +32,10 @@ static void test_getBrushType ()
     GdipCreateSolidFill (1, &brush);
 
     status = GdipGetBrushType (NULL, &brushType);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetBrushType ((GpBrush *) brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -49,10 +49,10 @@ static void test_clone ()
     GdipCreateSolidFill (1, &brush);
 
     status = GdipCloneBrush (NULL, &clone);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCloneBrush ((GpBrush *) brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -65,10 +65,10 @@ static void test_delete ()
     GdipCreateSolidFill (1, &brush);
 
     status = GdipDeleteBrush ((GpBrush *) brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipDeleteBrush (NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 }
 
 int

--- a/tests/testclip.c
+++ b/tests/testclip.c
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#define C(func) assert(func == Ok)
+#define C(func) assert (func == Ok)
 
 #ifdef WIN32
 using namespace Gdiplus;
@@ -69,7 +69,7 @@ test_gdip_clip()
 
 	C (GdipGetClip (graphics, clip));
 	C (GdipIsInfiniteRegion(clip, graphics, &is_infinite));
-	assert(is_infinite);
+	assert (is_infinite);
 
 	// Create a path
 
@@ -96,7 +96,7 @@ test_gdip_clip()
 	C (GdipSetClipPath (graphics, path, CombineModeExclude));
 	C (GdipGetClip (graphics, clip));
 	C (GdipIsInfiniteRegion (clip, graphics, &is_infinite));
-	assert(!is_infinite);
+	assert (!is_infinite);
 
 	// Clear the clipped image (background)
 	C (GdipGraphicsClear (graphics, 0x80ff0000));
@@ -131,7 +131,7 @@ test_gdip_clip()
 		int *other_p = (int*)other_bm.data.Scan0;
 		int i;
 		for (i = 0; i < width * height; ++i)
-			assert(*p++ == *other_p++);
+			assert (*p++ == *other_p++);
 	}
 
 	C (GdipBitmapUnlockBits (bitmap, &bm.data));

--- a/tests/testfont.c
+++ b/tests/testfont.c
@@ -17,7 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <wchar.h>
+#include "testhelpers.h"
 
 #ifdef WIN32
 using namespace Gdiplus;
@@ -136,7 +136,7 @@ static void test_getFontCollectionFamilyList ()
 	GpFontFamily *families[2] = {NULL, NULL};
 	INT numFound;
 
-	fontFile = g_utf8_to_utf16 ("test.ttf", -1, NULL, NULL, NULL);
+	fontFile = createWchar ("test.ttf");
 	GdipNewPrivateFontCollection(&collection);
 
 	//Empty list.
@@ -187,10 +187,10 @@ static void test_privateAddFontFile ()
 	WCHAR name[LF_FACESIZE];
 
 	GdipNewPrivateFontCollection (&collection);
-	ttfFile = g_utf8_to_utf16 ("test.ttf", -1, NULL, NULL, NULL);
-	otfFile = g_utf8_to_utf16 ("test.otf", -1, NULL, NULL, NULL);
-	invalidFile = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
-	noSuchFile = g_utf8_to_utf16 ("noSuchFile.ttf", -1, NULL, NULL, NULL);
+	ttfFile = createWchar ("test.ttf");
+	otfFile = createWchar ("test.otf");
+	invalidFile = createWchar ("test.bmp");
+	noSuchFile = createWchar ("noSuchFile.ttf");
 
 	// Valid TTF file.
 	status = GdipPrivateAddFontFile (collection, ttfFile);
@@ -453,7 +453,7 @@ static void test_createFontFromLogfontW ()
 	Unit unit;
 	GpFontFamily *family;
 
-	fontName = g_utf8_to_utf16 ("Times New Roman", -1, NULL, NULL, NULL);
+	fontName = createWchar ("Times New Roman");
 	hdc = getEmptyHDC ();
 
 	logfont.lfHeight = 10;
@@ -870,7 +870,7 @@ static void test_createFontFamilyFromName ()
 	WCHAR *fontName;
 
 	GdipNewPrivateFontCollection (&collection);
-	fontName = g_utf8_to_utf16 ("test.ttf", -1, NULL, NULL, NULL);
+	fontName = createWchar ("test.ttf");
 	GdipPrivateAddFontFile (collection, fontName);
 
 	status = GdipCreateFontFamilyFromName (Tahoma, NULL, &family);

--- a/tests/testfont.c
+++ b/tests/testfont.c
@@ -81,15 +81,15 @@ static void test_newPrivateFontCollection ()
 	INT count;
 
 	status = GdipNewPrivateFontCollection (&collection);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetFontCollectionFamilyCount (collection, &count);
-	assert (status == Ok);
-	assert (count == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (count,  0);
 
 	// Negative tests.
 	status = GdipNewPrivateFontCollection (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePrivateFontCollection (&collection);
 }
@@ -102,12 +102,12 @@ static void test_deletePrivateFontCollection ()
 	GdipNewPrivateFontCollection(&collection);
 
 	status = GdipDeletePrivateFontCollection (&collection);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (!collection && "Expected the pointer to be set to NULL.");
 
 	// Negative tests.
 	status = GdipDeletePrivateFontCollection (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 }
 
 static void test_getFontCollectionFamilyCount ()
@@ -120,10 +120,10 @@ static void test_getFontCollectionFamilyCount ()
 
 	// Negative tests.
 	status = GdipGetFontCollectionFamilyCount (NULL, &count);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetFontCollectionFamilyCount (collection, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePrivateFontCollection (&collection);
 }
@@ -141,34 +141,34 @@ static void test_getFontCollectionFamilyList ()
 
 	//Empty list.
 	status = GdipGetFontCollectionFamilyList (collection, 10, families, &numFound);
-	assert (status == Ok);
-	assert (numFound == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (numFound, 0);
 
 	status = GdipGetFontCollectionFamilyList (collection, 0, families, &numFound);
-	assert (status == Ok);
-	assert (numFound == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (numFound, 0);
 
 	status = GdipGetFontCollectionFamilyList (collection, -1, families, &numFound);
-	assert (status == Ok);
-	assert (numFound == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (numFound, 0);
 
 	// Non empty list.
 	GdipPrivateAddFontFile (collection, fontFile);
 	status = GdipGetFontCollectionFamilyList (collection, 0, families, &numFound);
-	assert (status == Ok);
-	assert (numFound == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (numFound, 0);
 	assert (families[0] == NULL);
 	assert (families[1] == NULL);
 
 	// Negative tests.
 	status = GdipGetFontCollectionFamilyList (NULL, 10, families, &numFound);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetFontCollectionFamilyList (collection, 10, NULL, &numFound);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetFontCollectionFamilyList (collection, 10, families, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePrivateFontCollection (&collection);
 	freeWchar (fontFile);
@@ -195,18 +195,18 @@ static void test_privateAddFontFile ()
 
 	// Valid TTF file.
 	status = GdipPrivateAddFontFile (collection, ttfFile);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetFontCollectionFamilyCount (collection, &count);
-	assert (status == Ok);
-	assert (count == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (count,  1);
 
 	status = GdipGetFontCollectionFamilyList (collection, 2, families, &numFound);
-	assert (status == Ok);
-	assert (numFound == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (numFound, 1);
 
 	status = GdipGetFamilyName (families[0], name, 0);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (stringsEqual (name, "Code New Roman"));
 
 	GdipDeletePrivateFontCollection (&collection);
@@ -215,18 +215,18 @@ static void test_privateAddFontFile ()
 	GdipNewPrivateFontCollection (&collection);
 
 	status = GdipPrivateAddFontFile (collection, otfFile);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetFontCollectionFamilyCount (collection, &count);
-	assert (status == Ok);
-	assert (count == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (count,  1);
 
 	status = GdipGetFontCollectionFamilyList (collection, 2, families, &numFound);
-	assert (status == Ok);
-	assert (numFound == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (numFound, 1);
 
 	status = GdipGetFamilyName (families[0], name, 0);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (stringsEqual (name, "Code New Roman"));
 
 	GdipDeletePrivateFontCollection (&collection);
@@ -235,21 +235,21 @@ static void test_privateAddFontFile ()
 	GdipNewPrivateFontCollection (&collection);
 
 	status = GdipPrivateAddFontFile (collection, invalidFile);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetFontCollectionFamilyCount (collection, &count);
-	assert (status == Ok);
-	assert (count == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (count,  0);
 
 	// Negative tests.
 	status = GdipPrivateAddFontFile (NULL, ttfFile);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipPrivateAddFontFile (collection, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipPrivateAddFontFile (collection, noSuchFile);
-	assert (status == FileNotFound);
+	assertEqualInt (status, FileNotFound);
 
 	GdipDeletePrivateFontCollection (&collection);
 	freeWchar (ttfFile);
@@ -275,18 +275,18 @@ static void test_privateAddMemoryFont ()
 
 	// Valid TTF file.
 	status = GdipPrivateAddMemoryFont (collection, memory, memoryLength);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetFontCollectionFamilyCount (collection, &count);
-	assert (status == Ok);
-	assert (count == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (count,  1);
 
 	status = GdipGetFontCollectionFamilyList (collection, 2, families, &numFound);
-	assert (status == Ok);
-	assert (numFound == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (numFound, 1);
 
 	status = GdipGetFamilyName (families[0], name, 0);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (stringsEqual (name, "Code New Roman"));
 
 	free (memory);
@@ -297,18 +297,18 @@ static void test_privateAddMemoryFont ()
 	memory = readFile ("test.otf", &memoryLength);
 
 	status = GdipPrivateAddMemoryFont (collection, memory, memoryLength);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetFontCollectionFamilyCount (collection, &count);
-	assert (status == Ok);
-	assert (count == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (count,  1);
 
 	status = GdipGetFontCollectionFamilyList (collection, 2, families, &numFound);
-	assert (status == Ok);
-	assert (numFound == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (numFound, 1);
 
 	status = GdipGetFamilyName (families[0], name, 0);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (stringsEqual (name, "Code New Roman"));
 
 	free (memory);
@@ -318,24 +318,24 @@ static void test_privateAddMemoryFont ()
 	GdipNewPrivateFontCollection (&collection);
 
 	status = GdipPrivateAddMemoryFont (collection, &invalidMemory, 1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetFontCollectionFamilyCount (collection, &count);
-	assert (status == Ok);
-	assert (count == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (count,  0);
 
 	// Negative tests.
 	status = GdipPrivateAddMemoryFont (NULL, &invalidMemory, 1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipPrivateAddMemoryFont (collection, NULL, 1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipPrivateAddMemoryFont (collection, &invalidMemory, -1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipPrivateAddMemoryFont (collection, &invalidMemory, 0);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePrivateFontCollection (&collection);
 }
@@ -349,19 +349,19 @@ static void test_newInstalledFontCollection ()
 	INT count2;
 
 	status = GdipNewInstalledFontCollection (&collection1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (collection1 && "Expected collection to be initialized.");
 
 	status = GdipGetFontCollectionFamilyCount (collection1, &count1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (count1 >= 0);
 
 	status = GdipNewInstalledFontCollection (&collection2);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (collection1 == collection2 && "Expected the FontCollecion to be a singleton.");
 
 	status = GdipGetFontCollectionFamilyCount (collection2, &count2);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (count1 == count2 && "Expected the FontCollection count to remain constant over multiple calls.");
 }
 
@@ -375,12 +375,12 @@ static void test_createFontFromDC ()
 
 	// Negative tests.
 	status = GdipCreateFontFromDC (NULL, &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// This causes a null pointer dereference in GDI+.
 #if !defined(USE_WINDOWS_LIBGDIPLUS)
 	status = GdipCreateFontFromDC (hdc, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #endif
 }
 
@@ -413,32 +413,32 @@ static void test_createFontFromLogfontA ()
 	strcpy (logfont.lfFaceName, "Times New Roman");
 
 	status = GdipCreateFontFromLogfontA (hdc, &logfont, &font);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetFontStyle (font, &style);
-	assert (style == 15);
+	assertEqualInt (style, 15);
 
 	GdipGetFontUnit(font, &unit);
-	assert (unit == UnitWorld);
+	assertEqualInt (unit, UnitWorld);
 
 	status = GdipGetFamily (font, &family);
 	// FIXME: this fails with libgdiplus.
 #if defined(USE_WINDOWS_LIBGDIPLUS)
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (family);
 #endif
 
 	// Negative tests.
 	status = GdipCreateFontFromLogfontA (NULL, &logfont, &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateFontFromLogfontA (hdc, NULL, &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// This causes a null pointer dereference in GDI+.
 #if !defined(USE_WINDOWS_LIBGDIPLUS)
 	status = GdipCreateFontFromLogfontA (hdc, &logfont, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #endif
 
 	GdipDeleteFont (font);
@@ -477,32 +477,32 @@ static void test_createFontFromLogfontW ()
 	memcpy ((void *) logfont.lfFaceName, (void *) fontName, sizeof(WCHAR) + 15 + 1);
 
 	status = GdipCreateFontFromLogfontW (hdc, &logfont, &font);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetFontStyle (font, &style);
-	assert (style == 15);
+	assertEqualInt (style, 15);
 
 	GdipGetFontUnit(font, &unit);
-	assert (unit == UnitWorld);
+	assertEqualInt (unit, UnitWorld);
 
 	status = GdipGetFamily (font, &family);
 	// FIXME: this fails with libgdiplus.
 #if defined(USE_WINDOWS_LIBGDIPLUS)
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (family);
 #endif
 
 	// Negative tests.
 	status = GdipCreateFontFromLogfontW (NULL, &logfont, &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateFontFromLogfontW (hdc, NULL, &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// This causes a null pointer dereference in GDI+.
 #if !defined(USE_WINDOWS_LIBGDIPLUS)
 	status = GdipCreateFontFromLogfontW (hdc, &logfont, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #endif
 
 	GdipDeleteFont (font);
@@ -527,7 +527,7 @@ static void test_createFont ()
 	GdipCreateFont (originalFamily, 10, 10, UnitPixel, &font);
 
 	status = GdipGetFamily (font, &family);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (family && family != originalFamily);
 
 	GdipGetFamilyName (originalFamily, originalFamilyName, 0);
@@ -535,17 +535,17 @@ static void test_createFont ()
 	assert (!strcmp ((char *) originalFamilyName, (char *) familyName));
 
 	GdipGetFontUnit (font, &unit);
-	assert (unit == UnitPixel);
+	assertEqualInt (unit, UnitPixel);
 
 	GdipGetFontStyle(font, &style);
-	assert (style == 10);
+	assertEqualInt (style, 10);
 
 	// Negative tests.
 	status = GdipCreateFont (NULL, 10, 10, UnitPixel, &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateFont (family, 10, 10, UnitPixel, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// FIXME: there are several places that indirectly call GdipCreateFont in
 	// libgdiplus but allow negative em sizes on GDI+ because the GDI+
@@ -554,24 +554,24 @@ static void test_createFont ()
 	// API is called.
 #if defined(USE_WINDOWS_LIBGDIPLUS)
 	status = GdipCreateFont (family, -1, 10, UnitPixel, &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateFont (family, 0, 10, UnitPixel, &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #endif
 
 	status = GdipCreateFont (family, 10, 10, UnitDisplay, &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateFont (family, 10, 10, (Unit)(UnitWorld - 1), &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 #if defined(USE_WINDOWS_LIBGDIPLUS)
 	status = GdipCreateFont (family, 10, 10, (Unit)(UnitMillimeter + 1), &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #else
 	status = GdipCreateFont (family, 10, 10, (Unit)(UnitCairoPoint + 1), &font);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #endif
 
 	GdipDeleteFont (font);
@@ -590,11 +590,11 @@ static void test_deleteFont ()
 	GdipCreateFont (family, 10, 10, UnitPixel, &font);
 
 	status = GdipDeleteFont (font);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	// Negative tests.
 	status = GdipDeleteFont (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFontFamily (family);
 }
@@ -611,10 +611,10 @@ static void test_getFamily ()
 
 	// Negative tests.
 	status = GdipGetFamily (NULL, &family);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetFamily (font, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFont (font);
 	GdipDeleteFontFamily (originalFamily);
@@ -632,10 +632,10 @@ static void test_getFontStyle ()
 
 	// Negative tests.
 	status = GdipGetFontStyle (NULL, &style);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetFontStyle (font, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFont (font);
 	GdipDeleteFontFamily (originalFamily);
@@ -652,14 +652,14 @@ static void test_getFontSize ()
 	GdipCreateFont (originalFamily, 10, 10, UnitPixel, &font);
 
 	status = GdipGetFontSize (font, &size);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	// Negative tests.
 	status = GdipGetFontSize (NULL, &size);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetFontSize (font, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFont (font);
 	GdipDeleteFontFamily (originalFamily);
@@ -677,10 +677,10 @@ static void test_getFontUnit ()
 
 	// Negative tests.
 	status = GdipGetFontUnit (NULL, &unit);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetFontUnit (font, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFont (font);
 	GdipDeleteFontFamily (originalFamily);
@@ -697,18 +697,18 @@ static void test_getFontHeight ()
 	GdipCreateFont (originalFamily, 10, 10, UnitPixel, &font);
 
 	status = GdipGetFontHeight (font, NULL, &height);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	// FIXME: this returns a different value with libgdiplus.
 #if defined(USE_WINDOWS_LIBGDIPLUS)
-	assert (floatsEqual (height, 11.3183594));
+	assertEqualFloat (height, 11.3183594);
 #endif
 
 	// Negative tests.
 	status = GdipGetFontHeight (NULL, NULL, &height);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetFontHeight (font, NULL, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFont (font);
 	GdipDeleteFontFamily (originalFamily);
@@ -725,18 +725,18 @@ static void test_getFontHeightGivenDPI ()
 	GdipCreateFont (originalFamily, 10, 10, UnitPixel, &font);
 
 	status = GdipGetFontHeightGivenDPI (font, 10, &height);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	// FIXME: this returns a different value with libgdiplus.
 #if defined(USE_WINDOWS_LIBGDIPLUS)
-	assert (floatsEqual (height, 11.3183594));
+	assertEqualFloat (height, 11.3183594);
 #endif
 
 	// Negative tests.
 	status = GdipGetFontHeightGivenDPI (NULL, 10, &height);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetFontHeightGivenDPI (font, 10, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFont (font);
 	GdipDeleteFontFamily (originalFamily);
@@ -759,28 +759,28 @@ static void test_getLogfontA ()
 	GdipGetFamilyName (originalFamily, originalFamilyName, 0);
 
 	status = GdipGetLogFontA (font, graphics, &logfont);
-	assert (status == Ok);
-	assert (logfont.lfHeight == -10);
-	assert (logfont.lfWidth == 0);
-	assert (logfont.lfEscapement == 0);
-	assert (logfont.lfOrientation == 0);
-	assert (logfont.lfWeight == 400);
-	assert (logfont.lfCharSet == 0);
-	assert (logfont.lfOutPrecision == 0);
-	assert (logfont.lfClipPrecision == 0);
-	assert (logfont.lfQuality == 0);
-	assert (logfont.lfPitchAndFamily == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (logfont.lfHeight, -10);
+	assertEqualInt (logfont.lfWidth, 0);
+	assertEqualInt (logfont.lfEscapement, 0);
+	assertEqualInt (logfont.lfOrientation, 0);
+	assertEqualInt (logfont.lfWeight, 400);
+	assertEqualInt (logfont.lfCharSet, 0);
+	assertEqualInt (logfont.lfOutPrecision, 0);
+	assertEqualInt (logfont.lfClipPrecision, 0);
+	assertEqualInt (logfont.lfQuality, 0);
+	assertEqualInt (logfont.lfPitchAndFamily, 0);
 	assert (stringsEqual (originalFamilyName, logfont.lfFaceName));
 
 	// Negative tests.
 	status = GdipGetLogFontA (NULL, graphics, &logfont);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetLogFontA (font, NULL, &logfont);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetLogFontA (font, graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFont (font);
 	GdipDeleteFontFamily (originalFamily);
@@ -804,28 +804,28 @@ static void test_getLogfontW ()
 	GdipGetFamilyName (originalFamily, originalFamilyName, 0);
 
 	status = GdipGetLogFontW (font, graphics, &logfont);
-	assert (status == Ok);
-	assert (logfont.lfHeight == -10);
-	assert (logfont.lfWidth == 0);
-	assert (logfont.lfEscapement == 0);
-	assert (logfont.lfOrientation == 0);
-	assert (logfont.lfWeight == 400);
-	assert (logfont.lfCharSet == 0);
-	assert (logfont.lfOutPrecision == 0);
-	assert (logfont.lfClipPrecision == 0);
-	assert (logfont.lfQuality == 0);
-	assert (logfont.lfPitchAndFamily == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (logfont.lfHeight, -10);
+	assertEqualInt (logfont.lfWidth, 0);
+	assertEqualInt (logfont.lfEscapement, 0);
+	assertEqualInt (logfont.lfOrientation, 0);
+	assertEqualInt (logfont.lfWeight, 400);
+	assertEqualInt (logfont.lfCharSet, 0);
+	assertEqualInt (logfont.lfOutPrecision, 0);
+	assertEqualInt (logfont.lfClipPrecision, 0);
+	assertEqualInt (logfont.lfQuality, 0);
+	assertEqualInt (logfont.lfPitchAndFamily, 0);
 	assert (!strcmp ((char *) originalFamilyName, (char *) logfont.lfFaceName));
 
 	// Negative tests.
 	status = GdipGetLogFontW (NULL, graphics, &logfont);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetLogFontW (font, NULL, &logfont);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetLogFontW (font, graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFont (font);
 	GdipDeleteFontFamily (originalFamily);
@@ -846,23 +846,23 @@ static void verifyFontFamily (GpFontFamily *family, const char *expectedName, UI
 	UINT16 lineSpacing;
 
 	status = GdipGetFamilyName (family, name, 1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (stringsEqual (name, expectedName) || stringsEqual (name, alternateExpectedName));
 
 	status = GdipGetEmHeight (family, FontStyleRegular, &emHeight);
-	assert (status == Ok);
-	assert (emHeight == 2048);
+	assertEqualInt (status, Ok);
+	assertEqualInt (emHeight, 2048);
 
 	status = GdipGetCellAscent (family, FontStyleRegular, &cellAscent);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (cellAscent == expectedCellAscent || cellAscent == alternateCellAscent);
 
 	status = GdipGetCellDescent (family, FontStyleRegular, &cellDescent);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (cellDescent == expectedCellDescent || cellDescent == alternateCellDescent);
 
 	status = GdipGetLineSpacing (family, FontStyleRegular, &lineSpacing);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (lineSpacing == expectedLineSpacing || lineSpacing == alternateLineSpacing);
 
 	GdipDeleteFontFamily (family);
@@ -880,32 +880,32 @@ static void test_createFontFamilyFromName ()
 	GdipPrivateAddFontFile (collection, fontName);
 
 	status = GdipCreateFontFamilyFromName (Tahoma, NULL, &family);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyFontFamily (family, "Tahoma", 2049, 423, 2472, "DejaVu Sans", 1901, 483, 2384);
 
 	status = GdipCreateFontFamilyFromName (CodeNewRoman, collection, &family);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyFontFamily (family, "Code New Roman", 2059, 430, 2489, "Code New Roman", 1901, 483, 2384);
 
 	// Negative tests.
 	status = GdipCreateFontFamilyFromName (NULL, collection, &family);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateFontFamilyFromName (CodeNewRoman, collection, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// FIXME: Libgdiplus does not validate that the font family exists
 	// if the collection is NULL.
 #if defined(USE_WINDOWS_LIBGDIPLUS)
 	status = GdipCreateFontFamilyFromName (NoSuchFont, NULL, &family);
-	assert (status == FontFamilyNotFound);
+	assertEqualInt (status, FontFamilyNotFound);
 #endif
 
 	status = GdipCreateFontFamilyFromName (Tahoma, collection, &family);
-	assert (status == FontFamilyNotFound);
+	assertEqualInt (status, FontFamilyNotFound);
 
 	status = GdipCreateFontFamilyFromName (NoSuchFont, collection, &family);
-	assert (status == FontFamilyNotFound);
+	assertEqualInt (status, FontFamilyNotFound);
 
 	GdipDeletePrivateFontCollection (&collection);
 	freeWchar (fontName);
@@ -920,15 +920,15 @@ static void test_cloneFontFamily ()
 	GdipCreateFontFamilyFromName (Tahoma, NULL, &family);
 	
 	status = GdipCloneFontFamily (family, &clonedFamily);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyFontFamily (clonedFamily, "Tahoma", 2049, 423, 2472, "DejaVu Sans", 1901, 483, 2384);
 
 	// Negative tests.
 	status = GdipCloneFontFamily (NULL, &clonedFamily);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCloneFontFamily (family, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 	
 	GdipDeleteFontFamily (family);
 }
@@ -941,11 +941,11 @@ static void test_deleteFontFamily ()
 	GdipCreateFontFamilyFromName (Tahoma, NULL, &family);
 	
 	status = GdipDeleteFontFamily (family);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	// Negative tests.
 	status = GdipDeleteFontFamily (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 }
 
 static void test_getGenericFontFamilySansSerif ()
@@ -955,16 +955,16 @@ static void test_getGenericFontFamilySansSerif ()
 	GpFontFamily *family2;
 
 	status = GdipGetGenericFontFamilySansSerif  (&family1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (family1);
 
 	status = GdipGetGenericFontFamilySansSerif (&family2);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (family2 && family1 == family2);
 
 	// Negative tests.
 	status = GdipGetGenericFontFamilySansSerif (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFontFamily (family1);
 	GdipDeleteFontFamily (family2);
@@ -977,16 +977,16 @@ static void test_getGenericFontFamilySerif ()
 	GpFontFamily *family2;
 
 	status = GdipGetGenericFontFamilySerif  (&family1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (family1);
 
 	status = GdipGetGenericFontFamilySerif  (&family2);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (family2 && family1 == family2);
 
 	// Negative tests.
 	status = GdipGetGenericFontFamilySerif (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFontFamily (family1);
 	GdipDeleteFontFamily (family2);
@@ -999,16 +999,16 @@ static void test_getGenericFontFamilyMonospace ()
 	GpFontFamily *family2;
 
 	status = GdipGetGenericFontFamilyMonospace  (&family1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (family1);
 
 	status = GdipGetGenericFontFamilyMonospace  (&family2);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (family2 && family1 == family2);
 
 	// Negative tests.
 	status = GdipGetGenericFontFamilyMonospace (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFontFamily (family1);
 	GdipDeleteFontFamily (family2);
@@ -1023,18 +1023,18 @@ static void test_getFamilyName ()
 	GdipCreateFontFamilyFromName (Tahoma, NULL, &family);
 
 	status = GdipGetFamilyName (family, name, 57920);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (stringsEqual(name, "Tahoma") || stringsEqual (name, "DejaVu Sans"));
 
 	// Negative tests.
 	status = GdipGetFamilyName (NULL, name, 1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetFamilyName (family, NULL, 1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetFamilyName (NULL, NULL, 1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFontFamily (family);
 }
@@ -1048,23 +1048,23 @@ static void test_isStyleAvailable ()
 	GdipCreateFontFamilyFromName (Tahoma, NULL, &family);
 
 	status = GdipIsStyleAvailable (family, FontStyleBold, &isStyleAvailable);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isStyleAvailable == TRUE);
 
 	status = GdipIsStyleAvailable (family, -1, &isStyleAvailable);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isStyleAvailable == TRUE);
 
 	status = GdipIsStyleAvailable (family, FontStyleStrikeout + 1, &isStyleAvailable);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isStyleAvailable == TRUE);
 
 	// Negative tests.
 	status = GdipIsStyleAvailable (NULL, FontStyleBold, &isStyleAvailable);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipIsStyleAvailable (family, FontStyleBold, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFontFamily (family);
 }
@@ -1079,10 +1079,10 @@ static void test_getEmHeight ()
 
 	// Negative tests.
 	status = GdipGetEmHeight (NULL, FontStyleBold, &emHeight);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetEmHeight (family, FontStyleBold, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFontFamily (family);
 }
@@ -1097,10 +1097,10 @@ static void test_getCellAscent ()
 
 	// Negative tests.
 	status = GdipGetCellAscent (NULL, FontStyleBold, &cellAscent);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetCellAscent (family, FontStyleBold, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFontFamily (family);
 }
@@ -1115,10 +1115,10 @@ static void test_getCellDescent ()
 
 	// Negative tests.
 	status = GdipGetCellDescent (NULL, FontStyleBold, &cellDescent);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetCellDescent (family, FontStyleBold, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFontFamily (family);
 }
@@ -1133,10 +1133,10 @@ static void test_getLineSpacing ()
 
 	// Negative tests.
 	status = GdipGetLineSpacing (NULL, FontStyleBold, &lineSpacing);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetLineSpacing (family, FontStyleBold, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteFontFamily (family);
 }

--- a/tests/testfont.c
+++ b/tests/testfont.c
@@ -171,6 +171,7 @@ static void test_getFontCollectionFamilyList ()
 	assert (status == InvalidParameter);
 
 	GdipDeletePrivateFontCollection (&collection);
+	freeWchar (fontFile);
 }
 
 static void test_privateAddFontFile ()
@@ -251,6 +252,10 @@ static void test_privateAddFontFile ()
 	assert (status == FileNotFound);
 
 	GdipDeletePrivateFontCollection (&collection);
+	freeWchar (ttfFile);
+	freeWchar (otfFile);
+	freeWchar (invalidFile);
+	freeWchar (noSuchFile);
 }
 
 static void test_privateAddMemoryFont ()
@@ -504,6 +509,7 @@ static void test_createFontFromLogfontW ()
 #if defined(USE_WINDOWS_LIBGDIPLUS)
 	GdipDeleteFontFamily (family);
 #endif
+	freeWchar (fontName);
 }
 
 static void test_createFont ()
@@ -902,6 +908,7 @@ static void test_createFontFamilyFromName ()
 	assert (status == FontFamilyNotFound);
 
 	GdipDeletePrivateFontCollection (&collection);
+	freeWchar (fontName);
 }
 
 static void test_cloneFontFamily ()

--- a/tests/testgdi.c
+++ b/tests/testgdi.c
@@ -77,7 +77,7 @@ win_draw(win_t *win)
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 0, 0);
 	CHECK_GDIP_ST(st);
-	g_free (unis);
+	freeWchar (unis);
 	GdipDisposeImage (img);
 	img = NULL;
 
@@ -88,7 +88,7 @@ win_draw(win_t *win)
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 100, 0);
 	CHECK_GDIP_ST(st);
-	g_free (unis);
+	freeWchar (unis);
 	GdipDisposeImage (img);
 	img = NULL;
 
@@ -99,7 +99,7 @@ win_draw(win_t *win)
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 200, 0);
 	CHECK_GDIP_ST(st);
-	g_free (unis);
+	freeWchar (unis);
 	GdipDisposeImage (img);
 	img = NULL;
 
@@ -110,7 +110,7 @@ win_draw(win_t *win)
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 0, 100);
 	CHECK_GDIP_ST(st);
-	g_free (unis);
+	freeWchar (unis);
 	GdipDisposeImage (img);
 	img = NULL;
 
@@ -121,7 +121,7 @@ win_draw(win_t *win)
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 200, 100);
 	CHECK_GDIP_ST(st);
-	g_free (unis);
+	freeWchar (unis);
 	GdipDisposeImage (img);
 	img = NULL;
 

--- a/tests/testgdi.c
+++ b/tests/testgdi.c
@@ -17,6 +17,7 @@
 
 #include "GdiPlusFlat.h"
 #include <X11/Xlib.h>
+#include "testhelpers.h"
 
 typedef struct win {
 	Display *dpy;
@@ -71,7 +72,7 @@ win_draw(win_t *win)
 	
 	
 	
-	unis = g_utf8_to_utf16 ("test.jpg", -1, NULL, NULL, NULL);
+	unis = createWchar ("test.jpg");
 	st = GdipLoadImageFromFile (unis, &img);
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 0, 0);
@@ -82,7 +83,7 @@ win_draw(win_t *win)
 
 	printf("jpg drawn \n");
 
-	unis = g_utf8_to_utf16 ("test.tif", -1, NULL, NULL, NULL);
+	unis = createWchar ("test.tif");
 	st = GdipLoadImageFromFile (unis, &img);
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 100, 0);
@@ -93,7 +94,7 @@ win_draw(win_t *win)
 
 	printf("tif drawn \n");
 
-	unis = g_utf8_to_utf16 ("test.gif", -1, NULL, NULL, NULL);
+	unis = createWchar ("test.gif");
 	st = GdipLoadImageFromFile (unis, &img);
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 200, 0);
@@ -104,7 +105,7 @@ win_draw(win_t *win)
 
 	printf("gif drawn \n");
 
-	unis = g_utf8_to_utf16 ("test.png", -1, NULL, NULL, NULL);
+	unis = createWchar ("test.png");
 	st = GdipLoadImageFromFile (unis, &img);
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 0, 100);
@@ -115,7 +116,7 @@ win_draw(win_t *win)
 
 	printf("png drawn \n");
 
-	unis = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	unis = createWchar ("test.bmp");
 	st = GdipLoadImageFromFile (unis, &img);
 	CHECK_GDIP_ST(st);
 	st = GdipDrawImage (gp, img, 200, 100);

--- a/tests/testgraphics.c
+++ b/tests/testgraphics.c
@@ -18,19 +18,19 @@
 #include <assert.h>
 #include "testhelpers.h"
 
-static GpGraphics *getImageGraphics (GpImage *image)
+static GpGraphics *getImageGraphics (GpImage **image)
 {
 	GpStatus status;
 	WCHAR *filePath;
 	GpGraphics *graphics;
 
 	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
+	status = GdipLoadImageFromFile (filePath, image);
 	assertEqualInt (status, Ok);
 
 	freeWchar (filePath);
 	
-	status = GdipGetImageGraphicsContext (image, &graphics);
+	status = GdipGetImageGraphicsContext (*image, &graphics);
 	assertEqualInt (status, Ok);
 	
 	return graphics;

--- a/tests/testgraphics.c
+++ b/tests/testgraphics.c
@@ -16,12 +16,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <math.h>
-#include <float.h>
+#include "testhelpers.h"
 
 static void test_createFromHDC()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphicsOriginal;
@@ -29,7 +28,7 @@ static void test_createFromHDC()
 	GpGraphics *graphicsFromHdc;
 	TextRenderingHint textRenderingHint;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -74,7 +73,7 @@ static void test_createFromHDC()
 
 static void test_createFromHDC2()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphicsOriginal;
@@ -82,7 +81,7 @@ static void test_createFromHDC2()
 	GpGraphics *graphicsFromHdc;
 	TextRenderingHint textRenderingHint;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -167,13 +166,13 @@ static void test_createFromHWNDICM()
 
 static void test_hdc ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	HDC hdc;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -214,13 +213,13 @@ static void test_hdc ()
 
 static void test_compositingMode ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	CompositingMode mode;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -260,13 +259,13 @@ static void test_compositingMode ()
 
 static void test_compositingQuality ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	CompositingQuality quality;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -306,14 +305,14 @@ static void test_compositingQuality ()
 
 static void test_renderingOrigin ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	int x;
 	int y;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -357,13 +356,13 @@ static void test_renderingOrigin ()
 
 static void test_textRenderingHint ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	TextRenderingHint textRenderingHint;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -409,13 +408,13 @@ static void test_textRenderingHint ()
 
 static void test_textContrast ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	UINT textContrast;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -461,13 +460,13 @@ static void test_textContrast ()
 
 static void test_smoothingMode ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	SmoothingMode smoothingMode;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -541,13 +540,13 @@ static void test_smoothingMode ()
 
 static void test_pixelOffsetMode ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	PixelOffsetMode pixelOffsetMode;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -610,13 +609,13 @@ static void test_pixelOffsetMode ()
 
 static void test_interpolationMode ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	InterpolationMode interpolationMode;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -693,7 +692,7 @@ static void test_interpolationMode ()
 
 static void test_transform ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
@@ -701,7 +700,7 @@ static void test_transform ()
 	GpMatrix *setMatrix;
 	GpMatrix *nonInvertibleMatrix;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -761,13 +760,13 @@ static void test_transform ()
 
 static void test_pageUnit ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	Unit pageUnit;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -821,13 +820,13 @@ static void test_pageUnit ()
 
 static void test_pageScale ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	REAL pageScale;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -889,13 +888,13 @@ static void test_pageScale ()
 }
 static void test_dpiX ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	float dpiX;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -926,13 +925,13 @@ static void test_dpiX ()
 
 static void test_dpiY ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	REAL dpiY;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -963,12 +962,12 @@ static void test_dpiY ()
 
 static void test_flush ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
 	assert (status == Ok);
 
@@ -1004,12 +1003,12 @@ static void test_flush ()
 
 static void test_delete ()
 {
-	gunichar2 *filePath;
+	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 
-	filePath = g_utf8_to_utf16 ("test.bmp", -1, NULL, NULL, NULL);
+	filePath = createWchar ("test.bmp");
 	GdipLoadImageFromFile (filePath, &image);
 	GdipGetImageGraphicsContext (image, &graphics);
 	

--- a/tests/testgraphics.c
+++ b/tests/testgraphics.c
@@ -26,12 +26,12 @@ static GpGraphics *getImageGraphics (GpImage *image)
 
 	filePath = createWchar ("test.bmp");
 	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok && "Expected test.bmp to exist.");
+	assertEqualInt (status, Ok);
 
 	freeWchar (filePath);
 	
 	status = GdipGetImageGraphicsContext (image, &graphics);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	return graphics;
 }
@@ -48,35 +48,35 @@ static void test_createFromHDC()
 	graphicsOriginal = getImageGraphics (&image);
 
 	status = GdipSetTextRenderingHint (graphicsOriginal, TextRenderingHintClearTypeGridFit);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetDC (graphicsOriginal, &hdc);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipCreateFromHDC (0, &graphicsFromHdc);
-	assert (status == OutOfMemory);
+	assertEqualInt (status, OutOfMemory);
 
 	status = GdipCreateFromHDC (0, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateFromHDC (hdc, &graphicsFromHdc);
-	assert (status == Ok);
-	assert(graphicsFromHdc != NULL);
+	assertEqualInt (status, Ok);
+	assert (graphicsFromHdc != NULL);
 
 	// The graphics from the HDC should not have the same values as the original graphics.
 	status = GdipGetTextRenderingHint (graphicsFromHdc, &textRenderingHint);
-	assert(status == Ok);
-	assert(textRenderingHint == TextRenderingHintSystemDefault);
+	assertEqualInt (status, Ok);
+	assertEqualInt (textRenderingHint, TextRenderingHintSystemDefault);
 
 	// Modifying the graphics from the HDC should not modify the original graphics.
 	status = GdipSetTextRenderingHint (graphicsFromHdc, TextRenderingHintSingleBitPerPixelGridFit);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipReleaseDC (graphicsOriginal, hdc);
 
 	status = GdipGetTextRenderingHint (graphicsOriginal, &textRenderingHint);
-	assert(status == Ok);
-	assert(textRenderingHint == TextRenderingHintClearTypeGridFit);
+	assertEqualInt (status, Ok);
+	assertEqualInt (textRenderingHint, TextRenderingHintClearTypeGridFit);
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphicsOriginal);
@@ -95,35 +95,35 @@ static void test_createFromHDC2()
 	graphicsOriginal = getImageGraphics (&image);
 
 	status = GdipSetTextRenderingHint (graphicsOriginal, TextRenderingHintClearTypeGridFit);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetDC (graphicsOriginal, &hdc);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipCreateFromHDC2 (0, NULL, &graphicsFromHdc);
-	assert (status == OutOfMemory);
+	assertEqualInt (status, OutOfMemory);
 
 	status = GdipCreateFromHDC2 (0, NULL, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateFromHDC2 (hdc, NULL, &graphicsFromHdc);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (graphicsFromHdc != NULL);
 
 	// The graphics from the HDC should not have the same values as the original graphics.
 	status = GdipGetTextRenderingHint (graphicsFromHdc, &textRenderingHint);
-	assert (status == Ok);
-	assert (textRenderingHint == TextRenderingHintSystemDefault);
+	assertEqualInt (status, Ok);
+	assertEqualInt (textRenderingHint, TextRenderingHintSystemDefault);
 
 	// Modifying the graphics from the HDC should not modify the original graphics.
 	status = GdipSetTextRenderingHint (graphicsFromHdc, TextRenderingHintSingleBitPerPixelGridFit);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipReleaseDC (graphicsOriginal, hdc);
 
 	status = GdipGetTextRenderingHint (graphicsOriginal, &textRenderingHint);
-	assert (status == Ok);
-	assert (textRenderingHint == TextRenderingHintClearTypeGridFit);
+	assertEqualInt (status, Ok);
+	assertEqualInt (textRenderingHint, TextRenderingHintClearTypeGridFit);
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphicsOriginal);
@@ -136,17 +136,17 @@ static void test_createFromHWND()
 	GpGraphics *graphics;
 
 	status = GdipCreateFromHWND (0, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 // Libgdiplus does not implement GdipCreateFromHwnd.
 #if defined(USE_WINDOWS_GDIPLUS)
 	// HWND of zero means the current screen.
 	status = GdipCreateFromHWND (0, &graphics);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (graphics != NULL);
 #else
   status = GdipCreateFromHWND (0, &graphics);
-	assert (status == NotImplemented);
+	assertEqualInt (status, NotImplemented);
 #endif
 }
 
@@ -156,17 +156,17 @@ static void test_createFromHWNDICM()
 	GpGraphics *graphics;
 
 	status = GdipCreateFromHWNDICM (0, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 // Libgdiplus does not implement GdipCreateFromHwndICM.
 #if defined(USE_WINDOWS_GDIPLUS)
 	// HWND of zero means the current screen.
 	status = GdipCreateFromHWNDICM (0, &graphics);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (graphics != NULL);
 #else
   status = GdipCreateFromHWNDICM (0, &graphics);
-	assert (status == NotImplemented);
+	assertEqualInt (status, NotImplemented);
 #endif
 }
 
@@ -180,32 +180,32 @@ static void test_hdc ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetDC (NULL, &hdc);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetDC (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetDC (graphics, &hdc);
-	assert (status == Ok);
-	assert(hdc != 0);
+	assertEqualInt (status, Ok);
+	assert (hdc != 0);
 
 	status = GdipGetDC (graphics, &hdc);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipReleaseDC (NULL, hdc);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipReleaseDC (NULL, 0);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipReleaseDC (graphics, 0);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipReleaseDC (graphics, hdc);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipReleaseDC (graphics, hdc);
-	assert (status == InvalidParameter);	
+	assertEqualInt (status, InvalidParameter);	
 
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
@@ -221,29 +221,29 @@ static void test_compositingMode ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipSetCompositingMode (NULL, CompositingModeSourceCopy);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetCompositingMode (NULL, &mode);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetCompositingMode (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetCompositingMode (graphics, (CompositingMode)-1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetCompositingMode(graphics, &mode);
-	assert (status == Ok);
-	assert (mode == (CompositingMode)-1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (mode, (CompositingMode)-1);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetCompositingMode (graphics, &mode);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetCompositingMode (graphics, CompositingModeSourceCopy);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -261,29 +261,29 @@ static void test_compositingQuality ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetCompositingQuality(NULL, &quality);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetCompositingQuality (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetCompositingQuality (NULL, CompositingQualityAssumeLinear);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetCompositingQuality (graphics, (CompositingQuality)-1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetCompositingQuality (graphics, &quality);
-	assert (status == Ok);
-	assert (quality == (CompositingQuality)-1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (quality, (CompositingQuality)-1);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetCompositingQuality (graphics, &quality);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetCompositingQuality(graphics, CompositingQualityAssumeLinear);
-	assert(status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -302,33 +302,33 @@ static void test_renderingOrigin ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetRenderingOrigin (NULL, &x, &y);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetRenderingOrigin (graphics, NULL, &y);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetRenderingOrigin (graphics, &x, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetRenderingOrigin(NULL, 0, 0);
-	assert(status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetRenderingOrigin (graphics, 1, 2);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetRenderingOrigin (graphics, &x, &y);
-	assert (status == Ok);
-	assert (x == 1);
-	assert (y == 2);
+	assertEqualInt (status, Ok);
+	assertEqualInt (x, 1);
+	assertEqualInt (y, 2);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetRenderingOrigin(graphics, &x, &y);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetRenderingOrigin (graphics, 1, 2);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -346,35 +346,35 @@ static void test_textRenderingHint ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetTextRenderingHint (NULL, &textRenderingHint);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetTextRenderingHint (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetTextRenderingHint (NULL, TextRenderingHintAntiAlias);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetTextRenderingHint (graphics, (TextRenderingHint)(TextRenderingHintSystemDefault - 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetTextRenderingHint (graphics, (TextRenderingHint)(TextRenderingHintClearTypeGridFit + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetTextRenderingHint (graphics, TextRenderingHintClearTypeGridFit);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetTextRenderingHint (graphics, &textRenderingHint);
-	assert (status == Ok);
-	assert (textRenderingHint == TextRenderingHintClearTypeGridFit);
+	assertEqualInt (status, Ok);
+	assertEqualInt (textRenderingHint, TextRenderingHintClearTypeGridFit);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetTextRenderingHint(graphics, &textRenderingHint);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetTextRenderingHint (graphics, TextRenderingHintClearTypeGridFit);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -392,35 +392,35 @@ static void test_textContrast ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetTextContrast (NULL, &textContrast);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetTextContrast (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetTextContrast(NULL, 1);
-	assert(status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetTextContrast (graphics, -1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetTextContrast (graphics, 13);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetTextContrast (graphics, 12);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetTextContrast (graphics, &textContrast);
-	assert (status == Ok);
-	assert (textContrast == 12);
+	assertEqualInt (status, Ok);
+	assertEqualInt (textContrast, 12);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetTextContrast (graphics, &textContrast);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetTextContrast (graphics, 1);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -438,63 +438,63 @@ static void test_smoothingMode ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetSmoothingMode (NULL, &smoothingMode);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetSmoothingMode (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetSmoothingMode (NULL, SmoothingModeAntiAlias);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetSmoothingMode (graphics, SmoothingModeInvalid);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetSmoothingMode (graphics, (SmoothingMode)(SmoothingModeInvalid - 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetSmoothingMode (graphics, (SmoothingMode)(SmoothingModeAntiAlias + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// HighQuality -> AntiAlias
 	status = GdipSetSmoothingMode (graphics, SmoothingModeHighQuality);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetSmoothingMode (graphics, &smoothingMode);
-	assert (status == Ok);
-	assert (smoothingMode == SmoothingModeAntiAlias);
+	assertEqualInt (status, Ok);
+	assertEqualInt (smoothingMode, SmoothingModeAntiAlias);
 
 	// Default -> None
 	status = GdipSetSmoothingMode (graphics, SmoothingModeDefault);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetSmoothingMode (graphics, &smoothingMode);
-	assert (status == Ok);
-	assert (smoothingMode == SmoothingModeNone);
+	assertEqualInt (status, Ok);
+	assertEqualInt (smoothingMode, SmoothingModeNone);
 
 	// HighSpeed -> None
 	status = GdipSetSmoothingMode(graphics, SmoothingModeHighSpeed);
-	assert(status == Ok);
-
+	assertEqualInt (status, Ok);
+	
 	status = GdipGetSmoothingMode(graphics, &smoothingMode);
-	assert(status == Ok);
-	assert(smoothingMode == SmoothingModeNone);
+	assertEqualInt (status, Ok);
+	assertEqualInt (smoothingMode, SmoothingModeNone);
 
 	// Other -> Other
 	status = GdipSetSmoothingMode(graphics, SmoothingModeAntiAlias);
-	assert(status == Ok);
-
+	assertEqualInt (status, Ok);
+	
 	status = GdipGetSmoothingMode(graphics, &smoothingMode);
-	assert(status == Ok);
-	assert(smoothingMode == SmoothingModeAntiAlias);
+	assertEqualInt (status, Ok);
+	assertEqualInt (smoothingMode, SmoothingModeAntiAlias);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetSmoothingMode (graphics, &smoothingMode);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetSmoothingMode (graphics, SmoothingModeHighQuality);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -512,52 +512,52 @@ static void test_pixelOffsetMode ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetPixelOffsetMode (NULL, &pixelOffsetMode);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPixelOffsetMode (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPixelOffsetMode(NULL, PixelOffsetModeDefault);
-	assert(status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPixelOffsetMode (graphics, PixelOffsetModeInvalid);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPixelOffsetMode (graphics, (PixelOffsetMode)(PixelOffsetModeInvalid - 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPixelOffsetMode (graphics, (PixelOffsetMode)(PixelOffsetModeHalf + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPixelOffsetMode (graphics, PixelOffsetModeHighQuality);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPixelOffsetMode (graphics, &pixelOffsetMode);
-	assert (status == Ok);
-	assert (pixelOffsetMode == PixelOffsetModeHighQuality);
+	assertEqualInt (status, Ok);
+	assertEqualInt (pixelOffsetMode, PixelOffsetModeHighQuality);
 
 	status = GdipSetPixelOffsetMode (graphics, PixelOffsetModeDefault);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPixelOffsetMode (graphics, &pixelOffsetMode);
-	assert (status == Ok);
-	assert (pixelOffsetMode == PixelOffsetModeDefault);
+	assertEqualInt (status, Ok);
+	assertEqualInt (pixelOffsetMode, PixelOffsetModeDefault);
 
 	status = GdipSetPixelOffsetMode(graphics, PixelOffsetModeHighSpeed);
-	assert(status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPixelOffsetMode(graphics, &pixelOffsetMode);
-	assert(status == Ok);
-	assert(pixelOffsetMode == PixelOffsetModeHighSpeed);
+	assertEqualInt (status, Ok);
+	assertEqualInt (pixelOffsetMode, PixelOffsetModeHighSpeed);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetPixelOffsetMode (graphics, &pixelOffsetMode);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetPixelOffsetMode (graphics, PixelOffsetModeDefault);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -575,66 +575,66 @@ static void test_interpolationMode ()
 	graphics = getImageGraphics (&image);
 	
 	status = GdipGetInterpolationMode (NULL, &interpolationMode);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 // This causes an access violation in GDI+.
 #if !defined(USE_WINDOWS_GDIPLUS)
 	status = GdipGetInterpolationMode(graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #endif
 
 	status = GdipSetInterpolationMode(NULL, InterpolationModeBicubic);
-	assert(status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetInterpolationMode (graphics, InterpolationModeInvalid);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetInterpolationMode (graphics, (InterpolationMode)(InterpolationModeInvalid - 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetInterpolationMode (graphics, (InterpolationMode)(InterpolationModeHighQualityBicubic + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// Default -> Bilinear
 	status = GdipSetInterpolationMode (graphics, InterpolationModeDefault);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetInterpolationMode (graphics, &interpolationMode);
-	assert (status == Ok);
-	assert (interpolationMode == InterpolationModeBilinear);
+	assertEqualInt (status, Ok);
+	assertEqualInt (interpolationMode, InterpolationModeBilinear);
 
 	// HighQuality -> HighQualityBicubic
 	status = GdipSetInterpolationMode (graphics, InterpolationModeHighQuality);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetInterpolationMode (graphics, &interpolationMode);
-	assert (status == Ok);
-	assert (interpolationMode == InterpolationModeHighQualityBicubic);
+	assertEqualInt (status, Ok);
+	assertEqualInt (interpolationMode, InterpolationModeHighQualityBicubic);
 
 	// LowQuality -> NearestNeighbor
 	status = GdipSetInterpolationMode(graphics, InterpolationModeLowQuality);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetInterpolationMode (graphics, &interpolationMode);
-	assert (status == Ok);
-	assert (interpolationMode == InterpolationModeBilinear);
+	assertEqualInt (status, Ok);
+	assertEqualInt (interpolationMode, InterpolationModeBilinear);
 
 	// Other -> Other
 	status = GdipSetInterpolationMode (graphics, InterpolationModeBicubic);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetInterpolationMode (graphics, &interpolationMode);
-	assert (status == Ok);
-	assert (interpolationMode == InterpolationModeBicubic);
+	assertEqualInt (status, Ok);
+	assertEqualInt (interpolationMode, InterpolationModeBicubic);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetInterpolationMode (graphics, &interpolationMode);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetInterpolationMode (graphics, InterpolationModeBicubic);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -654,46 +654,46 @@ static void test_transform ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipCreateMatrix2 (0, 0, 0, 0, 0, 0, &matrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipCreateMatrix2 (146, 66, 158, 104, 42, 150, &setMatrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipCreateMatrix2 (123, 24, 82, 16, 47, 30, &nonInvertibleMatrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetWorldTransform (NULL, matrix);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetWorldTransform (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetWorldTransform (NULL, matrix);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetWorldTransform (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetWorldTransform (graphics, nonInvertibleMatrix);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetWorldTransform (graphics, setMatrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetWorldTransform (graphics, matrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	BOOL result;
 	GdipIsMatrixEqual (matrix, setMatrix, &result);
-	assert (result == 1);
+	assertEqualInt (result, 1);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetWorldTransform (graphics, matrix);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetWorldTransform (graphics, matrix);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -714,43 +714,43 @@ static void test_pageUnit ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetPageUnit (NULL, &pageUnit);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPageUnit (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPageUnit (NULL, UnitDisplay);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPageUnit (graphics, (Unit)(UnitWorld - 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 #if defined(USE_WINDOWS_GDIPLUS)
 	status = GdipSetPageUnit (graphics, (Unit)(UnitMillimeter + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #else
 	status = GdipSetPageUnit (graphics, (Unit)(UnitCairoPoint + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #endif
 
 	status = GdipSetPageUnit (graphics, UnitWorld);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPageUnit (graphics, UnitMillimeter);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPageUnit (graphics, &pageUnit);
-	assert (status == Ok);
-	assert (pageUnit == UnitMillimeter);
+	assertEqualInt (status, Ok);
+	assertEqualInt (pageUnit, UnitMillimeter);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetPageUnit (graphics, &pageUnit);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetPageUnit (graphics, UnitDisplay);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -768,52 +768,52 @@ static void test_pageScale ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetPageScale (NULL, &pageScale);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPageScale (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPageScale (NULL, UnitDisplay);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPageScale (graphics, -INFINITY);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPageScale (graphics, -1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPageScale (graphics, 0);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPageScale (graphics, FLT_MAX);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// 1000000032 appears to be the max value accepted by GDI+.
 	status = GdipSetPageScale (graphics, (float)1000000033);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPageScale (graphics, 1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPageScale (graphics, &pageScale);
-	assert (status == Ok);
-	assert (pageScale == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (pageScale, 1);
 
-	status = GdipSetPageScale (graphics, (float)1000000032);
-	assert (status == Ok);
+	status = GdipSetPageScale (graphics, (REAL) 1000000032);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPageScale (graphics, &pageScale);
-	assert (status == Ok);
-	assert (pageScale == 1000000032);
+	assertEqualInt (status, Ok);
+	assertEqualFloat (pageScale, 1000000032);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetPageScale (graphics, &pageScale);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipSetPageScale (graphics, 1);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -831,20 +831,20 @@ static void test_dpiX ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetDpiX (NULL, &dpiX);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetDpiX (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetDpiX (graphics, &dpiX);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (dpiX > 0);
 
 	HDC hdc;
 	GdipGetDC (graphics, &hdc);
 
 	status = GdipGetDpiX (graphics, &dpiX);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC(graphics, hdc);
 
@@ -862,20 +862,20 @@ static void test_dpiY ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipGetDpiY (NULL, &dpiY);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetDpiY (graphics, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetDpiY (graphics, &dpiY);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (dpiY > 0);
 
 	HDC hdc;
 	GdipGetDC(graphics, &hdc);
 
 	status = GdipGetDpiY (graphics, &dpiY);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -892,25 +892,25 @@ static void test_flush ()
 	graphics = getImageGraphics (&image);
 
 	status = GdipFlush (NULL, FlushIntentionFlush);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipFlush (graphics, FlushIntentionFlush);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipFlush (graphics, FlushIntentionSync);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipFlush (graphics, (FlushIntention)(FlushIntentionFlush - 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipFlush (graphics, (FlushIntention)(FlushIntentionSync + 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	HDC hdc;
 	status = GdipGetDC (graphics, &hdc);
 
 	status = GdipFlush (graphics, FlushIntentionSync);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
@@ -930,15 +930,15 @@ static void test_delete ()
 	status = GdipGetDC (graphics, &hdc);
 
 	status = GdipDeleteGraphics (graphics);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	GdipReleaseDC (graphics, hdc);
 
 	status = GdipDeleteGraphics (graphics);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipDeleteGraphics (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDisposeImage (image);
 }

--- a/tests/testgraphics.c
+++ b/tests/testgraphics.c
@@ -18,9 +18,26 @@
 #include <assert.h>
 #include "testhelpers.h"
 
+static GpGraphics *getImageGraphics (GpImage *image)
+{
+	GpStatus status;
+	WCHAR *filePath;
+	GpGraphics *graphics;
+
+	filePath = createWchar ("test.bmp");
+	status = GdipLoadImageFromFile (filePath, &image);
+	assert (status == Ok && "Expected test.bmp to exist.");
+
+	freeWchar (filePath);
+	
+	status = GdipGetImageGraphicsContext (image, &graphics);
+	assert (status == Ok);
+	
+	return graphics;
+}
+
 static void test_createFromHDC()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphicsOriginal;
@@ -28,12 +45,7 @@ static void test_createFromHDC()
 	GpGraphics *graphicsFromHdc;
 	TextRenderingHint textRenderingHint;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext (image, &graphicsOriginal);
-	assert(status == Ok);
+	graphicsOriginal = getImageGraphics (&image);
 
 	status = GdipSetTextRenderingHint (graphicsOriginal, TextRenderingHintClearTypeGridFit);
 	assert (status == Ok);
@@ -73,7 +85,6 @@ static void test_createFromHDC()
 
 static void test_createFromHDC2()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphicsOriginal;
@@ -81,12 +92,7 @@ static void test_createFromHDC2()
 	GpGraphics *graphicsFromHdc;
 	TextRenderingHint textRenderingHint;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext (image, &graphicsOriginal);
-	assert(status == Ok);
+	graphicsOriginal = getImageGraphics (&image);
 
 	status = GdipSetTextRenderingHint (graphicsOriginal, TextRenderingHintClearTypeGridFit);
 	assert (status == Ok);
@@ -166,18 +172,12 @@ static void test_createFromHWNDICM()
 
 static void test_hdc ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	HDC hdc;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext (image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetDC (NULL, &hdc);
 	assert (status == InvalidParameter);
@@ -213,18 +213,12 @@ static void test_hdc ()
 
 static void test_compositingMode ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	CompositingMode mode;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext (image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipSetCompositingMode (NULL, CompositingModeSourceCopy);
 	assert (status == InvalidParameter);
@@ -259,18 +253,12 @@ static void test_compositingMode ()
 
 static void test_compositingQuality ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	CompositingQuality quality;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext (image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetCompositingQuality(NULL, &quality);
 	assert (status == InvalidParameter);
@@ -305,19 +293,13 @@ static void test_compositingQuality ()
 
 static void test_renderingOrigin ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	int x;
 	int y;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext(image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetRenderingOrigin (NULL, &x, &y);
 	assert (status == InvalidParameter);
@@ -356,18 +338,12 @@ static void test_renderingOrigin ()
 
 static void test_textRenderingHint ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	TextRenderingHint textRenderingHint;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext (image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetTextRenderingHint (NULL, &textRenderingHint);
 	assert (status == InvalidParameter);
@@ -408,18 +384,12 @@ static void test_textRenderingHint ()
 
 static void test_textContrast ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	UINT textContrast;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext (image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetTextContrast (NULL, &textContrast);
 	assert (status == InvalidParameter);
@@ -460,18 +430,12 @@ static void test_textContrast ()
 
 static void test_smoothingMode ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	SmoothingMode smoothingMode;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext (image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetSmoothingMode (NULL, &smoothingMode);
 	assert (status == InvalidParameter);
@@ -540,18 +504,12 @@ static void test_smoothingMode ()
 
 static void test_pixelOffsetMode ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	PixelOffsetMode pixelOffsetMode;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext (image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetPixelOffsetMode (NULL, &pixelOffsetMode);
 	assert (status == InvalidParameter);
@@ -609,18 +567,12 @@ static void test_pixelOffsetMode ()
 
 static void test_interpolationMode ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	InterpolationMode interpolationMode;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext(image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 	
 	status = GdipGetInterpolationMode (NULL, &interpolationMode);
 	assert (status == InvalidParameter);
@@ -692,7 +644,6 @@ static void test_interpolationMode ()
 
 static void test_transform ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
@@ -700,12 +651,7 @@ static void test_transform ()
 	GpMatrix *setMatrix;
 	GpMatrix *nonInvertibleMatrix;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext(image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipCreateMatrix2 (0, 0, 0, 0, 0, 0, &matrix);
 	assert (status == Ok);
@@ -760,18 +706,12 @@ static void test_transform ()
 
 static void test_pageUnit ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	Unit pageUnit;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext(image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetPageUnit (NULL, &pageUnit);
 	assert (status == InvalidParameter);
@@ -820,18 +760,12 @@ static void test_pageUnit ()
 
 static void test_pageScale ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	REAL pageScale;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext(image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetPageScale (NULL, &pageScale);
 	assert (status == InvalidParameter);
@@ -886,20 +820,15 @@ static void test_pageScale ()
 	GdipDisposeImage (image);
 	GdipDeleteGraphics (graphics);
 }
+
 static void test_dpiX ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
-	float dpiX;
+	REAL dpiX;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext(image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetDpiX (NULL, &dpiX);
 	assert (status == InvalidParameter);
@@ -925,18 +854,12 @@ static void test_dpiX ()
 
 static void test_dpiY ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
 	REAL dpiY;
 
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext(image, &graphics);
-	assert(status == Ok);
+	graphics = getImageGraphics (&image);
 
 	status = GdipGetDpiY (NULL, &dpiY);
 	assert (status == InvalidParameter);
@@ -962,17 +885,11 @@ static void test_dpiY ()
 
 static void test_flush ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
-
-	filePath = createWchar ("test.bmp");
-	status = GdipLoadImageFromFile (filePath, &image);
-	assert (status == Ok);
-
-	status = GdipGetImageGraphicsContext (image, &graphics);
-	assert (status == Ok);
+	
+	graphics = getImageGraphics (&image);
 
 	status = GdipFlush (NULL, FlushIntentionFlush);
 	assert (status == InvalidParameter);
@@ -1003,14 +920,11 @@ static void test_flush ()
 
 static void test_delete ()
 {
-	WCHAR *filePath;
 	GpStatus status;
 	GpImage *image;
 	GpGraphics *graphics;
-
-	filePath = createWchar ("test.bmp");
-	GdipLoadImageFromFile (filePath, &image);
-	GdipGetImageGraphicsContext (image, &graphics);
+	
+	graphics = getImageGraphics (&image);
 	
 	HDC hdc;
 	status = GdipGetDC (graphics, &hdc);

--- a/tests/testhatchbrush.c
+++ b/tests/testhatchbrush.c
@@ -37,20 +37,20 @@ static void test_clone ()
     GdipCreateHatchBrush (HatchStyle10Percent, 1, 2, (GpHatch **)&brush);
 
     status = GdipCloneBrush (brush, &clone);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (clone && brush != clone);
 
     GdipGetBrushType (clone, &brushType);
-    assert (brushType == BrushTypeHatchFill);
+    assertEqualInt (brushType, BrushTypeHatchFill);
 
     GdipGetHatchStyle ((GpHatch *) clone, &hatchStyle);
-    assert (hatchStyle == HatchStyle10Percent);
+    assertEqualInt (hatchStyle, HatchStyle10Percent);
 
     GdipGetHatchForegroundColor ((GpHatch *) clone, &foregroundColor);
-    assert (foregroundColor == 1);
+    assertEqualInt (foregroundColor, 1);
 
     GdipGetHatchBackgroundColor ((GpHatch *) clone, &backgroundColor);
-    assert (backgroundColor == 2);
+    assertEqualInt (backgroundColor, 2);
 
     GdipDeleteBrush (brush);
     GdipDeleteBrush (clone);
@@ -63,29 +63,29 @@ static void test_createHatchBrush ()
     GpBrushType brushType;
 
     status = GdipCreateHatchBrush (HatchStyleMin, 1, 2, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (brush != NULL && "Expected the brush to be initialized.");
 
     status = GdipGetBrushType ((GpBrush *) brush, &brushType);
-    assert (status == Ok);
-    assert (brushType == BrushTypeHatchFill);
+    assertEqualInt (status, Ok);
+    assertEqualInt (brushType, BrushTypeHatchFill);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateHatchBrush (HatchStyleMax, 1, 2, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (brush != NULL && "Expected the brush to be initialized.");
 
     GdipDeleteBrush ((GpBrush *)brush);
 
     status = GdipCreateHatchBrush (HatchStyle05Percent, 1, 2, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateHatchBrush ((HatchStyle)(HatchStyleMin - 1), 1, 2, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateHatchBrush ((HatchStyle)(HatchStyleMax + 1), 1, 2, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 }
 
 static void test_getHatchStyle ()
@@ -97,14 +97,14 @@ static void test_getHatchStyle ()
     GdipCreateHatchBrush (HatchStyle05Percent, 1, 2, &brush);
 
     status = GdipGetHatchStyle (brush, &hatchStyle);
-    assert (status == Ok);
-    assert (hatchStyle == HatchStyle05Percent);
+    assertEqualInt (status, Ok);
+    assertEqualInt (hatchStyle, HatchStyle05Percent);
 
     status = GdipGetHatchStyle (NULL, &hatchStyle);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetHatchStyle (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -118,14 +118,14 @@ static void test_getForegroundColor ()
     GdipCreateHatchBrush (HatchStyle05Percent, 1, 2, &brush);
 
     status = GdipGetHatchForegroundColor (brush, &foregroundColor);
-    assert (status == Ok);
-    assert (foregroundColor == 1);
+    assertEqualInt (status, Ok);
+    assertEqualInt (foregroundColor, 1);
 
     status = GdipGetHatchForegroundColor (NULL, &foregroundColor);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetHatchForegroundColor (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -139,14 +139,14 @@ static void test_getBackgroundColor ()
     GdipCreateHatchBrush (HatchStyle05Percent, 1, 2, &brush);
 
     status = GdipGetHatchBackgroundColor (brush, &backgroundColor);
-    assert (status == Ok);
-    assert (backgroundColor == 2);
+    assertEqualInt (status, Ok);
+    assertEqualInt (backgroundColor, 2);
 
     status = GdipGetHatchBackgroundColor (NULL, &backgroundColor);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetHatchBackgroundColor (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -2,15 +2,15 @@
 #include <float.h>
 #include <math.h>
 
-int floatsEqual(float v1, float v2)
+BOOL floatsEqual (float v1, float v2)
 {
-    if (isnan (v1))
-        return isnan (v2);
+	if (isnan (v1))
+		return isnan (v2);
 
-    if (isinf (v1))
-        return isinf (v2);
+	if (isinf (v1))
+		return isinf (v2);
 
-    return fabs (v1 - v2) < 0.0001;
+	return fabs (v1 - v2) < 0.0001;
 }
 
 void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5, REAL e6)
@@ -40,3 +40,29 @@ void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5
 #define createWchar(c) L ##c
 #define freeWchar(c)
 #endif
+
+#define assertEqualInt(actual, expected) assertEqualIntImpl (actual, expected, __FILE__, __LINE__)
+void assertEqualIntImpl (INT actual, INT expected, const char *file, INT line)
+{
+    if (actual != expected)
+    {
+        printf ("Assertion failed on line %d in %s\n", line, file);
+        printf ("Expected: %d\n", actual);
+        printf ("Actual:   %d\n", expected);
+
+        abort ();
+    }
+}
+
+#define assertEqualFloat(actual, expected) assertEqualFloatImpl (actual, expected, __FILE__, __LINE__)
+void assertEqualFloatImpl (REAL actual, REAL expected, const char *file, INT line)
+{
+    if (!floatsEqual (actual, expected))
+    {
+        printf ("Assertion failed on line %d in %s\n", line, file);
+        printf ("Expected: %f\n", actual);
+        printf ("Actual:   %f\n", expected);
+
+        abort ();
+    }
+}

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -26,8 +26,8 @@ void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5
         !floatsEqual (elements[5], e6)) {
 
         fprintf (stderr, "Expected matrices to be equal\n");
-        fprintf (stderr, "Actual:   %f, %f, %f, %f, %f, %f\n", e1, e2, e3, e4, e5, e6);
-        fprintf (stderr, "Expected: %f, %f, %f, %f, %f, %f\n\n", elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
+        fprintf (stderr, "Expected: %f, %f, %f, %f, %f, %f\n", e1, e2, e3, e4, e5, e6);
+        fprintf (stderr, "Actual:   %f, %f, %f, %f, %f, %f\n\n", elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
 
         abort ();
     }

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -25,11 +25,11 @@ void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5
         !floatsEqual (elements[4], e5) ||
         !floatsEqual (elements[5], e6)) {
 
-        printf ("Expected matrices to be equal\n");
-        printf ("Actual:   %f, %f, %f, %f, %f, %f\n", e1, e2, e3, e4, e5, e6);
-        printf ("Expected: %f, %f, %f, %f, %f, %f\n\n", elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
+        fprintf (stderr, "Expected matrices to be equal\n");
+        fprintf (stderr, "Actual:   %f, %f, %f, %f, %f, %f\n", e1, e2, e3, e4, e5, e6);
+        fprintf (stderr, "Expected: %f, %f, %f, %f, %f, %f\n\n", elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
 
-        assert (FALSE);
+        abort ();
     }
 }
 
@@ -46,9 +46,9 @@ void assertEqualIntImpl (INT actual, INT expected, const char *file, INT line)
 {
     if (actual != expected)
     {
-        printf ("Assertion failed on line %d in %s\n", line, file);
-        printf ("Expected: %d\n", actual);
-        printf ("Actual:   %d\n", expected);
+        fprintf (stderr, "Assertion failed on line %d in %s\n", line, file);
+        fprintf (stderr, "Expected: %d\n", expected);
+        fprintf (stderr, "Actual:   %d\n", actual);
 
         abort ();
     }
@@ -59,9 +59,9 @@ void assertEqualFloatImpl (REAL actual, REAL expected, const char *file, INT lin
 {
     if (!floatsEqual (actual, expected))
     {
-        printf ("Assertion failed on line %d in %s\n", line, file);
-        printf ("Expected: %f\n", actual);
-        printf ("Actual:   %f\n", expected);
+        fprintf (stderr, "Assertion failed on line %d in %s\n", line, file);
+        fprintf (stderr, "Expected: %f\n", expected);
+        fprintf (stderr, "Actual:   %f\n", actual);
 
         abort ();
     }

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -32,3 +32,9 @@ void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5
         assert (FALSE);
     }
 }
+
+#if !defined(USE_WINDOWS_LIBGDIPLUS)
+#define createWchar(c) g_utf8_to_utf16 (c, -1, NULL, NULL, NULL);
+#else
+#define createWchar(c) L ##c
+#endif

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -35,6 +35,8 @@ void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5
 
 #if !defined(USE_WINDOWS_LIBGDIPLUS)
 #define createWchar(c) g_utf8_to_utf16 (c, -1, NULL, NULL, NULL);
+#define freeWchar(c) g_free(c)
 #else
 #define createWchar(c) L ##c
+#define freeWchar(c)
 #endif

--- a/tests/testlineargradientbrush.c
+++ b/tests/testlineargradientbrush.c
@@ -37,26 +37,26 @@ static void verifyLineGradientBrush (GpLineGradient *brush, REAL x, REAL y, REAL
     GdipCreateMatrix (&brushTransform);
 
     status = GdipGetBrushType (brush, &brushType);
-    assert (brushType == BrushTypeLinearGradient);
+    assertEqualInt (brushType, BrushTypeLinearGradient);
 
     status = GdipGetLineRect (brush, &rect);
-    assert (status == Ok);
-    assert (rect.X == x);
-    assert (rect.Y == y);
-    assert (rect.Width == width);
-    assert (rect.Height == height);
+    assertEqualFloat (status, Ok);
+    assertEqualFloat (rect.X, x);
+    assertEqualFloat (rect.Y, y);
+    assertEqualFloat (rect.Width, width);
+    assertEqualFloat (rect.Height, height);
 
     status = GdipGetLineColors (brush, colors);
-    assert (status == Ok);
-    assert (colors[0] == startColor);
-    assert (colors[1] == endColor);
+    assertEqualInt (status, Ok);
+    assertEqualInt (colors[0], startColor);
+    assertEqualInt (colors[1], endColor);
 
     status = GdipGetLineWrapMode (brush, &wrapMode);
-    assert (status == Ok);
-    assert (wrapMode == expectedWrapMode);
+    assertEqualInt (status, Ok);
+    assertEqualInt (wrapMode, expectedWrapMode);
 
     status = GdipGetLineTransform (brush, brushTransform);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyMatrix (brushTransform, e1, e2, e3, e4, e5, e6);
 
     GdipDeleteMatrix (brushTransform);
@@ -70,30 +70,30 @@ static void test_createLineBrush ()
     GpPointF point2 = { 2, 3 };
 
     status = GdipCreateLineBrush (&point1, &point2, 10, 11, WrapModeTile, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTile, 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrush (&point2, &point1, 10, 11, (WrapMode)(WrapModeTile - 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeTile - 1), -1, 2, -0.8f, -0.4f, 6.2f, 2.6f);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrush (&point1, &point2, 10, 11, (WrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
 
     status = GdipCreateLineBrush (NULL, &point2, 10, 11, WrapModeTile, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrush (&point1, NULL, 10, 11, WrapModeTile, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrush (&point1, &point2, 10, 11, WrapModeClamp, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrush (&point1, &point2, 10, 11, WrapModeTile, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -106,30 +106,30 @@ static void test_createLineBrushI ()
     GpPoint point2 = { 2, 3 };
 
     status = GdipCreateLineBrushI (&point1, &point2, 10, 11, WrapModeTile, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTile, 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushI (&point2, &point1, 10, 11, (WrapMode)(WrapModeTile - 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeTile - 1), -1, 2, -0.8f, -0.4f, 6.2f, 2.6f);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushI (&point1, &point2, 10, 11, (WrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
 
     status = GdipCreateLineBrushI (NULL, &point2, 10, 11, WrapModeTile, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushI (&point1, NULL, 10, 11, WrapModeTile, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushI (&point1, &point2, 10, 11, WrapModeClamp, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushI (&point1, &point2, 10, 11, WrapModeTile, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -141,59 +141,59 @@ static void test_createLineBrushFromRect ()
     GpRectF rect1 = { 1, 3, 1, 2 };
 
     status = GdipCreateLineBrushFromRect (&rect1, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTile, 1, 0, 0, 1, 0, 0);
     GdipDeleteBrush ((GpBrush *) brush);
 
     GpRectF rect2 = { 1, 3, -1, -2 };
     status = GdipCreateLineBrushFromRect (&rect2, 10, 11, LinearGradientModeBackwardDiagonal, (WrapMode)(WrapModeTile - 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, -1, -2, 10, 11, (WrapMode)(WrapModeTile - 1), -1, 2, -0.5, -1, 2, 3);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRect (&rect1, 10, 11, LinearGradientModeForwardDiagonal, (WrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1, 2, -0.5, 1, 2, -3);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRect (&rect1, 10, 11, LinearGradientModeVertical, WrapModeTileFlipX, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipX, 0, 2, -0.5, 0, 3.5, 1);
 
     status = GdipCreateLineBrushFromRect (NULL, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GpRectF rect3 = { 1, 3, 0, 1 };
     status = GdipCreateLineBrushFromRect (&rect3, 10, 11, LinearGradientModeBackwardDiagonal, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing.
 #if defined(USE_WINDOWS_GDIPLUS)
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 #endif
 
     GpRectF rect4 = { 1, 3, 1, 0 };
     status = GdipCreateLineBrushFromRect (&rect4, 10, 11, LinearGradientModeBackwardDiagonal, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
 #if defined(USE_WINDOWS_GDIPLUS)
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 #endif
 
     status = GdipCreateLineBrushFromRect (&rect1, 10, 11, (LinearGradientMode)(LinearGradientModeHorizontal - 1), WrapModeTile, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateLineBrushFromRect (&rect1, 10, 11, (LinearGradientMode)(LinearGradientModeBackwardDiagonal + 1), WrapModeTile, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateLineBrushFromRect (NULL, 10, 11, (LinearGradientMode)(LinearGradientModeBackwardDiagonal + 1), WrapModeTile, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushFromRect (&rect1, 10, 11, (LinearGradientMode)(LinearGradientModeBackwardDiagonal + 1), WrapModeTile, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushFromRect (&rect1, 10, 11, LinearGradientModeHorizontal, WrapModeClamp, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushFromRect (&rect1, 10, 11, LinearGradientModeHorizontal, WrapModeTile, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -205,59 +205,59 @@ static void test_createLineBrushFromRectI ()
     GpRect rect1 = { 1, 3, 1, 2 };
 
     status = GdipCreateLineBrushFromRectI (&rect1, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTile, 1, 0, 0, 1, 0, 0);
     GdipDeleteBrush ((GpBrush *) brush);
 
     GpRect rect2 = { 1, 3, -1, -2 };
     status = GdipCreateLineBrushFromRectI (&rect2, 10, 11, LinearGradientModeBackwardDiagonal, (WrapMode)(WrapModeTile - 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, -1, -2, 10, 11, (WrapMode)(WrapModeTile - 1), -1, 2, -0.5, -1, 2, 3);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRectI (&rect1, 10, 11, LinearGradientModeForwardDiagonal, (WrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1, 2, -0.5, 1, 2, -3);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRectI (&rect1, 10, 11, LinearGradientModeVertical, WrapModeTileFlipX, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipX, 0, 2, -0.5, 0, 3.5, 1);
 
     status = GdipCreateLineBrushFromRectI (NULL, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GpRect rect3 = { 1, 3, 0, 1 };
     status = GdipCreateLineBrushFromRectI (&rect3, 10, 11, LinearGradientModeBackwardDiagonal, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
 #if defined(USE_WINDOWS_GDIPLUS)
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 #endif
 
     GpRect rect4 = { 1, 3, 1, 0 };
     status = GdipCreateLineBrushFromRectI (&rect4, 10, 11, LinearGradientModeBackwardDiagonal, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
 #if defined(USE_WINDOWS_GDIPLUS)
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 #endif
 
     status = GdipCreateLineBrushFromRectI (&rect1, 10, 11, (LinearGradientMode)(LinearGradientModeHorizontal - 1), WrapModeTile, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateLineBrushFromRectI (&rect1, 10, 11, (LinearGradientMode)(LinearGradientModeBackwardDiagonal + 1), WrapModeTile, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateLineBrushFromRectI (NULL, 10, 11, (LinearGradientMode)(LinearGradientModeBackwardDiagonal + 1), WrapModeTile, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushFromRectI (&rect1, 10, 11, (LinearGradientMode)(LinearGradientModeBackwardDiagonal + 1), WrapModeTile, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushFromRectI (&rect1, 10, 11, LinearGradientModeHorizontal, WrapModeClamp, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushFromRectI (&rect1, 10, 11, LinearGradientModeHorizontal, WrapModeTile, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -269,57 +269,57 @@ static void test_createLineBrushFromRectWithAngle ()
     GpRectF rect1 = { 1, 3, 1, 2 };
 
     status = GdipCreateLineBrushFromRectWithAngle (&rect1, 10, 11, 0, TRUE, WrapModeTile, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTile, 1, 0, 0, 1, 0, 0);
     GdipDeleteBrush ((GpBrush *) brush);
 
     GpRectF rect2 = { 1, 3, -1, -2 };
     status = GdipCreateLineBrushFromRectWithAngle (&rect2, 10, 11, 135, TRUE, (WrapMode)(WrapModeTile - 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, -1, -2, 10, 11, (WrapMode)(WrapModeTile - 1), -1, 2, -0.5, -1, 2, 3);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRectWithAngle (&rect2, 10, 11, -225, FALSE, (WrapMode)(WrapModeTile - 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, -1, -2, 10, 11, (WrapMode)(WrapModeTile - 1), -1.500000, 1.500000, -0.750000, -0.750000, 2.750000, 2.750000);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRectWithAngle (&rect1, 10, 11, 405, TRUE, (WrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1, 2, -0.5, 1, 2, -3);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRectWithAngle (&rect1, 10, 11, 45, FALSE, (WrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1.5, 1.5, -0.75, 0.75, 2.25, -1.25);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRectWithAngle (&rect1, 10, 11, 90, TRUE, WrapModeTileFlipX, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipX, 0, 2, -0.5, 0, 3.5, 1);
 
     status = GdipCreateLineBrushFromRectWithAngle (NULL, 10, 11, 90, TRUE, WrapModeTile, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GpRectF rect3 = { 1, 3, 0, 1 };
     status = GdipCreateLineBrushFromRectWithAngle (&rect3, 10, 11, 90, TRUE, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
 #if defined(USE_WINDOWS_GDIPLUS)
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 #endif
 
     GpRectF rect4 = { 1, 3, 1, 0 };
     status = GdipCreateLineBrushFromRectWithAngle (&rect4, 10, 11, 90, TRUE, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
 #if defined(USE_WINDOWS_GDIPLUS)
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 #endif
 
     status = GdipCreateLineBrushFromRectWithAngle (&rect1, 10, 11, 90, TRUE, WrapModeClamp, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushFromRectWithAngle (&rect1, 10, 11, 90, TRUE, WrapModeTile, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -331,57 +331,57 @@ static void test_createLineBrushFromRectWithAngleI ()
     GpRect rect1 = { 1, 3, 1, 2 };
 
     status = GdipCreateLineBrushFromRectWithAngleI (&rect1, 10, 11, 0, TRUE, WrapModeTile, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTile, 1, 0, 0, 1, 0, 0);
     GdipDeleteBrush ((GpBrush *) brush);
 
     GpRect rect2 = { 1, 3, -1, -2 };
     status = GdipCreateLineBrushFromRectWithAngleI (&rect2, 10, 11, 135, TRUE, (WrapMode)(WrapModeTile - 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, -1, -2, 10, 11, (WrapMode)(WrapModeTile - 1), -1, 2, -0.5, -1, 2, 3);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRectWithAngleI (&rect2, 10, 11, -225, FALSE, (WrapMode)(WrapModeTile - 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, -1, -2, 10, 11, (WrapMode)(WrapModeTile - 1), -1.500000, 1.500000, -0.750000, -0.750000, 2.750000, 2.750000);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRectWithAngleI (&rect1, 10, 11, 405, TRUE, (WrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1, 2, -0.5, 1, 2, -3);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRectWithAngleI (&rect1, 10, 11, 45, FALSE, (WrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1.5, 1.5, -0.75, 0.75, 2.25, -1.25);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateLineBrushFromRectWithAngleI (&rect1, 10, 11, 90, TRUE, WrapModeTileFlipX, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipX, 0, 2, -0.5, 0, 3.5, 1);
 
     status = GdipCreateLineBrushFromRectWithAngleI (NULL, 10, 11, 90, TRUE, WrapModeTile, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GpRect rect3 = { 1, 3, 0, 1 };
     status = GdipCreateLineBrushFromRectWithAngleI (&rect3, 10, 11, 90, TRUE, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
 #if defined(USE_WINDOWS_GDIPLUS)
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 #endif
 
     GpRect rect4 = { 1, 3, 1, 0 };
     status = GdipCreateLineBrushFromRectWithAngleI (&rect4, 10, 11, 90, TRUE, WrapModeTileFlipXY, &brush);
     // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
 #if defined(USE_WINDOWS_GDIPLUS)
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 #endif
 
     status = GdipCreateLineBrushFromRectWithAngleI (&rect1, 10, 11, 90, TRUE, WrapModeClamp, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateLineBrushFromRectWithAngleI (&rect1, 10, 11, 90, TRUE, WrapModeTile, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -396,14 +396,14 @@ static void test_setLineColors ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipSetLineColors (brush, 1, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineColors (brush, colors);
-    assert (colors[0] == 1);
-    assert (colors[1] == 2);
+    assertEqualInt (colors[0], 1);
+    assertEqualInt (colors[1], 2);
 
     status = GdipSetLineColors (NULL, 1, 2);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -418,10 +418,10 @@ static void test_getLineColors ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipGetLineColors (NULL, colors);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineColors (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -436,10 +436,10 @@ static void test_getLineRect ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipGetLineRect (NULL, &lineRect);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineRect (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -454,16 +454,16 @@ static void test_getLineRectI ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipGetLineRectI (brush, &lineRect);
-    assert (rect.X == 1);
-    assert (rect.Y == 3);
-    assert (rect.Width == 1);
-    assert (rect.Height == 2);
+    assertEqualInt (rect.X, 1);
+    assertEqualInt (rect.Y, 3);
+    assertEqualInt (rect.Width, 1);
+    assertEqualInt (rect.Height, 2);
 
     status = GdipGetLineRectI (NULL, &lineRect);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineRectI (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -478,13 +478,13 @@ static void test_setLineGammaCorrection ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipSetLineGammaCorrection (brush, TRUE);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineGammaCorrection (brush, &useGammaCorrection);
     assert (useGammaCorrection == TRUE);
 
     status = GdipSetLineGammaCorrection (NULL, TRUE);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -499,14 +499,14 @@ static void test_getLineGammaCorrection ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipGetLineGammaCorrection (brush, &useGammaCorrection);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (useGammaCorrection == FALSE);
 
     status = GdipGetLineGammaCorrection (NULL, &useGammaCorrection);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineGammaCorrection (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -521,14 +521,14 @@ static void test_getLineBlendCount ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipGetLineBlendCount (brush, &blendCount);
-    assert (status == Ok);
-    assert (blendCount == 1);
+    assertEqualInt (status, Ok);
+    assertEqualInt (blendCount, 1);
 
     status = GdipGetLineBlendCount (NULL, &blendCount);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineBlendCount (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -546,37 +546,37 @@ static void test_getLineBlend ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipGetLineBlend (brush, blend, positions, 1);
-    assert (status == Ok);
-    assert (floatsEqual (blend[0], 1));
+    assertEqualInt (status, Ok);
+    assertEqualFloat (blend[0], 1);
     // FIXME: it appears that Windows 10+ versions of GDI+ don't copy anything to positions.
-    // assert (floatsEqual (positions[0], 0));
+    // assertEqualFloat (positions[0], 0);
 
     status = GdipGetLineBlend (brush, blend, positions, 2);
-    assert (status == Ok);
-    assert (floatsEqual (blend[0], 1.0));
+    assertEqualInt (status, Ok);
+    assertEqualFloat (blend[0], 1.0);
     // FIXME: it appears that Windows 10+ versions of GDI+ don't copy anything to positions.
-    // assert (floatsEqual (positions[0], 0));
+    // assertEqualFloat (positions[0], 0);
 
     status = GdipSetLineBlend (brush, largeBlend, largePositions, 3);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetLineBlend (brush, blend, positions, 1);
-    assert (status == InsufficientBuffer);
+    assertEqualInt (status, InsufficientBuffer);
 
     status = GdipGetLineBlend (NULL, blend, positions, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineBlend (brush, NULL, positions, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineBlend (brush, blend, NULL, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineBlend (brush, blend, positions, 0);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineBlend (brush, blend, positions, -1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -613,70 +613,70 @@ static void test_setLineBlend ()
 
     // Count of 1.
     status = GdipSetLineBlend (brush, blend1, positions1, 1);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetLineBlend (brush, destBlend1, destPositions1, 1);
-    assert (status == Ok);
-    assert (destBlend1[0] == 3);
+    assertEqualInt (status, Ok);
+    assertEqualInt (destBlend1[0], 3);
     // FIXME: it appears GDI+ ignores the position value if there is a single element.
-    // assert (floatsEqual (destPositions1[0], 0));
+    // assertEqualFloat (destPositions1[0], 0);
 
     // Count of 2.
     status = GdipSetLineBlend (brush, blend2, positions2, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetLineBlend (brush, destBlend2, destPositions2, 2);
-    assert (status == Ok);
-    assert (destBlend2[0] == -1);
-    assert (destBlend2[1] == 0);
-    assert (destPositions2[0] == 0);
-    assert (destPositions2[1] == 1);
+    assertEqualInt (status, Ok);
+    assertEqualInt (destBlend2[0], -1);
+    assertEqualInt (destBlend2[1], 0);
+    assertEqualInt (destPositions2[0], 0);
+    assertEqualInt (destPositions2[1], 1);
 
     // Count of 3.
     status = GdipSetLineBlend (brush, blend3, positions3, 3);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetLineBlend (brush, destBlend3, destPositions3, 3);
-    assert (status == Ok);
-    assert (destBlend3[0] == 1);
-    assert (destBlend3[1] == 2);
-    assert (destBlend3[2] == 3);
-    assert (destPositions3[0] == 0);
-    assert (destPositions3[1] == 0.5);
-    assert (destPositions3[2] == 1);
+    assertEqualInt (status, Ok);
+    assertEqualFloat (destBlend3[0], 1);
+    assertEqualFloat (destBlend3[1], 2);
+    assertEqualFloat (destBlend3[2], 3);
+    assertEqualFloat (destPositions3[0], 0);
+    assertEqualFloat (destPositions3[1], 0.5);
+    assertEqualFloat (destPositions3[2], 1);
 
     // Should clear the existing blend.
     status = GdipSetLinePresetBlend (brush, linePresetBlend, linePresetPositions, 3);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetLineBlend (brush, destBlend2, destPositions2, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetLinePresetBlendCount (brush, &presetBlendCount);
-    assert (status == Ok);
-    assert (presetBlendCount == 0);
+    assertEqualInt (status, Ok);
+    assertEqualInt (presetBlendCount, 0);
 
     // Negative tests.
     status = GdipSetLineBlend (NULL, blend3, positions3, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineBlend (brush, NULL, positions3, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineBlend (brush, blend3, NULL, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineBlend (brush, blend2, invalidPositions1, 2);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineBlend (brush, blend2, invalidPositions2, 2);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineBlend (brush, blend3, positions3, 0);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineBlend (brush, blend3, positions3, -1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -691,14 +691,14 @@ static void test_getLinePresetBlendCount ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipGetLinePresetBlendCount (brush, &blendCount);
-    assert (status == Ok);
-    assert (blendCount == 0);
+    assertEqualInt (status, Ok);
+    assertEqualInt (blendCount, 0);
 
     status = GdipGetLinePresetBlendCount (NULL, &blendCount);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLinePresetBlendCount (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -714,25 +714,25 @@ static void test_getLinePresetBlend ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipGetLinePresetBlend (brush, blend, positions, 2);
-    assert (status == GenericError);
+    assertEqualInt (status, GenericError);
 
     status = GdipGetLinePresetBlend (NULL, blend, positions, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLinePresetBlend (brush, NULL, positions, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLinePresetBlend (brush, blend, NULL, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLinePresetBlend (brush, blend, positions, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLinePresetBlend (brush, blend, positions, 0);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLinePresetBlend (brush, blend, positions, -1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -764,64 +764,64 @@ static void test_setLinePresetBlend ()
 
     // Count of 2.
     status = GdipSetLinePresetBlend (brush, blend2, positions2, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetLinePresetBlend (brush, destBlend2, destPositions2, 2);
-    assert (status == Ok);
-    assert (destBlend2[0] == 1);
-    assert (destBlend2[1] == 0);
-    assert (destPositions2[0] == 0);
-    assert (destPositions2[1] == 1);
+    assertEqualInt (status, Ok);
+    assertEqualInt (destBlend2[0], 1);
+    assertEqualInt (destBlend2[1], 0);
+    assertEqualInt (destPositions2[0], 0);
+    assertEqualInt (destPositions2[1], 1);
 
     // Count of 3.
     status = GdipSetLinePresetBlend (brush, blend3, positions3, 3);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetLinePresetBlend (brush, destBlend3, destPositions3, 3);
-    assert (status == Ok);
-    assert (destBlend3[0] == 1);
-    assert (destBlend3[1] == 2);
-    assert (destBlend3[2] == 3);
-    assert (destPositions3[0] == 0);
-    assert (destPositions3[1] == 0.5);
-    assert (destPositions3[2] == 1);
+    assertEqualInt (status, Ok);
+    assertEqualInt (destBlend3[0], 1);
+    assertEqualInt (destBlend3[1], 2);
+    assertEqualInt (destBlend3[2], 3);
+    assertEqualInt (destPositions3[0], 0);
+    assertEqualFloat (destPositions3[1], 0.5);
+    assertEqualInt (destPositions3[2], 1);
 
     // Should clear the existing blend.
     status = GdipSetLineBlend (brush, lineBlend, linePositions, 3);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetLinePresetBlend (brush, destBlend2, destPositions2, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetLineBlendCount (brush, &blendCount);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     // FIXME: this returns 2 with GDI+.
-    // assert (blendCount == 2);
+    // assertEqualInt (blendCount, 2);
 
     // Negative tests.
     status = GdipSetLinePresetBlend (NULL, blend3, positions3, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLinePresetBlend (brush, NULL, positions3, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLinePresetBlend (brush, blend3, NULL, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLinePresetBlend (brush, blend2, invalidPositions1, 2);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLinePresetBlend (brush, blend2, invalidPositions2, 2);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLinePresetBlend (brush, blend3, positions3, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLinePresetBlend (brush, blend3, positions3, 0);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLinePresetBlend (brush, blend3, positions3, -1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -835,28 +835,28 @@ static void test_setLineSigmaBlend ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipSetLineSigmaBlend (brush, 0, 0.5f);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetLineSigmaBlend (brush, 0.5f, 1);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetLineSigmaBlend (brush, 1, 0);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetLineSigmaBlend (NULL, 0.5f, 0.5f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineSigmaBlend (brush, -0.01f, 0.5f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineSigmaBlend (brush, 1.01f, 0.5f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineSigmaBlend (brush, 0.5f, -0.01f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineSigmaBlend (brush, 0.5f, 1.01f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -870,28 +870,28 @@ static void test_setLineLinearBlend ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
     status = GdipSetLineLinearBlend (brush, 0, 0.5f);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetLineLinearBlend (brush, 0.5f, 1);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetLineLinearBlend (brush, 1, 0);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetLineLinearBlend (NULL, 0.5f, 0.5f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineLinearBlend (brush, -0.01f, 0.5);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineLinearBlend (brush, 1.01f, 0.5);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineLinearBlend (brush, 0.5f, -0.01f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineLinearBlend (brush, 0.5f, 1.01f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -906,28 +906,28 @@ static void test_setLineWrapMode ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTileFlipY, &brush);
 
     status = GdipSetLineWrapMode (brush, WrapModeTileFlipY);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineWrapMode (brush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeTileFlipY);
 
     status = GdipSetLineWrapMode (brush, (WrapMode)(WrapModeTile - 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineWrapMode (brush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeTileFlipY);
 
     status = GdipSetLineWrapMode (brush, (WrapMode)(WrapModeClamp + 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineWrapMode (brush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeTileFlipY);
 
     status = GdipSetLineWrapMode (NULL, WrapModeTile);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineWrapMode (brush, WrapModeClamp);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -942,10 +942,10 @@ static void test_getLineWrapMode ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTileFlipY, &brush);
 
     status = GdipGetLineWrapMode (NULL, &wrapMode);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineWrapMode (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -961,10 +961,10 @@ static void test_getLineTransform ()
     GdipCreateMatrix (&transform);
 
     status = GdipGetLineTransform (NULL, transform);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLineTransform (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (transform);
@@ -983,7 +983,7 @@ static void test_setLineTransform ()
     GdipCreateMatrix (&transform);
 
     status = GdipSetLineTransform (brush, matrix);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     assert (transform != matrix && "Expected new matrix to be a clone.");
@@ -996,10 +996,10 @@ static void test_setLineTransform ()
 
     // Negative tests.
     status = GdipSetLineTransform (NULL, transform);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetLineTransform (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (matrix);
@@ -1021,13 +1021,13 @@ static void test_resetLineTransform ()
     GdipSetLineTransform (brush, matrix);
 
     status = GdipResetLineTransform (brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 1, 0, 0, 1, 0, 0);
 
     status = GdipResetLineTransform (NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (matrix);
@@ -1053,7 +1053,7 @@ static void test_multiplyLineTransform ()
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipMultiplyLineTransform (brush, matrix, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
@@ -1062,14 +1062,14 @@ static void test_multiplyLineTransform ()
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipMultiplyLineTransform (brush, matrix, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
 
     // Null matrix - nop.
     status = GdipMultiplyLineTransform (brush, NULL, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
@@ -1078,7 +1078,7 @@ static void test_multiplyLineTransform ()
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipMultiplyLineTransform (brush, matrix, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
@@ -1087,17 +1087,17 @@ static void test_multiplyLineTransform ()
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipMultiplyLineTransform (brush, matrix, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
 
     // Negative tests.
     status = GdipMultiplyLineTransform (NULL, matrix, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipMultiplyLineTransform (brush, nonInvertibleMatrix, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (originalTransform);
@@ -1122,7 +1122,7 @@ static void test_translateLineTransform ()
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipTranslateLineTransform (brush, 5, 6, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 1, 2, 3, 4, 10, 12);
@@ -1131,20 +1131,20 @@ static void test_translateLineTransform ()
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipTranslateLineTransform (brush, 5, 6, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 1, 2, 3, 4, 28, 40);
 
     // Negative tests.
     status = GdipTranslateLineTransform (NULL, 1, 1, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipTranslateLineTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipTranslateLineTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (originalTransform);
@@ -1167,7 +1167,7 @@ static void test_scaleLineTransform ()
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipScaleLineTransform (brush, 0.5, 0.75, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 0.5, 1.5, 1.5, 3, 2.5, 4.5);
@@ -1176,20 +1176,20 @@ static void test_scaleLineTransform ()
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipScaleLineTransform (brush, 0.5, 0.75, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 0.5, 1, 2.25, 3, 5, 6);
 
     // Negative tests.
     status = GdipScaleLineTransform (NULL, 1, 1, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipScaleLineTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipScaleLineTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (originalTransform);
@@ -1212,7 +1212,7 @@ static void test_rotateLineTransform ()
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipRotateLineTransform (brush, 90, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, -2, 1, -4, 3, -6, 5);
@@ -1221,20 +1221,20 @@ static void test_rotateLineTransform ()
     GdipSetLineTransform (brush, originalTransform);
 
     status = GdipRotateLineTransform (brush, 90, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 3, 4, -1, -2, 5, 6);
 
     // Negative tests.
     status = GdipRotateLineTransform (NULL, 90, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipRotateLineTransform (brush, 90, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipRotateLineTransform (brush, 90, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (originalTransform);
@@ -1269,33 +1269,33 @@ static void test_clone ()
     GdipSetLineGammaCorrection (brush, TRUE);
 
     status = GdipCloneBrush ((GpBrush *) brush, &clonedBrush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (clonedBrush && clonedBrush != brush);
 
     GdipGetBrushType (clonedBrush, &brushType);
-    assert (brushType == BrushTypeLinearGradient);
+    assertEqualInt (brushType, BrushTypeLinearGradient);
 
     GdipGetLineWrapMode ((GpLineGradient *) clonedBrush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeTileFlipY);
 
     GdipGetLineColors (brush, colors);
-    assert (colors[0] == 10);
-    assert (colors[1] == 11);
+    assertEqualInt (colors[0], 10);
+    assertEqualInt (colors[1], 11);
 
     GdipGetLineRect ((GpLineGradient *) clonedBrush, &rect);
-    assert (rect.X == 1);
-    assert (rect.Y == 3);
-    assert (rect.Width == 1);
-    assert (rect.Height == 2);
+    assertEqualInt (rect.X, 1);
+    assertEqualInt (rect.Y, 3);
+    assertEqualInt (rect.Width, 1);
+    assertEqualInt (rect.Height, 2);
 
     GdipGetLineBlendCount ((GpLineGradient *) clonedBrush, &blendCount);
-    assert (blendCount == 2);
+    assertEqualInt (blendCount, 2);
 
     GdipGetLineBlend ((GpLineGradient *) clonedBrush, blendResult, positionsResult, 2);
-    assert (blendResult[0] == 1);
-    assert (blendResult[1] == 2);
-    assert (positionsResult[0] == 0);
-    assert (positionsResult[1] == 1);
+    assertEqualInt (blendResult[0], 1);
+    assertEqualInt (blendResult[1], 2);
+    assertEqualInt (positionsResult[0], 0);
+    assertEqualInt (positionsResult[1], 1);
 
     GdipGetLineTransform ((GpLineGradient *) clonedBrush, matrix);
     verifyMatrix (matrix, 1, 2, 3, 4, 5, 6);

--- a/tests/testmatrix.c
+++ b/tests/testmatrix.c
@@ -29,12 +29,12 @@ static void test_createMatrix ()
 	GpMatrix *matrix;
 
 	status = GdipCreateMatrix (&matrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 1, 0, 0, 1, 0, 0);
 
 	// Negative tests.
 	status = GdipCreateMatrix (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -45,12 +45,12 @@ static void test_createMatrix2 ()
 	GpMatrix *matrix;
 
 	status = GdipCreateMatrix2 (1, 2, 3, 4, 5, 6, &matrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 1, 2, 3, 4, 5, 6);
 
 	// Negative tests.
 	status = GdipCreateMatrix2 (1, 2, 3, 4, 5, 6, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -70,18 +70,18 @@ static void test_createMatrix3 ()
 	points[2].Y = 0;
 
 	status = GdipCreateMatrix3 (&rect, points, &matrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, -2.75f, 0.75f, -0.4f, -1.4f, 28.15f, 18.65f);
 
 	// Negative tests.
 	status = GdipCreateMatrix3 (NULL, points, &matrix);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateMatrix3 (&rect, NULL, &matrix);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateMatrix3 (&rect, points, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -101,18 +101,18 @@ static void test_createMatrix3I ()
 	points[2].Y = 0;
 
 	status = GdipCreateMatrix3I (&rect, points, &matrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, -2.75f, 0.75f, -0.4f, -1.4f, 28.15f, 18.65f);
 
 	// Negative tests.
 	status = GdipCreateMatrix3I (NULL, points, &matrix);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateMatrix3I (&rect, NULL, &matrix);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreateMatrix3I (&rect, points, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -126,16 +126,16 @@ static void test_cloneMatrix ()
 	GdipCreateMatrix2 (1, 2, 3, 4, 5, 6, &matrix);
 
 	status = GdipCloneMatrix (matrix, &clonedMatrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (clonedMatrix && clonedMatrix != matrix);
 	verifyMatrix (clonedMatrix, 1, 2, 3, 4, 5, 6);
 
 	// Negative tests.
 	status = GdipCloneMatrix (NULL, &clonedMatrix);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCloneMatrix (matrix, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 	GdipDeleteMatrix (clonedMatrix);
@@ -149,11 +149,11 @@ static void test_deleteMatrix ()
 	GdipCreateMatrix (&matrix);
 
 	status = GdipDeleteMatrix (matrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	// Negative tests.
 	status = GdipDeleteMatrix (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 }
 
 static void test_setMatrixElements ()
@@ -164,12 +164,12 @@ static void test_setMatrixElements ()
 	GdipCreateMatrix (&matrix);
 
 	status = GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 1, 2, 3, 4, 5, 6);
 
 	// Negative tests.
 	status = GdipSetMatrixElements (NULL, 1, 2, 3, 4, 5, 6);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 }
 
 static void test_multiplyMatrix ()
@@ -186,42 +186,42 @@ static void test_multiplyMatrix ()
 	// MatrixOrderAppend.
 	GdipSetMatrixElements (originalTransform, 1, 2, 3, 4, 5, 6);
 	status = GdipMultiplyMatrix (originalTransform, matrix, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (originalTransform, 10, 13, 22, 29, 40, 52);
 
 	// MatrixOrderPrepend.
 	GdipSetMatrixElements (originalTransform, 1, 2, 3, 4, 5, 6);
 	status = GdipMultiplyMatrix (originalTransform, matrix, MatrixOrderPrepend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (originalTransform, 11, 16, 19, 28, 32, 46);
 
 	// Non invertible matrix.
 	GdipSetMatrixElements (originalTransform, 1, 2, 3, 4, 5, 6);
 	status = GdipMultiplyMatrix (originalTransform, nonInvertibleMatrix, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (originalTransform, 287, 56, 697, 136, 1154, 246);
 
 	// Negative tests.
 	status = GdipMultiplyMatrix (NULL, matrix, MatrixOrderAppend);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipMultiplyMatrix (originalTransform, NULL, MatrixOrderAppend);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipMultiplyMatrix (originalTransform, originalTransform, MatrixOrderAppend);
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipMultiplyMatrix (originalTransform, originalTransform, (MatrixOrder)(MatrixOrderPrepend - 1));
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipMultiplyMatrix (originalTransform, originalTransform, (MatrixOrder)(MatrixOrderAppend + 1));
-	assert (status == ObjectBusy);
+	assertEqualInt (status, ObjectBusy);
 
 	status = GdipMultiplyMatrix (originalTransform, NULL, (MatrixOrder)(MatrixOrderPrepend - 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipMultiplyMatrix (originalTransform, NULL, (MatrixOrder)(MatrixOrderAppend + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (originalTransform);
 	GdipDeleteMatrix (matrix);
@@ -238,30 +238,30 @@ static void test_translateMatrix ()
 	// MatrixOrderAppend.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipTranslateMatrix (matrix, 5, 6, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 1, 2, 3, 4, 10, 12);
 
 	// MatrixOrderPrepend.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipTranslateMatrix (matrix, 5, 6, MatrixOrderPrepend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 1, 2, 3, 4, 28, 40);
 
 	// Zero value.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipTranslateMatrix (matrix, 0, 0, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 1, 2, 3, 4, 5, 6);
 
 	// Negative tests.
 	status = GdipTranslateMatrix (NULL, 1, 2, MatrixOrderAppend);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipTranslateMatrix (matrix, 1, 2, (MatrixOrder)(MatrixOrderPrepend - 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipTranslateMatrix (matrix, 1, 2, (MatrixOrder)(MatrixOrderAppend + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -276,36 +276,36 @@ static void test_scaleMatrix ()
 	// MatrixOrderAppend.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipScaleMatrix (matrix, 0.5, 0.75, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 0.5, 1.5, 1.5, 3, 2.5, 4.5);
 
 	// MatrixOrderPrepend.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipScaleMatrix (matrix, 0.5, 0.75, MatrixOrderPrepend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 0.5, 1, 2.25, 3, 5, 6);
 
 	// Zero value.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipScaleMatrix (matrix, 0, 0, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix,  0, 0, 0, 0, 0, 0);
 
 	// Negative value.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipScaleMatrix (matrix, -0.5, -0.75, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, -0.5, -1.5, -1.5, -3, -2.5, -4.5);
 
 	// Negative tests.
 	status = GdipScaleMatrix (NULL, 1, 2, MatrixOrderAppend);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipScaleMatrix (matrix, 1, 2, (MatrixOrder)(MatrixOrderPrepend - 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipScaleMatrix (matrix, 1, 2, (MatrixOrder)(MatrixOrderAppend + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -320,36 +320,36 @@ static void test_rotateMatrix ()
 	// MatrixOrderAppend.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipRotateMatrix (matrix, 90, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, -2, 1, -4, 3, -6, 5);
 
 	// MatrixOrderPrepend.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipRotateMatrix (matrix, 90, MatrixOrderPrepend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 3, 4, -1, -2, 5, 6);
 
 	// Negative value.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipRotateMatrix (matrix, -90, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 2, -1, 4, -3, 6, -5);
 
 	// Large value.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipRotateMatrix (matrix, 630, MatrixOrderPrepend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, -3, -4, 1, 2, 5, 6);
 
 	// Negative tests.
 	status = GdipRotateMatrix (NULL, 45, MatrixOrderAppend);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipRotateMatrix (matrix, 45, (MatrixOrder)(MatrixOrderPrepend - 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipRotateMatrix (matrix, 45, (MatrixOrder)(MatrixOrderAppend + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -364,36 +364,36 @@ static void test_shearMatrix ()
 	// MatrixOrderAppend.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipShearMatrix (matrix, 1, 2, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 3, 4, 7, 10, 11, 16);
 
 	// MatrixOrderPrepend.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipShearMatrix (matrix, 1, 2, MatrixOrderPrepend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 7, 10, 4, 6, 5, 6);
 
 	// Zero value.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipShearMatrix (matrix, 0, 0, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 1, 2, 3, 4, 5, 6);
 
 	// Negative value.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipShearMatrix (matrix, -1, -2, MatrixOrderAppend);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, -1, 0, -1, -2, -1, -4);
 
 	// Negative tests.
 	status = GdipShearMatrix (NULL, 1, 2, MatrixOrderAppend);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipShearMatrix (matrix, 1, 2, (MatrixOrder)(MatrixOrderPrepend - 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipShearMatrix (matrix, 1, 2, (MatrixOrder)(MatrixOrderAppend + 1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -408,19 +408,19 @@ static void test_invertMatrix ()
 	GdipCreateMatrix2 (123, 24, 82, 16, 47, 30, &nonInvertibleMatrix);
 
 	status = GdipInvertMatrix (matrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, -2, 1, 1.5, -0.5, 1, -2);
 
 	status = GdipInvertMatrix (matrix);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (matrix, 1, 2, 3, 4, 5, 6);
 
 	// Negative tests.
 	status = GdipInvertMatrix (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 	
 	status = GdipInvertMatrix (nonInvertibleMatrix);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 	GdipDeleteMatrix (nonInvertibleMatrix);
@@ -442,26 +442,26 @@ static void test_transformMatrixPoints ()
 	points[2].Y = 6;
 
 	status = GdipTransformMatrixPoints (matrix, points, 3);
-	assert (status == Ok);
-	assert (points[0].X == 12);
-	assert (points[0].Y == 16);
-	assert (points[1].X == 20);
-	assert (points[1].Y == 28);
-	assert (points[2].X == 28);
-	assert (points[2].Y == 40);
+	assertEqualInt (status, Ok);
+	assertEqualInt (points[0].X, 12);
+	assertEqualInt (points[0].Y, 16);
+	assertEqualInt (points[1].X, 20);
+	assertEqualInt (points[1].Y, 28);
+	assertEqualInt (points[2].X, 28);
+	assertEqualInt (points[2].Y, 40);
 
 	// Negative tests.
 	status = GdipTransformMatrixPoints (NULL, points, 3);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipTransformMatrixPoints (matrix, NULL, 3);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipTransformMatrixPoints (matrix, points, 0);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipTransformMatrixPoints (matrix, points, -1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -482,29 +482,29 @@ static void test_transformMatrixPointsI ()
 	points[2].Y = 6;
 
 	status = GdipTransformMatrixPointsI (matrix, points, 3);
-	assert (status == Ok);
-	assert (points[0].X == 12);
-	assert (points[0].Y == 16);
-	assert (points[1].X == 20);
-	assert (points[1].Y == 28);
-	assert (points[2].X == 28);
-	assert (points[2].Y == 40);
+	assertEqualInt (status, Ok);
+	assertEqualInt (points[0].X, 12);
+	assertEqualInt (points[0].Y, 16);
+	assertEqualInt (points[1].X, 20);
+	assertEqualInt (points[1].Y, 28);
+	assertEqualInt (points[2].X, 28);
+	assertEqualInt (points[2].Y, 40);
 
 	// Negative tests.
 	status = GdipTransformMatrixPointsI (NULL, points, 3);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// This causes a null pointer dereference in GDI+.
 #if !defined(USE_WINDOWS_LIBGDIPLUS)
 	status = GdipTransformMatrixPointsI (matrix, NULL, 3);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 #endif
 
 	status = GdipTransformMatrixPointsI (matrix, points, 0);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipTransformMatrixPointsI (matrix, points, -1);
-	assert (status == OutOfMemory);
+	assertEqualInt (status, OutOfMemory);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -524,26 +524,26 @@ static void test_vectorTransformMatrixPoints ()
 	points[2].Y = 6;
 
 	status = GdipVectorTransformMatrixPoints (matrix, points, 3);
-	assert (status == Ok);
-	assert (points[0].X == 7);
-	assert (points[0].Y == 10);
-	assert (points[1].X == 15);
-	assert (points[1].Y == 22);
-	assert (points[2].X == 23);
-	assert (points[2].Y == 34);
+	assertEqualInt (status, Ok);
+	assertEqualInt (points[0].X, 7);
+	assertEqualInt (points[0].Y, 10);
+	assertEqualInt (points[1].X, 15);
+	assertEqualInt (points[1].Y, 22);
+	assertEqualInt (points[2].X, 23);
+	assertEqualInt (points[2].Y, 34);
 
 	// Negative tests.
 	status = GdipVectorTransformMatrixPoints (NULL, points, 3);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipVectorTransformMatrixPoints (matrix, NULL, 3);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipVectorTransformMatrixPoints (matrix, points, 0);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipVectorTransformMatrixPoints (matrix, points, -1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -563,26 +563,26 @@ static void test_vectorTransformMatrixPointsI ()
 	points[2].Y = 6;
 
 	status = GdipVectorTransformMatrixPointsI (matrix, points, 3);
-	assert (status == Ok);
-	assert (points[0].X == 7);
-	assert (points[0].Y == 10);
-	assert (points[1].X == 15);
-	assert (points[1].Y == 22);
-	assert (points[2].X == 23);
-	assert (points[2].Y == 34);
+	assertEqualInt (status, Ok);
+	assertEqualInt (points[0].X, 7);
+	assertEqualInt (points[0].Y, 10);
+	assertEqualInt (points[1].X, 15);
+	assertEqualInt (points[1].Y, 22);
+	assertEqualInt (points[2].X, 23);
+	assertEqualInt (points[2].Y, 34);
 
 	// Negative tests.
 	status = GdipVectorTransformMatrixPointsI (NULL, points, 3);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipVectorTransformMatrixPointsI (matrix, NULL, 3);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipVectorTransformMatrixPointsI (matrix, points, 0);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipVectorTransformMatrixPointsI (matrix, points, -1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -597,10 +597,10 @@ static void test_getMatrixElements ()
 
 	// Negative tests.
 	status = GdipGetMatrixElements (NULL, elements);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetMatrixElements (matrix, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 }
 
 static void test_isMatrixInvertible ()
@@ -614,19 +614,19 @@ static void test_isMatrixInvertible ()
 	GdipCreateMatrix2 (123, 24, 82, 16, 47, 30, &nonInvertibleMatrix);
 
 	status = GdipIsMatrixInvertible (matrix, &isInvertible);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isInvertible == TRUE);
 
 	status = GdipIsMatrixInvertible (nonInvertibleMatrix, &isInvertible);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isInvertible == FALSE);
 
 	// Negative tests.
 	status = GdipIsMatrixInvertible (NULL, &isInvertible);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 	
 	status = GdipIsMatrixInvertible (matrix, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 	GdipDeleteMatrix (nonInvertibleMatrix);
@@ -643,13 +643,13 @@ static void test_isMatrixIdentity ()
 	// Exactly identity.
 	GdipSetMatrixElements (matrix, 1, 0, 0, 1, 0, 0);
 	status = GdipIsMatrixIdentity (matrix, &isIdentity);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isIdentity == TRUE);
 
 	// Close to identity.
 	GdipSetMatrixElements (matrix, 0.9999f, -0.0001f, 0.0001f, 1.0001f, 0, 0);	
 	status = GdipIsMatrixIdentity (matrix, &isIdentity);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isIdentity == TRUE);
 
 	// Less close to identity.
@@ -657,22 +657,22 @@ static void test_isMatrixIdentity ()
 #if defined(USE_WINDOWS_LIBGDIPLUS)
 	GdipSetMatrixElements (matrix, 0.9998f, -0.0001f, 0.0001f, 1.0001f, 0, 0);
 	status = GdipIsMatrixIdentity (matrix, &isIdentity);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isIdentity == TRUE);
 #endif
 
 	// Not identity.
 	GdipSetMatrixElements (matrix, 1, 2, 3, 4, 5, 6);
 	status = GdipIsMatrixIdentity (matrix, &isIdentity);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isIdentity == FALSE);
 
 	// Negative tests.
 	status = GdipIsMatrixIdentity (NULL, &isIdentity);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 	
 	status = GdipIsMatrixIdentity (matrix, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 }
@@ -688,52 +688,52 @@ static void test_isMatrixEqual ()
 	GdipCreateMatrix2 (1, 2, 3, 4, 5, 6, &other);
 	
 	status = GdipIsMatrixEqual (matrix, other, &isEqual);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isEqual == TRUE);
 
 	status = GdipIsMatrixEqual (matrix, matrix, &isEqual);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isEqual == TRUE);
 
 	GdipSetMatrixElements (other, 2, 2, 3, 4, 5, 6);
 	status = GdipIsMatrixEqual (matrix, other, &isEqual);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isEqual == FALSE);
 
 	GdipSetMatrixElements (other, 1, 3, 3, 4, 5, 6);
 	status = GdipIsMatrixEqual (matrix, other, &isEqual);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isEqual == FALSE);
 
 	GdipSetMatrixElements (other, 1, 2, 4, 4, 5, 6);
 	status = GdipIsMatrixEqual (matrix, other, &isEqual);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isEqual == FALSE);
 
 	GdipSetMatrixElements (other, 1, 2, 3, 5, 5, 6);
 	status = GdipIsMatrixEqual (matrix, other, &isEqual);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isEqual == FALSE);
 
 	GdipSetMatrixElements (other, 1, 2, 3, 4, 6, 6);
 	status = GdipIsMatrixEqual (matrix, other, &isEqual);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isEqual == FALSE);
 
 	GdipSetMatrixElements (other, 1, 2, 3, 4, 5, 7);
 	status = GdipIsMatrixEqual (matrix, other, &isEqual);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (isEqual == FALSE);
 
 	// Negative tests.
 	status = GdipIsMatrixEqual (NULL, other, &isEqual);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 	
 	status = GdipIsMatrixEqual (matrix, NULL, &isEqual);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 	
 	status = GdipIsMatrixEqual (matrix, other, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteMatrix (matrix);
 	GdipDeleteMatrix (other);

--- a/tests/testpathgradientbrush.c
+++ b/tests/testpathgradientbrush.c
@@ -38,30 +38,30 @@ static void verifyPathGradientBrush (GpPathGradient *brush, REAL x, REAL y, REAL
     GdipCreateMatrix (&brushTransform);
 
     status = GdipGetBrushType (brush, &brushType);
-    assert (brushType == BrushTypePathGradient);
+    assertEqualInt (brushType, BrushTypePathGradient);
 
     status = GdipGetPathGradientRect (brush, &rect);
-    assert (status == Ok);
-    assert (rect.X == x);
-    assert (rect.Y == y);
-    assert (rect.Width == width);
-    assert (rect.Height == height);
+    assertEqualInt (status, Ok);
+    assertEqualFloat (rect.X, x);
+    assertEqualFloat (rect.Y, y);
+    assertEqualFloat (rect.Width, width);
+    assertEqualFloat (rect.Height, height);
 
     status = GdipGetPathGradientCenterColor (brush, &color);
-    assert (status == Ok);
-    assert (color == centerColor);
+    assertEqualInt (status, Ok);
+    assertEqualInt (color, centerColor);
 
     status = GdipGetPathGradientCenterPoint (brush, &centerPoint);
-    assert (status == Ok);
-    assert (centerPoint.X == centerX);
-    assert (centerPoint.Y == centerY);
+    assertEqualInt (status, Ok);
+    assertEqualFloat (centerPoint.X, centerX);
+    assertEqualFloat (centerPoint.Y, centerY);
 
     status = GdipGetPathGradientWrapMode (brush, &wrapMode);
-    assert (status == Ok);
-    assert (wrapMode == expectedWrapMode);
+    assertEqualInt (status, Ok);
+    assertEqualInt (wrapMode, expectedWrapMode);
 
     status = GdipGetPathGradientTransform (brush, brushTransform);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyMatrix (brushTransform, 1, 0, 0, 1, 0, 0);
 
     GdipDeleteMatrix (brushTransform);
@@ -85,34 +85,34 @@ static void test_createPathGradient ()
     };
 
     status = GdipCreatePathGradient (points2, 2, WrapModeClamp, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xff000000, -4.5, 6.5, WrapModeClamp);
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreatePathGradient (threePoints, 3, WrapModeTile, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyPathGradientBrush (brush, 1, 2, 4, 11, 0xff000000, 3, 7, WrapModeTile);
 
     status = GdipCreatePathGradient (NULL, 2, WrapModeClamp, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradient (points2, 1, WrapModeClamp, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradient (points2, 0, WrapModeClamp, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradient (points2, -1, WrapModeClamp, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradient (points2, 2, (WrapMode)(WrapModeTile - 1), &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradient (points2, 2, (WrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradient (points2, 2, WrapModeClamp, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -134,33 +134,33 @@ static void test_createPathGradientI ()
     };
 
     status = GdipCreatePathGradientI (points, 2, WrapModeClamp, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xff000000, -4.5, 6.5, WrapModeClamp);
 
     status = GdipCreatePathGradientI (points3, 3, WrapModeTile, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyPathGradientBrush (brush, 1, 2, 4, 11, 0xff000000, 3, 7, WrapModeTile);
 
     status = GdipCreatePathGradientI (NULL, 2, WrapModeClamp, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreatePathGradientI (points, 1, WrapModeClamp, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradientI (points, 0, WrapModeClamp, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradientI (points, -1, WrapModeClamp, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradientI (points, 2, (WrapMode)(WrapModeTile - 1), &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradientI (points, 2, (WrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradientI (points, 2, WrapModeClamp, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -174,27 +174,27 @@ static void test_createPathGradientFromPath ()
     GpPath *emptyPath;
 
     status = GdipCreatePath2 (threePoints, types, 3, FillModeAlternate, &path);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipCreatePath (FillModeWinding, &emptyPath);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipCreatePathGradientFromPath (path, &brush);
     // FIXME: this fails in GDI+.
-    // assert (status == Ok);
+    // assertEqualInt (status, Ok);
     // verifyPathGradientBrush (brush, 1, 2, 4, 11, 0xffffffff, 3, 7, WrapModeClamp);
 
     status = GdipCreatePathGradientFromPath (NULL, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradientFromPath (emptyPath, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradientFromPath (NULL, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreatePathGradientFromPath (path, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *)brush);
     GdipDeletePath (path);
@@ -210,10 +210,10 @@ static void test_getPathGradientCenterColor ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientCenterColor (NULL, &centerColor);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientCenterColor (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -227,13 +227,13 @@ static void test_setPathGradientCenterColor ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipSetPathGradientCenterColor (brush, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientCenterColor (brush, &centerColor);
-    assert (centerColor == 2);
+    assertEqualInt (centerColor, 2);
 
     status = GdipSetPathGradientCenterColor (NULL, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -248,23 +248,23 @@ static void test_getPathGradientSurroundColorCount ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientSurroundColorCount (brush, &count);
-    assert (status == Ok);
-    assert (count == 3);
+    assertEqualInt (status, Ok);
+    assertEqualInt (count,  3);
     GdipDeleteBrush ((GpBrush *) brush);
 
     // Two points.
     GdipCreatePathGradient (threePoints, 2, WrapModeTileFlipXY, &brush);
 
     status = GdipGetPathGradientSurroundColorCount (brush, &count);
-    assert (status == Ok);
-    assert (count == 2);
+    assertEqualInt (status, Ok);
+    assertEqualInt (count,  2);
 
     // Negative tests
     status = GdipGetPathGradientSurroundColorCount (NULL, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientSurroundColorCount (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -280,38 +280,38 @@ static void test_getPathGradientSurroundColorsWithCount ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == Ok);
-    assert (count == 1);
-    assert (colors[0] == 0xffffffff);
-    assert (colors[1] == 0xffffffff);
-    assert (colors[2] == 0xffffffff);
+    assertEqualInt (status, Ok);
+    assertEqualInt (count,  1);
+    assertEqualInt (colors[0], 0xffffffff);
+    assertEqualInt (colors[1], 0xffffffff);
+    assertEqualInt (colors[2], 0xffffffff);
 
     // Negative tests
     status = GdipGetPathGradientSurroundColorsWithCount (NULL, colors, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientSurroundColorsWithCount (brush, NULL, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     // FIXME: this causes GDI+ to crash.
     // status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, NULL);
-    // assert (status == InvalidParameter);
+    // assertEqualInt (status, InvalidParameter);
 
     count = 2;
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     count = 1;
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     count = 0;
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     count = -1;
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -330,81 +330,81 @@ static void test_setPathGradientSurroundColorsWithCount ()
 
     // Three surround colors.
     status = GdipSetPathGradientSurroundColorsWithCount (brush, threeSurroundColors, &count);
-    assert (status == Ok);
-    assert (count == 3);
+    assertEqualInt (status, Ok);
+    assertEqualInt (count,  3);
 
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == Ok);
-    assert (count == 3);
-    assert (colors[0] == 1);
-    assert (colors[1] == 2);
-    assert (colors[2] == 3);
+    assertEqualInt (status, Ok);
+    assertEqualInt (count,  3);
+    assertEqualInt (colors[0], 1);
+    assertEqualInt (colors[1], 2);
+    assertEqualInt (colors[2], 3);
 
     // Two empty colors.
     count = 2;
     status = GdipSetPathGradientSurroundColorsWithCount (brush, threeEmptyColors, &count);
-    assert (status == Ok);
-    assert (count == 2);
+    assertEqualInt (status, Ok);
+    assertEqualInt (count,  2);
 
     count = 3;
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == Ok);
-    assert (count == 1);
-    assert (colors[0] == 0);
-    assert (colors[1] == 0);
-    assert (colors[2] == 0);
+    assertEqualInt (status, Ok);
+    assertEqualInt (count,  1);
+    assertEqualInt (colors[0], 0);
+    assertEqualInt (colors[1], 0);
+    assertEqualInt (colors[2], 0);
 
     // Two same colors.
     count = 2;
     status = GdipSetPathGradientSurroundColorsWithCount (brush, twoSameColors, &count);
-    assert (status == Ok);
-    assert (count == 2);
+    assertEqualInt (status, Ok);
+    assertEqualInt (count,  2);
 
     count = 3;
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == Ok);
-    assert (count == 1);
-    assert (colors[0] == 1);
-    assert (colors[1] == 1);
-    assert (colors[2] == 1);
+    assertEqualInt (status, Ok);
+    assertEqualInt (count,  1);
+    assertEqualInt (colors[0], 1);
+    assertEqualInt (colors[1], 1);
+    assertEqualInt (colors[2], 1);
 
     // One surround color.
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     count = 1;
     status = GdipSetPathGradientSurroundColorsWithCount (brush, threeSurroundColors, &count);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     count = 3;
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == Ok);
-    assert (count == 1);
-    assert (colors[0] == 1);
-    assert (colors[1] == 1);
-    assert (colors[2] == 1);
+    assertEqualInt (status, Ok);
+    assertEqualInt (count, 1);
+    assertEqualInt (colors[0], 1);
+    assertEqualInt (colors[1], 1);
+    assertEqualInt (colors[2], 1);
 
     // Negative tests
     status = GdipSetPathGradientSurroundColorsWithCount (NULL, colors, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientSurroundColorsWithCount (brush, NULL, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     // FIXME: this causes GDI+ to crash.
     // status = GdipSetPathGradientSurroundColorsWithCount (brush, colors, NULL);
-    // assert (status == InvalidParameter);
+    // assertEqualInt (status, InvalidParameter);
 
     count = 4;
     status = GdipSetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     count = 0;
     status = GdipSetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     count = -1;
     status = GdipSetPathGradientSurroundColorsWithCount (brush, colors, &count);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -419,13 +419,13 @@ static void test_getPathGradientPath ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientPath (brush, path);
-    assert (status == NotImplemented);
+    assertEqualInt (status, NotImplemented);
 
     status = GdipGetPathGradientPath (NULL, path);
-    assert (status == NotImplemented);
+    assertEqualInt (status, NotImplemented);
 
     status = GdipGetPathGradientPath (brush, NULL);
-    assert (status == NotImplemented);
+    assertEqualInt (status, NotImplemented);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeletePath (path);
@@ -441,13 +441,13 @@ static void test_setPathGradientPath ()
     GdipCreatePath (FillModeWinding, &path);
 
     status = GdipSetPathGradientPath (brush, path);
-    assert (status == NotImplemented);
+    assertEqualInt (status, NotImplemented);
 
     status = GdipSetPathGradientPath (NULL, path);
-    assert (status == NotImplemented);
+    assertEqualInt (status, NotImplemented);
 
     status = GdipSetPathGradientPath (brush, NULL);
-    assert (status == NotImplemented);
+    assertEqualInt (status, NotImplemented);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeletePath (path);
@@ -462,15 +462,15 @@ static void test_getPathGradientCenterPoint ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientCenterPoint (brush, &centerPoint);
-    assert (status == Ok);
-    assert (centerPoint.X == 3);
-    assert (centerPoint.Y == 7);
+    assertEqualInt (status, Ok);
+    assertEqualInt (centerPoint.X, 3);
+    assertEqualInt (centerPoint.Y, 7);
 
     status = GdipGetPathGradientCenterPoint (NULL, &centerPoint);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientCenterPoint (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -491,25 +491,25 @@ static void test_getPathGradientCenterPointI ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientCenterPointI (brush, &centerPoint);
-    assert (status == Ok);
-    assert (centerPoint.X == 3);
-    assert (centerPoint.Y == 7);
+    assertEqualInt (status, Ok);
+    assertEqualInt (centerPoint.X, 3);
+    assertEqualInt (centerPoint.Y, 7);
     GdipDeleteBrush ((GpBrush *) brush);
 
     // > 0.5 is rounded up.
     GdipCreatePathGradient (roundUpPoints, 3, WrapModeTileFlipXY, &brush);
 
     status = GdipGetPathGradientCenterPointI (brush, &centerPoint);
-    assert (status == Ok);
-    assert (centerPoint.X == 9);
-    assert (centerPoint.Y == 7);
+    assertEqualInt (status, Ok);
+    assertEqualInt (centerPoint.X, 9);
+    assertEqualInt (centerPoint.Y, 7);
 
     // Negative tests.
     status = GdipGetPathGradientCenterPointI (NULL, &centerPoint);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientCenterPointI (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -526,26 +526,26 @@ static void test_setPathGradientCenterPoint ()
 
     // Set within the bounds of the brush.
     status = GdipSetPathGradientCenterPoint (brush, &point);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientCenterPoint (brush, &centerPoint);
-    assert (centerPoint.X == 1);
-    assert (centerPoint.Y == 2);
+    assertEqualInt (centerPoint.X, 1);
+    assertEqualInt (centerPoint.Y, 2);
 
     // Set outside the bounds of the brush.
     status = GdipSetPathGradientCenterPoint (brush, &outOfBoundsPoint);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientCenterPoint (brush, &centerPoint);
-    assert (centerPoint.X == 100);
-    assert (centerPoint.Y == 200);
+    assertEqualInt (centerPoint.X, 100);
+    assertEqualInt (centerPoint.Y, 200);
 
     // Negative tests.
     status = GdipSetPathGradientCenterPoint (NULL, &point);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientCenterPoint (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -562,26 +562,26 @@ static void test_setPathGradientCenterPointI ()
 
     // Set within the bounds of the brush.
     status = GdipSetPathGradientCenterPointI (brush, &point);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientCenterPoint (brush, &centerPoint);
-    assert (centerPoint.X == 1);
-    assert (centerPoint.Y == 2);
+    assertEqualInt (centerPoint.X, 1);
+    assertEqualInt (centerPoint.Y, 2);
 
     // Set outside the bounds of the brush.
     status = GdipSetPathGradientCenterPointI (brush, &outOfBoundsPoint);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientCenterPoint (brush, &centerPoint);
-    assert (centerPoint.X == 100);
-    assert (centerPoint.Y == 200);
+    assertEqualInt (centerPoint.X, 100);
+    assertEqualInt (centerPoint.Y, 200);
 
     // Negative tests.
     status = GdipSetPathGradientCenterPointI (NULL, &point);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientCenterPointI (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -600,17 +600,17 @@ static void test_getPathGradientRect ()
     GdipCreatePathGradient (points, 2, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientRect (brush, &rect);
-    assert (status == Ok);
-    assert (rect.X == 1.5);
-    assert (rect.Y == 2.5);
-    assert (rect.Width == 3.5);
-    assert (rect.Height == 4.5);
+    assertEqualInt (status, Ok);
+    assertEqualFloat (rect.X, 1.5);
+    assertEqualFloat (rect.Y, 2.5);
+    assertEqualFloat (rect.Width, 3.5);
+    assertEqualFloat (rect.Height, 4.5);
 
     status = GdipGetPathGradientRect (NULL, &rect);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientRect (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -640,11 +640,11 @@ static void test_getPathGradientRectI ()
     GdipCreatePathGradient (points1, 2, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientRectI (brush, &rect);
-    assert (status == Ok);
-    assert (rect.X == 2);
-    assert (rect.Y == 3);
-    assert (rect.Width == 4);
-    assert (rect.Height == 5);
+    assertEqualInt (status, Ok);
+    assertEqualInt (rect.X, 2);
+    assertEqualInt (rect.Y, 3);
+    assertEqualInt (rect.Width, 4);
+    assertEqualInt (rect.Height, 5);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
@@ -652,11 +652,11 @@ static void test_getPathGradientRectI ()
     GdipCreatePathGradient (points2, 2, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientRectI (brush, &rect);
-    assert (status == Ok);
-    assert (rect.X == 2);
-    assert (rect.Y == 3);
-    assert (rect.Width == 4);
-    assert (rect.Height == 5);
+    assertEqualInt (status, Ok);
+    assertEqualInt (rect.X, 2);
+    assertEqualInt (rect.Y, 3);
+    assertEqualInt (rect.Width, 4);
+    assertEqualInt (rect.Height, 5);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
@@ -664,18 +664,18 @@ static void test_getPathGradientRectI ()
     GdipCreatePathGradient (points3, 2, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientRectI (brush, &rect);
-    assert (status == Ok);
-    assert (rect.X == 1);
-    assert (rect.Y == 2);
-    assert (rect.Width == 3);
-    assert (rect.Height == 4);
+    assertEqualInt (status, Ok);
+    assertEqualInt (rect.X, 1);
+    assertEqualInt (rect.Y, 2);
+    assertEqualInt (rect.Width, 3);
+    assertEqualInt (rect.Height, 4);
 
     // Negative tests.
     status = GdipGetPathGradientRectI (NULL, &rect);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientRectI (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -689,14 +689,14 @@ static void test_getPathGradientPointCount ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientPointCount (brush, &pointCount);
-    assert (status == Ok);
-    assert (pointCount == 3);
+    assertEqualInt (status, Ok);
+    assertEqualInt (pointCount, 3);
 
     status = GdipGetPathGradientPointCount (NULL, &pointCount);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientPointCount (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -710,13 +710,13 @@ static void test_setPathGradientGammaCorrection ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipSetPathGradientGammaCorrection (brush, TRUE);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientGammaCorrection (brush, &useGammaCorrection);
     assert (useGammaCorrection == TRUE);
 
     status = GdipSetPathGradientGammaCorrection (NULL, TRUE);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -733,10 +733,10 @@ static void test_getPathGradientGammaCorrection ()
     assert (useGammaCorrection == FALSE);
 
     status = GdipGetPathGradientGammaCorrection (NULL, &useGammaCorrection);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientGammaCorrection (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -750,13 +750,13 @@ static void test_getPathGradientBlendCount ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientBlendCount (brush, &blendCount);
-    assert (blendCount == 1);
+    assertEqualInt (blendCount, 1);
 
     status = GdipGetPathGradientBlendCount (NULL, &blendCount);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientBlendCount (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -773,37 +773,37 @@ static void test_getPathGradientBlend ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientBlend (brush, blend, positions, 1);
-    assert (status == Ok);
-    assert (floatsEqual(blend[0], 1));
+    assertEqualInt (status, Ok);
+    assertEqualFloat (blend[0], 1);
     // FIXME: it appears that Windows 10+ versions of GDI+ don't copy anything to positions.
-    // assert (floatsEqual(positions[0], 0));
+    // assertEqualFloat (positions[0], 0);
 
     status = GdipGetPathGradientBlend (brush, blend, positions, 2);
-    assert (status == Ok);
-    assert (floatsEqual(blend[0], 1));
+    assertEqualInt (status, Ok);
+    assertEqualFloat (blend[0], 1);
     // FIXME: it appears that Windows 10+ versions of GDI+ don't copy anything to positions.
-    // assert (floatsEqual(positions[0], 0));
+    // assertEqualFloat (positions[0], 0);
 
     status = GdipSetPathGradientBlend (brush, largeBlend, largePositions, 3);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetPathGradientBlend (brush, blend, positions, 1);
-    assert (status == InsufficientBuffer);
+    assertEqualInt (status, InsufficientBuffer);
 
     status = GdipGetPathGradientBlend (NULL, blend, positions, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientBlend (brush, NULL, positions, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientBlend (brush, blend, NULL, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientBlend (brush, blend, positions, 0);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientBlend (brush, blend, positions, -1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -839,71 +839,71 @@ static void test_setPathGradientBlend ()
 
     // Count of 1.
     status = GdipSetPathGradientBlend (brush, blend1, positions1, 1);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetPathGradientBlend (brush, destBlend1, destPositions1, 1);
-    assert (status == Ok);
-    assert (destBlend1[0] == 3);
+    assertEqualInt (status, Ok);
+    assertEqualInt (destBlend1[0], 3);
     // FIXME: it appears GDI+ ignores the position value if there is a single element.
-    // assert (floatsEqual(destPositions1[0], 0));
+    // assertEqualFloat(destPositions1[0], 0));
 
     // Count of 2.
     status = GdipSetPathGradientBlend (brush, blend2, positions2, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetPathGradientBlend (brush, destBlend2, destPositions2, 2);
-    assert (status == Ok);
-    assert (destBlend2[0] == -1);
-    assert (destBlend2[1] == 0);
-    assert (destPositions2[0] == 0);
-    assert (destPositions2[1] == 1);
+    assertEqualInt (status, Ok);
+    assertEqualInt (destBlend2[0], -1);
+    assertEqualInt (destBlend2[1], 0);
+    assertEqualInt (destPositions2[0], 0);
+    assertEqualInt (destPositions2[1], 1);
 
     // Count of 3.
     status = GdipSetPathGradientBlend (brush, blend3, positions3, 3);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetPathGradientBlend (brush, destBlend3, destPositions3, 3);
-    assert (status == Ok);
-    assert (destBlend3[0] == 1);
-    assert (destBlend3[1] == 2);
-    assert (destBlend3[2] == 3);
-    assert (destPositions3[0] == 0);
-    assert (destPositions3[1] == 0.5);
-    assert (destPositions3[2] == 1);
+    assertEqualInt (status, Ok);
+    assertEqualFloat (destBlend3[0], 1);
+    assertEqualFloat (destBlend3[1], 2);
+    assertEqualFloat (destBlend3[2], 3);
+    assertEqualFloat (destPositions3[0], 0);
+    assertEqualFloat (destPositions3[1], 0.5);
+    assertEqualFloat (destPositions3[2], 1);
 
     // Should clear the existing blend.
     status = GdipSetPathGradientPresetBlend (brush, pathPresetBlend, pathPresetPositions, 3);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetPathGradientBlend (brush, destBlend2, destPositions2, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetPathGradientPresetBlendCount (brush, &presetBlendCount);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     // FIXME: this returns 0 with GDI+.
-    // assert (presetBlendCount == 0);
+    // assertEqualInt (presetBlendCount, 0);
 
     // Negative tests.
     status = GdipSetPathGradientBlend (NULL, blend3, positions3, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientBlend (brush, NULL, positions3, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientBlend (brush, blend3, NULL, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientBlend (brush, blend2, invalidPositions1, 2);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientBlend (brush, blend2, invalidPositions2, 2);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientBlend (brush, blend3, positions3, 0);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientBlend (brush, blend3, positions3, -1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -917,15 +917,15 @@ static void test_getPathGradientPresetBlendCount ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientPresetBlendCount (brush, &blendCount);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     // FIXME: this returns 0 with GDI+.
-    // assert (blendCount == 0);
+    // assertEqualInt (blendCount, 0);
 
     status = GdipGetPathGradientPresetBlendCount (NULL, &blendCount);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientPresetBlendCount (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -941,34 +941,34 @@ static void test_getPathGradientPresetBlend ()
 
     // FIXME: GDI+ has no preset colors by default.
     // status = GdipGetPathGradientPresetBlend (brush, blend, positions, 2);
-    // assert (status == GenericError);
+    // assertEqualInt (status, GenericError);
 
     status = GdipGetPathGradientPresetBlend (NULL, blend, positions, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientPresetBlend (brush, NULL, positions, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientPresetBlend (brush, blend, NULL, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientPresetBlend (brush, blend, positions, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientPresetBlend (brush, blend, positions, 0);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientPresetBlend (brush, blend, positions, -1);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipGetPathGradientPresetBlend (NULL, blend, positions, -1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientPresetBlend (brush, NULL, positions, -1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientPresetBlend (brush, blend, NULL, -1);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -999,65 +999,65 @@ static void test_setPathGradientPresetBlend ()
 
     // Count of 2.
     status = GdipSetPathGradientPresetBlend (brush, blend2, positions2, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetPathGradientPresetBlend (brush, destBlend2, destPositions2, 2);
-    assert (status == Ok);
-    assert (destBlend2[0] == 1);
-    assert (destBlend2[1] == 0);
-    assert (destPositions2[0] == 0);
-    assert (destPositions2[1] == 1);
+    assertEqualInt (status, Ok);
+    assertEqualInt (destBlend2[0], 1);
+    assertEqualInt (destBlend2[1], 0);
+    assertEqualInt (destPositions2[0], 0);
+    assertEqualInt (destPositions2[1], 1);
 
     // Count of 3.
     status = GdipSetPathGradientPresetBlend (brush, blend3, positions3, 3);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetPathGradientPresetBlend (brush, destBlend3, destPositions3, 3);
-    assert (status == Ok);
-    assert (destBlend3[0] == 1);
-    assert (destBlend3[1] == 2);
-    assert (destBlend3[2] == 3);
-    assert (destPositions3[0] == 0);
-    assert (destPositions3[1] == 0.5);
-    assert (destPositions3[2] == 1);
+    assertEqualInt (status, Ok);
+    assertEqualFloat (destBlend3[0], 1);
+    assertEqualFloat (destBlend3[1], 2);
+    assertEqualFloat (destBlend3[2], 3);
+    assertEqualFloat (destPositions3[0], 0);
+    assertEqualFloat (destPositions3[1], 0.5);
+    assertEqualFloat (destPositions3[2], 1);
 
     // Should clear the existing blend.
     status = GdipSetPathGradientBlend (brush, pathBlend, pathPositions, 3);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetPathGradientPresetBlend (brush, destBlend2, destPositions2, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipGetPathGradientBlendCount (brush, &blendCount);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     // FIXME: this returns 2 with GDI+.
-    // assert (blendCount == 2);
+    // assertEqualInt (blendCount, 2);
 
     // Negative tests.
     status = GdipSetPathGradientPresetBlend (NULL, blend3, positions3, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientPresetBlend (brush, NULL, positions3, 3);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     // FIXME: this caused GDI+ to crash.
     // status = GdipSetPathGradientPresetBlend (brush, blend3, NULL, 3);
-    // assert (status == InvalidParameter);
+    // assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientPresetBlend (brush, blend2, invalidPositions1, 2);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientPresetBlend (brush, blend2, invalidPositions2, 2);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientPresetBlend (brush, blend3, positions3, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientPresetBlend (brush, blend3, positions3, 0);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientPresetBlend (brush, blend3, positions3, -1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -1070,28 +1070,28 @@ static void test_setPathGradientSigmaBlend ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipSetPathGradientSigmaBlend (brush, 0, 0.5f);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetPathGradientSigmaBlend (brush, 0.5f, 1);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetPathGradientSigmaBlend (brush, 1, 0);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetPathGradientSigmaBlend (NULL, 0.5f, 0.5f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientSigmaBlend (brush, -0.01f, 0.5f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientSigmaBlend (brush, 1.01f, 0.5f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientSigmaBlend (brush, 0.5f, -0.01f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientSigmaBlend (brush, 0.5f, 1.01f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -1104,28 +1104,28 @@ static void test_setPathGradientLinearBlend ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipSetPathGradientLinearBlend (brush, 0, 0.5f);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetPathGradientLinearBlend (brush, 0.5f, 1);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetPathGradientLinearBlend (brush, 1, 0);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     status = GdipSetPathGradientLinearBlend (NULL, 0.5f, 0.5f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientLinearBlend (brush, -0.01f, 0.5f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientLinearBlend (brush, 1.01f, 0.5);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientLinearBlend (brush, 0.5f, -0.01f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientLinearBlend (brush, 0.5f, 1.01f);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -1139,10 +1139,10 @@ static void test_getPathGradientWrapMode ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientWrapMode (NULL, &wrapMode);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientWrapMode (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -1156,25 +1156,25 @@ static void test_setPathGradientWrapMode ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipSetPathGradientWrapMode (brush, WrapModeTileFlipY);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientWrapMode (brush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeTileFlipY);
 
     status = GdipSetPathGradientWrapMode (brush, (WrapMode)(WrapModeTile - 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientWrapMode (brush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeTileFlipY);
 
     status = GdipSetPathGradientWrapMode (brush, (WrapMode)(WrapModeClamp + 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientWrapMode (brush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeTileFlipY);
 
     status = GdipSetPathGradientWrapMode (NULL, WrapModeTile);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -1189,10 +1189,10 @@ static void test_getPathGradientTransform ()
     GdipCreateMatrix (&transform);
 
     status = GdipGetPathGradientTransform (NULL, transform);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientTransform (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (transform);
@@ -1210,7 +1210,7 @@ static void test_setPathGradientTransform ()
     GdipCreateMatrix (&transform);
 
     status = GdipSetPathGradientTransform (brush, matrix);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     assert (transform != matrix && "Expected new matrix to be a clone.");
@@ -1223,10 +1223,10 @@ static void test_setPathGradientTransform ()
 
     // Negative tests.
     status = GdipSetPathGradientTransform (NULL, transform);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientTransform (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (matrix);
@@ -1247,13 +1247,13 @@ static void test_resetPathGradientTransform ()
     GdipSetPathGradientTransform (brush, matrix);
 
     status = GdipResetPathGradientTransform (brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 1, 0, 0, 1, 0, 0);
 
     status = GdipResetPathGradientTransform (NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (matrix);
@@ -1278,7 +1278,7 @@ static void test_multiplyPathGradientTransform ()
     GdipSetPathGradientTransform (brush, originalTransform);
 
     status = GdipMultiplyPathGradientTransform (brush, matrix, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
@@ -1287,14 +1287,14 @@ static void test_multiplyPathGradientTransform ()
     GdipSetPathGradientTransform (brush, originalTransform);
 
     status = GdipMultiplyPathGradientTransform (brush, matrix, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
 
     // Null matrix - nop.
     status = GdipMultiplyPathGradientTransform (brush, NULL, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
@@ -1303,7 +1303,7 @@ static void test_multiplyPathGradientTransform ()
     GdipSetPathGradientTransform (brush, originalTransform);
 
     status = GdipMultiplyPathGradientTransform (brush, matrix, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
@@ -1312,17 +1312,17 @@ static void test_multiplyPathGradientTransform ()
     GdipSetPathGradientTransform (brush, originalTransform);
     
     status = GdipMultiplyPathGradientTransform (brush, matrix, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
 
     // Negative tests.
     status = GdipMultiplyPathGradientTransform (NULL, matrix, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipMultiplyPathGradientTransform (brush, nonInvertibleMatrix, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (originalTransform);
@@ -1346,7 +1346,7 @@ static void test_translatePathGradientTransform ()
     GdipSetPathGradientTransform (brush, originalTransform);
 
     status = GdipTranslatePathGradientTransform (brush, 5, 6, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 1, 2, 3, 4, 10, 12);
@@ -1355,20 +1355,20 @@ static void test_translatePathGradientTransform ()
     GdipSetPathGradientTransform (brush, originalTransform);
 
     status = GdipTranslatePathGradientTransform (brush, 5, 6, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 1, 2, 3, 4, 28, 40);
 
     // Negative tests.
     status = GdipTranslatePathGradientTransform (NULL, 1, 1, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipTranslatePathGradientTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipTranslatePathGradientTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (originalTransform);
@@ -1390,7 +1390,7 @@ static void test_scalePathGradientTransform ()
     GdipSetPathGradientTransform (brush, originalTransform);
 
     status = GdipScalePathGradientTransform (brush, 0.5, 0.75, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 0.5, 1.5, 1.5, 3, 2.5, 4.5);
@@ -1399,20 +1399,20 @@ static void test_scalePathGradientTransform ()
     GdipSetPathGradientTransform (brush, originalTransform);
 
     status = GdipScalePathGradientTransform (brush, 0.5, 0.75, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 0.5, 1, 2.25, 3, 5, 6);
 
     // Negative tests.
     status = GdipScalePathGradientTransform (NULL, 1, 1, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipScalePathGradientTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipScalePathGradientTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (originalTransform);
@@ -1434,7 +1434,7 @@ static void test_rotatePathGradientTransform ()
     GdipSetPathGradientTransform (brush, originalTransform);
 
     status = GdipRotatePathGradientTransform (brush, 90, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, -2, 1, -4, 3, -6, 5);
@@ -1443,20 +1443,20 @@ static void test_rotatePathGradientTransform ()
     GdipSetPathGradientTransform (brush, originalTransform);
 
     status = GdipRotatePathGradientTransform (brush, 90, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 3, 4, -1, -2, 5, 6);
 
     // Negative tests.
     status = GdipRotatePathGradientTransform (NULL, 90, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipRotatePathGradientTransform (brush, 90, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipRotatePathGradientTransform (brush, 90, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (originalTransform);
@@ -1473,21 +1473,21 @@ static void test_getPathGradientFocusScales ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipGetPathGradientFocusScales (brush, &xScale, &yScale);
-    assert (status == Ok);
-    assert (xScale == 0);
-    assert (yScale == 0);
+    assertEqualInt (status, Ok);
+    assertEqualFloat (xScale, 0);
+    assertEqualFloat (yScale, 0);
 
     status = GdipGetPathGradientFocusScales (NULL, &xScale, &yScale);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientFocusScales (NULL, &xScale, &yScale);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientFocusScales (brush, NULL, &yScale);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPathGradientFocusScales (brush, &xScale, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -1502,28 +1502,28 @@ static void test_setPathGradientFocusScales ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
     status = GdipSetPathGradientFocusScales (brush, 1, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientFocusScales (brush, &xScale, &yScale);
-    assert (xScale == 1);
-    assert (yScale == 2);
+    assertEqualFloat (xScale, 1);
+    assertEqualFloat (yScale, 2);
 
     status = GdipSetPathGradientFocusScales (brush, -1, -2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientFocusScales (brush, &xScale, &yScale);
-    assert (xScale == -1);
-    assert (yScale == -2);
+    assertEqualFloat (xScale, -1);
+    assertEqualFloat (yScale, -2);
 
     status = GdipSetPathGradientFocusScales (brush, 0, 0);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPathGradientFocusScales (brush, &xScale, &yScale);
-    assert (xScale == 0);
-    assert (yScale == 0);
+    assertEqualFloat (xScale, 0);
+    assertEqualFloat (yScale, 0);
 
     status = GdipSetPathGradientFocusScales (NULL, 0, 0);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -1565,43 +1565,43 @@ static void test_clone ()
     GdipSetPathGradientSurroundColorsWithCount (brush, surroundColors, &surroundColorsCount);
 
     status = GdipCloneBrush ((GpBrush *) brush, &clonedBrush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (clonedBrush && clonedBrush != brush);
 
     GdipGetBrushType (clonedBrush, &brushType);
-    assert (brushType == BrushTypePathGradient);
+    assertEqualInt (brushType, BrushTypePathGradient);
 
     GdipGetPathGradientWrapMode ((GpPathGradient *) clonedBrush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipX);
+    assertEqualInt (wrapMode, WrapModeTileFlipX);
 
     GdipGetPathGradientFocusScales ((GpPathGradient *) clonedBrush, &xScale, &yScale);
-    assert (xScale == 1);
-    assert (yScale == 2);
+    assertEqualFloat (xScale, 1);
+    assertEqualFloat (yScale, 2);
 
     GdipGetPathGradientCenterColor ((GpPathGradient *) clonedBrush, &centerColor);
-    assert (centerColor == 3);
+    assertEqualInt (centerColor, 3);
 
     GdipGetPathGradientCenterPoint ((GpPathGradient *) clonedBrush, &centerPoint);
-    assert (centerPoint.X == 3);
-    assert (centerPoint.Y == 7);
+    assertEqualInt (centerPoint.X, 3);
+    assertEqualInt (centerPoint.Y, 7);
 
     GdipGetPathGradientRect ((GpPathGradient *) clonedBrush, &rect);
-    assert (rect.X == 1);
-    assert (rect.Y == 2);
-    assert (rect.Width == 4);
-    assert (rect.Height == 11);
+    assertEqualInt (rect.X, 1);
+    assertEqualInt (rect.Y, 2);
+    assertEqualInt (rect.Width, 4);
+    assertEqualInt (rect.Height, 11);
 
     GdipGetPathGradientPointCount ((GpPathGradient *) clonedBrush, &pointCount);
-    assert (pointCount == 3);
+    assertEqualInt (pointCount, 3);
 
     GdipGetPathGradientBlendCount ((GpPathGradient *) clonedBrush, &blendCount);
-    assert (blendCount == 2);
+    assertEqualInt (blendCount, 2);
 
     GdipGetPathGradientBlend ((GpPathGradient *) clonedBrush, blendResult, positionsResult, 2);
-    assert (blendResult[0] == 1);
-    assert (blendResult[1] == 2);
-    assert (positionsResult[0] == 0);
-    assert (positionsResult[1] == 1);
+    assertEqualFloat (blendResult[0], 1);
+    assertEqualFloat (blendResult[1], 2);
+    assertEqualFloat (positionsResult[0], 0);
+    assertEqualFloat (positionsResult[1], 1);
 
     GdipGetPathGradientGammaCorrection ((GpPathGradient *) clonedBrush, &useGammaCorrection);
     assert (useGammaCorrection == TRUE);
@@ -1610,9 +1610,9 @@ static void test_clone ()
     verifyMatrix (matrix, 1, 2, 3, 4, 5, 6);
 
     GdipGetPathGradientSurroundColorsWithCount (brush, surroundColorsResult, &surroundColorsCount);
-    assert (surroundColorsResult[0] == 1);
-    assert (surroundColorsResult[1] == 2);
-    assert (surroundColorsResult[2] == 3);
+    assertEqualInt (surroundColorsResult[0], 1);
+    assertEqualInt (surroundColorsResult[1], 2);
+    assertEqualInt (surroundColorsResult[2], 3);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteBrush ((GpBrush *) clonedBrush);

--- a/tests/testpen.c
+++ b/tests/testpen.c
@@ -28,7 +28,7 @@ static GpImage * getImage ()
     GpStatus status;
     GpBitmap *image;
     status = GdipCreateBitmapFromScan0 (100, 68, 0, PixelFormat32bppRGB, NULL, &image);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     return (GpImage *)image;
 }
@@ -60,75 +60,75 @@ static void verifyPen (GpPen *pen, REAL expectedWidth, Unit expectedUnit, PenTyp
 	GdipCreateMatrix (&transform);
 
 	status = GdipGetPenWidth (pen, &width);
-	assert (status == Ok);
-	assert (floatsEqual (width, expectedWidth));
+	assertEqualInt (status, Ok);
+	assertEqualFloat (width, expectedWidth);
 
 	status = GdipGetPenUnit (pen, &unit);
-	assert (status == Ok);
-	assert (unit == expectedUnit);
+	assertEqualInt (status, Ok);
+	assertEqualInt (unit, expectedUnit);
 
 	status = GdipGetPenFillType (pen, &type);
-	assert (status == Ok);
-	assert (type == expectedType);
+	assertEqualInt (status, Ok);
+	assertEqualInt (type, expectedType);
 
 	status = GdipGetPenLineJoin (pen, &lineJoin);
-	assert (status == Ok);
-	assert (lineJoin == LineJoinMiter);
+	assertEqualInt (status, Ok);
+	assertEqualInt (lineJoin, LineJoinMiter);
 
 	status = GdipGetPenMode (pen, &mode);
-	assert (status == Ok);
-	assert (mode == PenAlignmentCenter);
+	assertEqualInt (status, Ok);
+	assertEqualInt (mode, PenAlignmentCenter);
 
 	status = GdipGetPenBrushFill (pen, &brush);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetBrushType (brush, &brushType);
-	assert (status == Ok);
-	assert (brushType == (BrushType)expectedType);
+	assertEqualInt (status, Ok);
+	assertEqualInt (brushType, (BrushType)expectedType);
 	
 	status = GdipGetPenStartCap (pen, &startCap);
-	assert (status == Ok);
-	assert (startCap == LineCapFlat);
+	assertEqualInt (status, Ok);
+	assertEqualInt (startCap, LineCapFlat);
 
 	status = GdipGetPenEndCap (pen, &endCap);
-	assert (status == Ok);
-	assert (endCap == LineCapFlat);
+	assertEqualInt (status, Ok);
+	assertEqualInt (endCap, LineCapFlat);
 
 	status = GdipGetPenDashCap197819 (pen, &dashCap);
-	assert (status == Ok);
-	assert (dashCap == DashCapFlat);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashCap, DashCapFlat);
 
 	status = GdipGetPenDashStyle (pen, &dashStyle);
-	assert (status == Ok);
-	assert (dashStyle == DashStyleSolid);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashStyle, DashStyleSolid);
 
 	status = GdipGetPenCustomStartCap (pen, &customStartCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (!customStartCap);
 	
 	status = GdipGetPenCustomEndCap (pen, &customEndCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (!customEndCap);
 
 	status = GdipGetPenMiterLimit (pen, &miterLimit);
-	assert (status == Ok);
-	assert (miterLimit == 10);
+	assertEqualInt (status, Ok);
+	assertEqualInt (miterLimit, 10);
 
 	status = GdipGetPenTransform (pen, transform);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyMatrix (transform, 1, 0, 0, 1, 0, 0);
 
 	status = GdipGetPenDashCount (pen, &dashCount);
-	assert (status == Ok);
-	assert (dashCount == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashCount, 0);
 
 	status = GdipGetPenDashOffset (pen, &dashOffset);
-	assert (status == Ok);
-	assert (dashOffset == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashOffset, 0);
 
 	status = GdipGetPenCompoundCount (pen, &compoundCount);
-	assert (status == Ok);
-	assert (compoundCount == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (compoundCount, 0);
 
 	GdipDeleteMatrix (transform);
 	GdipDeleteBrush (brush);
@@ -142,8 +142,8 @@ static void verifySolidBrushPen (GpPen *pen, ARGB expectedColor, REAL expectedWi
 	verifyPen (pen, expectedWidth, expectedUnit, PenTypeSolidColor);
 
 	status = GdipGetPenColor (pen, &color);
-	assert (status == Ok);
-	assert (color == expectedColor);
+	assertEqualInt (status, Ok);
+	assertEqualInt (color, expectedColor);
 }
 
 static void verifyNonSolidBrushPen (GpPen *pen, REAL expectedWidth, Unit expectedUnit, PenType expectedType)
@@ -154,7 +154,7 @@ static void verifyNonSolidBrushPen (GpPen *pen, REAL expectedWidth, Unit expecte
 	verifyPen (pen, expectedWidth, expectedUnit, expectedType);
 
 	status = GdipGetPenColor (pen, &color);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 }
 
 static void test_createPen1 ()
@@ -163,54 +163,54 @@ static void test_createPen1 ()
 	GpPen *pen;
 
 	status = GdipCreatePen1 (1, 10, UnitWorld, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifySolidBrushPen (pen, 1, 10, UnitWorld);
 	GdipDeletePen (pen);
 
 	status = GdipCreatePen1 (1, 0, UnitPixel, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifySolidBrushPen (pen, 1, 0, UnitPixel);
 	GdipDeletePen (pen);
 
 	status = GdipCreatePen1 (1, -1, UnitPoint, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifySolidBrushPen (pen, 1, -1, UnitPoint);
 	GdipDeletePen (pen);
 
 	status = GdipCreatePen1 (1, 10, UnitInch, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifySolidBrushPen (pen, 1, 10, UnitInch);
 	GdipDeletePen (pen);
 
 	status = GdipCreatePen1 (1, 10, UnitDocument, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifySolidBrushPen (pen, 1, 10, UnitDocument);
 	GdipDeletePen (pen);
 
 	status = GdipCreatePen1 (1, 10, UnitMillimeter, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifySolidBrushPen (pen, 1, 10, UnitMillimeter);
 	GdipDeletePen (pen);
 
 #if !defined(_WIN32)
 	status = GdipCreatePen1 (1, 10, UnitCairoPoint, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifySolidBrushPen (pen, 1, 10, UnitCairoPoint);
 	GdipDeletePen (pen);
 #endif
 
 	// Negative tests.
 	status = GdipCreatePen1 (1, 10, (Unit)(UnitWorld - 1), &pen);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreatePen1 (1, 10, UnitDisplay, &pen);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreatePen1 (1, 10, (Unit)(8), &pen);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreatePen1 (1, 10, UnitWorld, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 }
 
 static GpPointF threePoints[3] =
@@ -242,60 +242,60 @@ static void test_createPen2 ()
 
 	// SolidBrush/UnitWorld.
 	status = GdipCreatePen2 (solidBrush, 10, UnitWorld, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifySolidBrushPen (pen, 1, 10, UnitWorld);
 	GdipDeletePen (pen);
 
 	// HatchFill/UnitPixel
 	status = GdipCreatePen2 (hatchBrush, 0, UnitPixel, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyNonSolidBrushPen (pen, 0, UnitPixel, PenTypeHatchFill);
 	GdipDeletePen (pen);
 
 	// TextureFill/UnitPoint
 	status = GdipCreatePen2 (textureBrush, -1, UnitPoint, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyNonSolidBrushPen (pen, -1, UnitPoint, PenTypeTextureFill);
 	GdipDeletePen (pen);
 
 	// PathGradient/UnitInch.
 	status = GdipCreatePen2 (pathGradientBrush, 10, UnitInch, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyNonSolidBrushPen (pen, 10, UnitInch, PenTypePathGradient);
 	GdipDeletePen (pen);
 
 	// LineGradient/UnitDocument.
 	status = GdipCreatePen2 (lineGradientBrush, 10, UnitDocument, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyNonSolidBrushPen (pen, 10, UnitDocument, PenTypeLinearGradient);
 	GdipDeletePen (pen);
 
 	// LinearGradient/UnitDocument.
 	status = GdipCreatePen2 (lineGradientBrush, 10, UnitMillimeter, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyNonSolidBrushPen (pen, 10, UnitMillimeter, PenTypeLinearGradient);
 	GdipDeletePen (pen);
 
 #if !defined(_WIN32)
 // LinearGradient/UnitCairoPoint.
 	status = GdipCreatePen2 (lineGradientBrush, 10, UnitCairoPoint, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifyNonSolidBrushPen (pen, 10, UnitCairoPoint, PenTypeLinearGradient);
 	GdipDeletePen (pen);
 #endif
 
 	// Negative tests.
 	status = GdipCreatePen1 (1, 10, (Unit)(UnitWorld - 1), &pen);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreatePen1 (1, 10, UnitDisplay, &pen);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreatePen1 (1, 10, (Unit)(8), &pen);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipCreatePen1 (1, 10, UnitWorld, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeleteBrush ((GpBrush *) solidBrush);
 	GdipDeleteBrush ((GpBrush *) hatchBrush);
@@ -314,15 +314,15 @@ static void test_clone ()
 	GdipCreatePen1 (1, 10, UnitDocument, &pen);
 
 	status = GdipClonePen (pen, &clone);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	verifySolidBrushPen (clone, 1, 10, UnitDocument);
 
 	// Negative tests.
 	status = GdipClonePen (NULL, &clone);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipClonePen (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 	GdipDeletePen (clone);
@@ -337,10 +337,10 @@ static void test_getPenWidth ()
 	GdipCreatePen1 (1, 10, UnitWorld, &pen);
 
 	status = GdipGetPenWidth (NULL, &width);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenWidth (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -354,14 +354,14 @@ static void test_setPenWidth ()
 	GdipCreatePen1 (1, 10, UnitWorld, &pen);
 
 	status = GdipSetPenWidth (pen, -1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenWidth (pen, &width);
-	assert (status == Ok);
-	assert (width == -1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (width, -1);
 
 	status = GdipSetPenWidth (NULL, 10);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -375,10 +375,10 @@ static void test_getPenUnit ()
 	GdipCreatePen1 (1, 10, UnitWorld, &pen);
 
 	status = GdipGetPenUnit (NULL, &unit);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenUnit (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -393,74 +393,74 @@ static void test_setPenUnit ()
 
 	// UnitWorld.
 	status = GdipSetPenUnit (pen, UnitWorld);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenUnit (pen, &unit);
-	assert (status == Ok);
-	assert (unit == UnitWorld);
+	assertEqualInt (status, Ok);
+	assertEqualInt (unit, UnitWorld);
 
 	// UnitPixel.
 	status = GdipSetPenUnit (pen, UnitPixel);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenUnit (pen, &unit);
-	assert (status == Ok);
-	assert (unit == UnitPixel);
+	assertEqualInt (status, Ok);
+	assertEqualInt (unit, UnitPixel);
 
 	// UnitPoint.
 	status = GdipSetPenUnit (pen, UnitPoint);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenUnit (pen, &unit);
-	assert (status == Ok);
-	assert (unit == UnitPoint);
+	assertEqualInt (status, Ok);
+	assertEqualInt (unit, UnitPoint);
 
 	// UnitInch.
 	status = GdipSetPenUnit (pen, UnitInch);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenUnit (pen, &unit);
-	assert (status == Ok);
-	assert (unit == UnitInch);
+	assertEqualInt (status, Ok);
+	assertEqualInt (unit, UnitInch);
 
 	// UnitDocument.
 	status = GdipSetPenUnit (pen, UnitDocument);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenUnit (pen, &unit);
-	assert (status == Ok);
-	assert (unit == UnitDocument);
+	assertEqualInt (status, Ok);
+	assertEqualInt (unit, UnitDocument);
 
 	// UnitMillimeter.
 	status = GdipSetPenUnit (pen, UnitMillimeter);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenUnit (pen, &unit);
-	assert (status == Ok);
-	assert (unit == UnitMillimeter);
+	assertEqualInt (status, Ok);
+	assertEqualInt (unit, UnitMillimeter);
 
 #if !defined(_WIN32)
 	// UnitCairoPoint.
 	status = GdipSetPenUnit (pen, UnitCairoPoint);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenUnit (pen, &unit);
-	assert (status == Ok);
-	assert (unit == UnitCairoPoint);
+	assertEqualInt (status, Ok);
+	assertEqualInt (unit, UnitCairoPoint);
 #endif
 
 	// Negative tests.
 	status = GdipSetPenUnit (NULL, UnitWorld);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenUnit (pen, (Unit)(UnitWorld -1));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenUnit (pen, UnitDisplay);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenUnit (pen, (Unit)(8));
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -487,74 +487,74 @@ static void test_setPenLineCap197819 ()
 	status = GdipSetPenLineCap197819 (pen, LineCapArrowAnchor, LineCapDiamondAnchor, DashCapRound);
 
 	GdipGetPenStartCap (pen, &startCap);
-	assert (startCap == LineCapArrowAnchor);
+	assertEqualInt (startCap, LineCapArrowAnchor);
 
 	GdipGetPenEndCap (pen, &endCap);
-	assert (endCap == LineCapDiamondAnchor);
+	assertEqualInt (endCap, LineCapDiamondAnchor);
 
 	GdipGetPenDashCap197819 (pen, &dashCap);
-	assert (dashCap == DashCapRound);
+	assertEqualInt (dashCap, DashCapRound);
 
 	// Custom values.
 	status = GdipSetPenLineCap197819 (pen, LineCapCustom, LineCapCustom, DashCapTriangle);
 
 	GdipGetPenStartCap (pen, &startCap);
-	assert (startCap == LineCapCustom);
+	assertEqualInt (startCap, LineCapCustom);
 
 	GdipGetPenEndCap (pen, &endCap);
-	assert (endCap == LineCapCustom);
+	assertEqualInt (endCap, LineCapCustom);
 
 	GdipGetPenDashCap197819 (pen, &dashCap);
-	assert (dashCap == DashCapTriangle);
+	assertEqualInt (dashCap, DashCapTriangle);
 
 	// Invalid values - negative.
 	status = GdipSetPenLineCap197819 (pen, (LineCap)(LineCapFlat - 1), (LineCap)(LineCapFlat - 1), (DashCap)(DashCapFlat - 1));
 
 	GdipGetPenStartCap (pen, &startCap);
-	assert (startCap == (LineCap)(LineCapFlat - 1));
+	assertEqualInt (startCap, (LineCap)(LineCapFlat - 1));
 
 	GdipGetPenEndCap (pen, &endCap);
-	assert (endCap == (LineCap)(LineCapFlat - 1));
+	assertEqualInt (endCap, (LineCap)(LineCapFlat - 1));
 
 	GdipGetPenDashCap197819 (pen, &dashCap);
-	assert (dashCap == DashCapFlat);
+	assertEqualInt (dashCap, DashCapFlat);
 
 	// Invalid values - positive.
 	status = GdipSetPenLineCap197819 (pen, (LineCap)(LineCapCustom + 1), (LineCap)(LineCapCustom + 1), (DashCap)(DashCapTriangle + 1));
 
 	GdipGetPenStartCap (pen, &startCap);
-	assert (startCap == (LineCap)(LineCapCustom + 1));
+	assertEqualInt (startCap, (LineCap)(LineCapCustom + 1));
 
 	GdipGetPenEndCap (pen, &endCap);
-	assert (endCap == (LineCap)(LineCapCustom + 1));
+	assertEqualInt (endCap, (LineCap)(LineCapCustom + 1));
 
 	GdipGetPenDashCap197819 (pen, &dashCap);
-	assert (dashCap == DashCapFlat);
+	assertEqualInt (dashCap, DashCapFlat);
 
 	// Set when there is already a custom cap.
 	GdipSetPenCustomStartCap (pen, penCustomLineCap);
 	GdipSetPenCustomEndCap (pen, penCustomLineCap);
 
 	status = GdipSetPenLineCap197819 (pen, LineCapNoAnchor, LineCapFlat, DashCapRound);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenCustomStartCap (pen, &customStartCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetCustomLineCapBaseInset (customStartCap, &startCapBaseInset);
-	assert (status == Ok);
-	assert (startCapBaseInset == 10);
+	assertEqualInt (status, Ok);
+	assertEqualInt (startCapBaseInset, 10);
 
 	status = GdipGetPenCustomEndCap (pen, &customEndCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetCustomLineCapBaseInset (customEndCap, &endCapBaseInset);
-	assert (status == Ok);
-	assert (startCapBaseInset == 10);
+	assertEqualInt (status, Ok);
+	assertEqualInt (startCapBaseInset, 10);
 
 	// Negative tests.
 	status = GdipSetPenLineCap197819 (NULL, LineCapArrowAnchor, LineCapDiamondAnchor, DashCapFlat);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 	GdipDeletePath (path);
@@ -580,41 +580,41 @@ static void test_setPenStartCap ()
 	status = GdipSetPenStartCap (pen, LineCapArrowAnchor);
 
 	GdipGetPenStartCap (pen, &startCap);
-	assert (startCap == LineCapArrowAnchor);
+	assertEqualInt (startCap, LineCapArrowAnchor);
 
 	// Custom values.
 	status = GdipSetPenStartCap (pen, LineCapCustom);
 
 	GdipGetPenStartCap (pen, &startCap);
-	assert (startCap == LineCapCustom);
+	assertEqualInt (startCap, LineCapCustom);
 
 	// Set when there is already a custom cap.
 	GdipSetPenCustomStartCap (pen, penCustomLineCap);
 
 	status = GdipSetPenStartCap (pen, LineCapNoAnchor);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenCustomStartCap (pen, &customStartCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (!customStartCap && "Expected the pen's custom start cap to be cleared.");
 
 	// Invalid values - negative.
 	status = GdipSetPenStartCap (pen, (LineCap)(LineCapFlat - 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenStartCap (pen, &startCap);
-	assert (startCap == (LineCap)(LineCapFlat - 1));
+	assertEqualInt (startCap, (LineCap)(LineCapFlat - 1));
 
 	// Invalid values - positive.
 	status = GdipSetPenStartCap (pen, (LineCap)(LineCapCustom + 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenStartCap (pen, &startCap);
-	assert (startCap == (LineCap)(LineCapCustom + 1));
+	assertEqualInt (startCap, (LineCap)(LineCapCustom + 1));
 
 	// Negative tests.
 	status = GdipSetPenStartCap (NULL, LineCapArrowAnchor);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 	GdipDeleteCustomLineCap (penCustomLineCap);
@@ -636,45 +636,45 @@ static void test_setPenEndCap ()
 
 	// Valid values.
 	status = GdipSetPenEndCap (pen, LineCapArrowAnchor);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenEndCap (pen, &endCap);
-	assert (endCap == LineCapArrowAnchor);
+	assertEqualInt (endCap, LineCapArrowAnchor);
 
 	// Custom values.
 	status = GdipSetPenEndCap (pen, LineCapCustom);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenEndCap (pen, &endCap);
-	assert (endCap == LineCapCustom);
+	assertEqualInt (endCap, LineCapCustom);
 
 	// Set when there is already a custom cap.
 	GdipSetPenCustomEndCap (pen, penCustomLineCap);
 
 	status = GdipSetPenEndCap (pen, LineCapNoAnchor);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenCustomEndCap (pen, &customEndCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (!customEndCap && "Expected the pen's custom end cap to be cleared.");
 
 	// Invalid values - negative.
 	status = GdipSetPenEndCap (pen, (LineCap)(LineCapFlat - 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenEndCap (pen, &endCap);
-	assert (endCap == (LineCap)(LineCapFlat - 1));
+	assertEqualInt (endCap, (LineCap)(LineCapFlat - 1));
 
 	// Invalid values - positive.
 	status = GdipSetPenEndCap (pen, (LineCap)(LineCapCustom + 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenEndCap (pen, &endCap);
-	assert (endCap == (LineCap)(LineCapCustom + 1));
+	assertEqualInt (endCap, (LineCap)(LineCapCustom + 1));
 
 	// Negative tests.
 	status = GdipSetPenEndCap (NULL, LineCapArrowAnchor);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 	GdipDeleteCustomLineCap (penCustomLineCap);
@@ -691,42 +691,42 @@ static void tet_setPenDashCap197819 ()
 
 	// Round.
 	status = GdipSetPenDashCap197819 (pen, DashCapRound);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenDashCap197819 (pen, &dashCap);
-	assert (dashCap == DashCapRound);
+	assertEqualInt (dashCap, DashCapRound);
 
 	// Triangle.
 	status = GdipSetPenDashCap197819 (pen, DashCapTriangle);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenDashCap197819 (pen, &dashCap);
-	assert (dashCap == DashCapTriangle);
+	assertEqualInt (dashCap, DashCapTriangle);
 
 	// Flat.
 	status = GdipSetPenDashCap197819 (pen, DashCapFlat);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenDashCap197819 (pen, &dashCap);
-	assert (dashCap == DashCapFlat);
+	assertEqualInt (dashCap, DashCapFlat);
 
 	// Invalid values - negative.
 	status = GdipSetPenDashCap197819 (pen, (DashCap)(DashCapFlat - 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenDashCap197819 (pen, &dashCap);
-	assert (dashCap == DashCapFlat);
+	assertEqualInt (dashCap, DashCapFlat);
 
 	// Invalid values - positive.
 	status = GdipSetPenDashCap197819 (pen, (DashCap)(DashCapTriangle + 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipGetPenDashCap197819 (pen, &dashCap);
-	assert (dashCap == DashCapFlat);
+	assertEqualInt (dashCap, DashCapFlat);
 
 	// Negative tests.
 	status = GdipSetPenDashCap197819 (NULL, DashCapFlat);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -741,10 +741,10 @@ static void test_getPenStartCap ()
 
 	// Negative tests.
 	status = GdipGetPenStartCap (NULL, &startCap);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenStartCap (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -759,10 +759,10 @@ static void test_getPenEndCap ()
 
 	// Negative tests.
 	status = GdipGetPenEndCap (NULL, &endCap);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenEndCap (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -777,10 +777,10 @@ static void test_getPenDashCap197819 ()
 
 	// Negative tests.
 	status = GdipGetPenDashCap197819 (NULL, &dashCap);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenDashCap197819 (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -795,31 +795,31 @@ static void test_setPenLineJoin ()
 
 	// LineJoinBevel.
 	status = GdipSetPenLineJoin (pen, LineJoinBevel);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenLineJoin (pen, &lineJoin);
-	assert (status == Ok);
-	assert (lineJoin == LineJoinBevel);
+	assertEqualInt (status, Ok);
+	assertEqualInt (lineJoin, LineJoinBevel);
 	
 	// Invalid value - negative.
 	status = GdipSetPenLineJoin (pen, (LineJoin)(LineJoinMiter - 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenLineJoin (pen, &lineJoin);
-	assert (status == Ok);
-	assert (lineJoin == (LineJoin)(LineJoinMiter - 1));
+	assertEqualInt (status, Ok);
+	assertEqualInt (lineJoin, (LineJoin)(LineJoinMiter - 1));
 	
 	// Invalid value - positive.
 	status = GdipSetPenLineJoin (pen, (LineJoin)(LineJoinMiterClipped + 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenLineJoin (pen, &lineJoin);
-	assert (status == Ok);
-	assert (lineJoin == (LineJoin)(LineJoinMiterClipped + 1));
+	assertEqualInt (status, Ok);
+	assertEqualInt (lineJoin, (LineJoin)(LineJoinMiterClipped + 1));
 
 	// Negative tests.
 	status = GdipSetPenLineJoin (NULL, LineJoinBevel);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -834,10 +834,10 @@ static void test_getPenLineJoin ()
 
 	// Negative tests.
 	status = GdipGetPenLineJoin (NULL, &lineJoin);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenLineJoin (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -857,26 +857,26 @@ static void test_setPenCustomStartCap ()
 	GdipCreateCustomLineCap (path, NULL, LineCapDiamondAnchor, 10, &penCustomLineCap);
 
 	status = GdipSetPenCustomStartCap (pen, penCustomLineCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenStartCap (pen, &startCap);
-	assert (status == Ok);
-	assert (startCap == LineCapCustom);
+	assertEqualInt (status, Ok);
+	assertEqualInt (startCap, LineCapCustom);
 
 	status = GdipGetPenCustomStartCap (pen, &customStartCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (customStartCap && customStartCap != penCustomLineCap);
 
 	status = GdipGetCustomLineCapBaseInset (customStartCap, &baseInset);
-	assert (status == Ok);
-	assert (baseInset == 10);
+	assertEqualInt (status, Ok);
+	assertEqualInt (baseInset, 10);
 
 	// Negative tests.
 	status = GdipSetPenCustomStartCap (NULL, penCustomLineCap);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenCustomStartCap (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 	GdipDeleteCustomLineCap (penCustomLineCap);
@@ -893,10 +893,10 @@ static void test_getPenCustomStartCap ()
 
 	// Negative tests.
 	status = GdipGetPenCustomStartCap (NULL, &customStartCap);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenCustomStartCap (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -916,26 +916,26 @@ static void test_setPenCustomEndCap ()
 	GdipCreateCustomLineCap (path, NULL, LineCapDiamondAnchor, 10, &penCustomLineCap);
 
 	status = GdipSetPenCustomEndCap (pen, penCustomLineCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenEndCap (pen, &endCap);
-	assert (status == Ok);
-	assert (endCap == LineCapCustom);
+	assertEqualInt (status, Ok);
+	assertEqualInt (endCap, LineCapCustom);
 
 	status = GdipGetPenCustomEndCap (pen, &customEndCap);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (customEndCap && customEndCap != penCustomLineCap);
 
 	status = GdipGetCustomLineCapBaseInset (customEndCap, &baseInset);
-	assert (status == Ok);
-	assert (baseInset == 10);
+	assertEqualInt (status, Ok);
+	assertEqualInt (baseInset, 10);
 
 	// Negative tests.
 	status = GdipSetPenCustomEndCap (NULL, penCustomLineCap);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenCustomEndCap (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 	GdipDeleteCustomLineCap (penCustomLineCap);
@@ -952,10 +952,10 @@ static void test_getPenCustomEndCap ()
 
 	// Negative tests.
 	status = GdipGetPenCustomEndCap (NULL, &customEndCap);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenCustomEndCap (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -970,31 +970,31 @@ static void test_setPenMiterLimit ()
 
 	// Positive.
 	status = GdipSetPenMiterLimit (pen, 100);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenMiterLimit (pen, &miterLimit);
-	assert (status == Ok);
-	assert (miterLimit == 100);
+	assertEqualInt (status, Ok);
+	assertEqualInt (miterLimit, 100);
 
 	// Zero.
 	status = GdipSetPenMiterLimit (pen, 0);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenMiterLimit (pen, &miterLimit);
-	assert (status == Ok);
-	assert (miterLimit == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (miterLimit, 1);
 
 	// Negative.
 	status = GdipSetPenMiterLimit (pen, -100);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenMiterLimit (pen, &miterLimit);
-	assert (status == Ok);
-	assert (miterLimit == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (miterLimit, 1);
 
 	// Negative tests.
 	status = GdipSetPenMiterLimit (NULL, 10);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1009,10 +1009,10 @@ static void test_getPenMiterLimit ()
 
 	// Negative tests.
 	status = GdipGetPenMiterLimit (NULL, &miterLimit);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenMiterLimit (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1028,10 +1028,10 @@ static void test_getPenTransform ()
 
 		// Negative tests.
     status = GdipGetPenTransform (NULL, transform);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetPenTransform (pen, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeletePen (pen);
     GdipDeleteMatrix (transform);
@@ -1049,7 +1049,7 @@ static void test_setPenTransform ()
     GdipCreateMatrix (&transform);
 
     status = GdipSetPenTransform (pen, matrix);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     assert (transform != matrix && "Expected new matrix to be a clone.");
@@ -1062,10 +1062,10 @@ static void test_setPenTransform ()
 
     // Negative tests.
     status = GdipSetPenTransform (NULL, transform);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPenTransform (pen, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeletePen (pen);
     GdipDeleteMatrix (matrix);
@@ -1091,7 +1091,7 @@ static void test_multiplyPenTransform ()
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipMultiplyPenTransform (pen, matrix, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
@@ -1100,14 +1100,14 @@ static void test_multiplyPenTransform ()
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipMultiplyPenTransform (pen, matrix, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
 
     // Null matrix.
     status = GdipMultiplyPenTransform (pen, NULL, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
@@ -1116,7 +1116,7 @@ static void test_multiplyPenTransform ()
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipMultiplyPenTransform (pen, matrix, (MatrixOrder)(MatrixOrderPrepend - 1));
-		assert (status == Ok);
+		assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
@@ -1125,17 +1125,17 @@ static void test_multiplyPenTransform ()
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipMultiplyPenTransform (pen, matrix, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
 
     // Negative tests.
     status = GdipMultiplyPenTransform (NULL, matrix, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipMultiplyPenTransform (pen, nonInvertibleMatrix, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeletePen (pen);
     GdipDeleteMatrix (originalTransform);
@@ -1159,7 +1159,7 @@ static void test_translatePenTransform ()
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipTranslatePenTransform (pen, 5, 6, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 1, 2, 3, 4, 10, 12);
@@ -1168,20 +1168,20 @@ static void test_translatePenTransform ()
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipTranslatePenTransform (pen, 5, 6, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 1, 2, 3, 4, 28, 40);
 
     // Negative tests.
     status = GdipTranslatePenTransform (NULL, 1, 1, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipTranslatePenTransform (pen, 1, 1, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipTranslatePenTransform (pen, 1, 1, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeletePen (pen);
     GdipDeleteMatrix (originalTransform);
@@ -1203,7 +1203,7 @@ static void test_scalePenTransform ()
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipScalePenTransform (pen, 0.5, 0.75, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 0.5, 1.5, 1.5, 3, 2.5, 4.5);
@@ -1212,20 +1212,20 @@ static void test_scalePenTransform ()
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipScalePenTransform (pen, 0.5, 0.75, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 0.5, 1, 2.25, 3, 5, 6);
 
     // Negative tests.
     status = GdipScalePenTransform (NULL, 1, 1, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipScalePenTransform (pen, 1, 1, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipScalePenTransform (pen, 1, 1, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeletePen (pen);
     GdipDeleteMatrix (originalTransform);
@@ -1247,7 +1247,7 @@ static void test_rotatePenTransform ()
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipRotatePenTransform (pen, 90, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, -2, 1, -4, 3, -6, 5);
@@ -1256,20 +1256,20 @@ static void test_rotatePenTransform ()
     GdipSetPenTransform (pen, originalTransform);
 
     status = GdipRotatePenTransform (pen, 90, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetPenTransform (pen, transform);
     verifyMatrix (transform, 3, 4, -1, -2, 5, 6);
 
     // Negative tests.
     status = GdipRotatePenTransform (NULL, 90, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipRotatePenTransform (pen, 90, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipRotatePenTransform (pen, 90, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeletePen (pen);
     GdipDeleteMatrix (originalTransform);
@@ -1286,31 +1286,31 @@ static void test_setPenMode ()
 
 	// PenAlignmentInset.
 	status = GdipSetPenMode (pen, PenAlignmentInset);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenMode (pen, &mode);
-	assert (status == Ok);
-	assert (mode == PenAlignmentInset);
+	assertEqualInt (status, Ok);
+	assertEqualInt (mode, PenAlignmentInset);
 	
 	// Invalid value - negative.
 	status = GdipSetPenMode (pen, (PenAlignment)(PenAlignmentCenter - 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenMode (pen, &mode);
-	assert (status == Ok);
-	assert (mode == (PenAlignment)(PenAlignmentCenter - 1));
+	assertEqualInt (status, Ok);
+	assertEqualInt (mode, (PenAlignment)(PenAlignmentCenter - 1));
 	
 	// Invalid value - positive.
 	status = GdipSetPenMode (pen, (PenAlignment)(PenAlignmentInset + 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenMode (pen, &mode);
-	assert (status == Ok);
-	assert (mode == (PenAlignment)(PenAlignmentInset + 1));
+	assertEqualInt (status, Ok);
+	assertEqualInt (mode, (PenAlignment)(PenAlignmentInset + 1));
 
 	// Negative tests.
 	status = GdipSetPenMode (NULL, PenAlignmentCenter);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1325,10 +1325,10 @@ static void test_getPenMode ()
 
 	// Negative tests.
 	status = GdipGetPenMode (NULL, &mode);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenMode (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1342,15 +1342,15 @@ static void test_setPenColor ()
 	GdipCreatePen1 (1, 10, UnitWorld, &pen);
 
 	status = GdipSetPenColor (pen, 100);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenColor (pen, &color);
-	assert (status == Ok);
-	assert (color == 100);
+	assertEqualInt (status, Ok);
+	assertEqualInt (color, 100);
 
 	// Negative tests.
 	status = GdipSetPenColor (NULL, 100);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1365,10 +1365,10 @@ static void test_getPenColor ()
 
 	// Negative tests.
 	status = GdipGetPenColor (NULL, &color);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenColor (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1392,39 +1392,39 @@ static void test_setPenBrushFill ()
 
 	// SolidFill.
 	status = GdipSetPenBrushFill (pen, solidBrush);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenBrushFill (pen, &brush);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (brush && brush != solidBrush && "Expected new brush to be a clone.");
 	
 	status = GdipGetPenColor (pen, &penColor);
-	assert (status == Ok);
-	assert (penColor == 100);
+	assertEqualInt (status, Ok);
+	assertEqualInt (penColor, 100);
 
 	status = GdipGetSolidFillColor ((GpSolidFill *) brush, &brushColor);
-	assert (status == Ok);
-	assert (brushColor == 100);
+	assertEqualInt (status, Ok);
+	assertEqualInt (brushColor, 100);
 	GdipDeleteBrush (brush);
 
 	// Non SolidFill.
 	status = GdipSetPenBrushFill (pen, textureBrush);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenBrushFill (pen, &brush);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (brush && brush != textureBrush && "Expected new brush to be a clone.");
 
 	status = GdipGetTextureWrapMode ((GpTexture *) brush, &brushWrapMode);
-	assert (status == Ok);
-	assert (brushWrapMode == WrapModeTileFlipX);
+	assertEqualInt (status, Ok);
+	assertEqualInt (brushWrapMode, WrapModeTileFlipX);
 
 	// Negative tests.
 	status = GdipSetPenBrushFill (NULL, solidBrush);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenBrushFill (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 	GdipDeleteBrush ((GpBrush *) solidBrush);
@@ -1442,10 +1442,10 @@ static void test_getPenBrushFill ()
 
 	// Negative tests.
 	status = GdipGetPenBrushFill (NULL, &brush);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenBrushFill (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1460,10 +1460,10 @@ static void test_getPenDashStyle ()
 
 	// Negative tests.
 	status = GdipGetPenDashStyle (NULL, &dashStyle);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenDashStyle (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1480,126 +1480,126 @@ static void test_setPenDashStyle ()
 
 	// DashStyleDashDot.
 	status = GdipSetPenDashStyle (pen, DashStyleDashDot);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenDashStyle (pen, &dashStyle);
-	assert (status == Ok);
-	assert (dashStyle == DashStyleDashDot);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashStyle, DashStyleDashDot);
 
 	status = GdipGetPenDashCount (pen, &dashCount);
-	assert (status == Ok);
-	assert (dashCount == 4);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashCount, 4);
 
 	status = GdipGetPenDashArray (pen, dashArray, dashCount);
-	assert (status == Ok);
-	assert (dashArray[0] == 3);
-	assert (dashArray[1] == 1);
-	assert (dashArray[2] == 1);
-	assert (dashArray[3] == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashArray[0], 3);
+	assertEqualInt (dashArray[1], 1);
+	assertEqualInt (dashArray[2], 1);
+	assertEqualInt (dashArray[3], 1);
 
 	// DashStyleSolid.
 	status = GdipSetPenDashStyle (pen, DashStyleSolid);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenDashStyle (pen, &dashStyle);
-	assert (status == Ok);
-	assert (dashStyle == DashStyleSolid);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashStyle, DashStyleSolid);
 
 	status = GdipGetPenDashCount (pen, &dashCount);
-	assert (status == Ok);
-	assert (dashCount == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashCount, 0);
 
 	// DashStyleDashDotDot.
 	status = GdipSetPenDashStyle (pen, DashStyleDashDotDot);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenDashStyle (pen, &dashStyle);
-	assert (status == Ok);
-	assert (dashStyle == DashStyleDashDotDot);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashStyle, DashStyleDashDotDot);
 
 	status = GdipGetPenDashCount (pen, &dashCount);
-	assert (status == Ok);
-	assert (dashCount == 6);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashCount, 6);
 
 	status = GdipGetPenDashArray (pen, dashArray, dashCount);
-	assert (status == Ok);
-	assert (dashArray[0] == 3);
-	assert (dashArray[1] == 1);
-	assert (dashArray[2] == 1);
-	assert (dashArray[3] == 1);
-	assert (dashArray[4] == 1);
-	assert (dashArray[5] == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashArray[0], 3);
+	assertEqualInt (dashArray[1], 1);
+	assertEqualInt (dashArray[2], 1);
+	assertEqualInt (dashArray[3], 1);
+	assertEqualInt (dashArray[4], 1);
+	assertEqualInt (dashArray[5], 1);
 
 	// DashStyleDot.
 	status = GdipSetPenDashStyle (pen, DashStyleDot);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenDashStyle (pen, &dashStyle);
-	assert (status == Ok);
-	assert (dashStyle == DashStyleDot);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashStyle, DashStyleDot);
 
 	status = GdipGetPenDashCount (pen, &dashCount);
-	assert (status == Ok);
-	assert (dashCount == 2);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashCount, 2);
 
 	status = GdipGetPenDashArray (pen, dashArray, dashCount);
-	assert (status == Ok);
-	assert (dashArray[0] == 1);
-	assert (dashArray[1] == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashArray[0], 1);
+	assertEqualInt (dashArray[1], 1);
 
 	// DashStyleDash.
 	status = GdipSetPenDashStyle (pen, DashStyleDash);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenDashStyle (pen, &dashStyle);
-	assert (status == Ok);
-	assert (dashStyle == DashStyleDash);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashStyle, DashStyleDash);
 
 	status = GdipGetPenDashCount (pen, &dashCount);
-	assert (status == Ok);
-	assert (dashCount == 2);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashCount, 2);
 
 	status = GdipGetPenDashArray (pen, dashArray, dashCount);
-	assert (status == Ok);
-	assert (dashArray[0] == 3);
-	assert (dashArray[1] == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashArray[0], 3);
+	assertEqualInt (dashArray[1], 1);
 
 	// DashStyleCustom.
 	status = GdipSetPenDashStyle (pen, DashStyleCustom);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenDashStyle (pen, &dashStyle);
-	assert (status == Ok);
-	assert (dashStyle == DashStyleCustom);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashStyle, DashStyleCustom);
 
 	status = GdipGetPenDashCount (pen, &dashCount);
-	assert (status == Ok);
-	assert (dashCount == 2);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashCount, 2);
 
 	status = GdipGetPenDashArray (pen, dashArray, dashCount);
-	assert (status == Ok);
-	assert (dashArray[0] == 3);
-	assert (dashArray[1] == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashArray[0], 3);
+	assertEqualInt (dashArray[1], 1);
 
 	// Invalid value - negative.
 	status = GdipSetPenDashStyle (pen, (DashStyle)(DashStyleSolid - 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenDashStyle (pen, &dashStyle);
-	assert (status == Ok);
-	assert (dashStyle == DashStyleCustom);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashStyle, DashStyleCustom);
 
 	// Invalid value - positive.
 	status = GdipSetPenDashStyle (pen, (DashStyle)(DashStyleCustom + 1));
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenDashStyle (pen, &dashStyle);
-	assert (status == Ok);
-	assert (dashStyle == DashStyleCustom);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashStyle, DashStyleCustom);
 
 	// Negative tests.
 	status = GdipSetPenDashStyle (NULL, DashStyleDash);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1614,10 +1614,10 @@ static void test_getPenDashOffset ()
 
 	// Negative tests.
 	status = GdipGetPenDashOffset (NULL, &dashOffset);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenDashOffset (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1632,31 +1632,31 @@ static void test_setPenDashOffset ()
 
 	// Positive.
 	status = GdipSetPenDashOffset (pen, 100);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenDashOffset (pen, &dashOffset);
-	assert (status == Ok);
-	assert (dashOffset == 100);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashOffset, 100);
 
 	// Zero.
 	status = GdipSetPenDashOffset (pen, 0);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenDashOffset (pen, &dashOffset);
-	assert (status == Ok);
-	assert (dashOffset == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashOffset, 0);
 
 	// Negative.
 	status = GdipSetPenDashOffset (pen, -100);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	
 	status = GdipGetPenDashOffset (pen, &dashOffset);
-	assert (status == Ok);
-	assert (dashOffset == -100);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashOffset, -100);
 
 	// Negative tests.
 	status = GdipSetPenDashOffset (NULL, 100);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1671,10 +1671,10 @@ static void test_getPenDashCount ()
 
 	// Negative tests.
 	status = GdipGetPenDashCount (NULL, &dashCount);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenDashCount (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1693,47 +1693,47 @@ static void test_setPenDashArray ()
 
 	// One dash.
 	status = GdipSetPenDashArray (pen, twoDashes, 1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenDashCount (pen, &dashCount);
-	assert (status == Ok);
-	assert (dashCount == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashCount, 1);
 
 	status = GdipGetPenDashArray (pen, dashes, dashCount);
-	assert (status == Ok);
-	assert (dashes[0] == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashes[0], 1);
 
 	// Two dashes.
 	status = GdipSetPenDashArray (pen, twoDashes, 2);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenDashCount (pen, &dashCount);
-	assert (status == Ok);
-	assert (dashCount == 2);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashCount, 2);
 
 	status = GdipGetPenDashArray (pen, dashes, dashCount);
-	assert (status == Ok);
-	assert (dashes[0] == 1);
-	assert (dashes[1] == 2);
+	assertEqualInt (status, Ok);
+	assertEqualInt (dashes[0], 1);
+	assertEqualInt (dashes[1], 2);
 
 	// Negative tests.
 	status = GdipSetPenDashArray (NULL, twoDashes, 2);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenDashArray (pen, NULL, 2);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenDashArray (pen, allZero, 2);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenDashArray (pen, negative, 2);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenDashArray (pen, dashes, 0);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenDashArray (pen, dashes, -1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1748,19 +1748,19 @@ static void test_getPenDashArray ()
 
 	// Negative tests.
 	status = GdipGetPenDashArray (NULL, dashes, 2);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenDashArray (pen, NULL, 2);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenDashArray (pen, dashes, 0);
-	assert (status == OutOfMemory);
+	assertEqualInt (status, OutOfMemory);
 
 	status = GdipGetPenDashArray (pen, dashes, -1);
-	assert (status == OutOfMemory);
+	assertEqualInt (status, OutOfMemory);
 
 	status = GdipGetPenDashArray (pen, dashes, 1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1775,10 +1775,10 @@ static void test_getPenCompoundCount ()
 
 	// Negative tests.
 	status = GdipGetPenCompoundCount (NULL, &compoundCount);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenCompoundCount (pen, NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1796,68 +1796,68 @@ static void test_setPenCompoundArray ()
 
 	// Two compounds - all 1.
 	status = GdipSetPenCompoundArray (pen, fourCompounds, 2);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenCompoundCount (pen, &compoundCount);
-	assert (status == Ok);
-	assert (compoundCount == 2);
+	assertEqualInt (status, Ok);
+	assertEqualInt (compoundCount, 2);
 
 	status = GdipGetPenCompoundArray (pen, compounds, compoundCount - 1);
-	assert (status == Ok);
-	assert (compounds[0] == 1);
-	assert (compounds[1] == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (compounds[0], 1);
+	assertEqualInt (compounds[1], 0);
 
 	status = GdipGetPenCompoundArray (pen, compounds, compoundCount);
-	assert (status == Ok);
-	assert (compounds[0] == 1);
-	assert (compounds[1] == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (compounds[0], 1);
+	assertEqualInt (compounds[1], 1);
 
 	// Two compounds - all 0.
 	status = GdipSetPenCompoundArray (pen, allZero, 2);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenCompoundCount (pen, &compoundCount);
-	assert (status == Ok);
-	assert (compoundCount == 2);
+	assertEqualInt (status, Ok);
+	assertEqualInt (compoundCount, 2);
 
 	status = GdipGetPenCompoundArray (pen, compounds, compoundCount);
-	assert (status == Ok);
-	assert (compounds[0] == 0);
-	assert (compounds[1] == 0);
+	assertEqualInt (status, Ok);
+	assertEqualInt (compounds[0], 0);
+	assertEqualInt (compounds[1], 0);
 
 	// Four compounds.
 	status = GdipSetPenCompoundArray (pen, fourCompounds, 4);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenCompoundCount (pen, &compoundCount);
-	assert (status == Ok);
-	assert (compoundCount == 4);
+	assertEqualInt (status, Ok);
+	assertEqualInt (compoundCount, 4);
 
 	status = GdipGetPenCompoundArray (pen, compounds, compoundCount);
-	assert (status == Ok);
-	assert (compounds[0] == 1);
-	assert (compounds[1] == 1);
-	assert (compounds[2] == 1);
-	assert (compounds[3] == 1);
+	assertEqualInt (status, Ok);
+	assertEqualInt (compounds[0], 1);
+	assertEqualInt (compounds[1], 1);
+	assertEqualInt (compounds[2], 1);
+	assertEqualInt (compounds[3], 1);
 
 	// Negative tests.
 	status = GdipSetPenCompoundArray (NULL, fourCompounds, 2);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenCompoundArray (pen, NULL, 2);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenCompoundArray (pen, fourCompounds, 3);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenCompoundArray (pen, fourCompounds, 1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenCompoundArray (pen, fourCompounds, 0);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipSetPenCompoundArray (pen, fourCompounds, -1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
 }
@@ -1873,42 +1873,42 @@ static void test_getPenCompoundArray ()
 
 	// Negative tests.
 	status = GdipGetPenCompoundArray (NULL, compounds, 2);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenCompoundArray (NULL, compounds, -1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenCompoundArray (pen, NULL, 2);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenCompoundArray (pen, NULL, -1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenCompoundArray (pen, compounds, 1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	// Empty compounds.
 	status = GdipGetPenCompoundArray (pen, compounds, 1);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenCompoundArray (pen, compounds, 0);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenCompoundArray (pen, compounds, -1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	// Non-empty compounds.
 	status = GdipSetPenCompoundArray (pen, twoCompounds, 2);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenCompoundArray (pen, compounds, 3);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 
 	status = GdipGetPenCompoundArray (pen, compounds, 0);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipGetPenCompoundArray (pen, compounds, -1);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	GdipDeletePen (pen);
 }
@@ -1919,14 +1919,14 @@ static void test_deletePen ()
 	GpPen *pen;
 
 	status = GdipCreatePen1 (1, 10, UnitWorld, &pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 
 	status = GdipDeletePen (pen);
-	assert (status == Ok);
+	assertEqualInt (status, Ok);
 	assert (pen);
 
 	status = GdipDeletePen (NULL);
-	assert (status == InvalidParameter);
+	assertEqualInt (status, InvalidParameter);
 }
 
 int

--- a/tests/testpng.c
+++ b/tests/testpng.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "GdiPlusFlat.h"
+#include "testhelpers.h"
 
 static int status_counter = 0;
 
@@ -33,7 +34,7 @@ main (int argc, char **argv)
     // PNG resave should preserve the palette transparency. Let's test it
     // by loading a PNG file and its palette, then resaving it and loading
     // it again for comparison.
-    unis = g_utf8_to_utf16 ("test-trns.png", -1, NULL, NULL, NULL);
+    unis = createWchar ("test-trns.png");
     status = GdipLoadImageFromFile (unis, &img);
     CHECK_STATUS(1);
     g_free (unis);
@@ -45,7 +46,7 @@ main (int argc, char **argv)
     GdipGetImagePalette (img, original_palette, original_palette_size);
     CHECK_STATUS(1);
 
-    unis = g_utf8_to_utf16 ("test-trns-resave.png", -1, NULL, NULL, NULL);
+    unis = createWchar ("test-trns-resave.png");
     status = GdipSaveImageToFile (img, unis, &png_clsid, NULL);
     CHECK_STATUS(1);
     GdipDisposeImage (img);
@@ -71,7 +72,7 @@ main (int argc, char **argv)
 
     // Test grayscale image with alpha channel. The image should be converted
     // into 32-bit ARGB format and the alpha channel should be preserved.
-    unis = g_utf8_to_utf16 ("test-gsa.png", -1, NULL, NULL, NULL);
+    unis = createWchar ("test-gsa.png");
     status = GdipCreateBitmapFromFile (unis, &bitmap);
     CHECK_STATUS(1);
     g_free (unis);

--- a/tests/testpng.c
+++ b/tests/testpng.c
@@ -37,7 +37,7 @@ main (int argc, char **argv)
     unis = createWchar ("test-trns.png");
     status = GdipLoadImageFromFile (unis, &img);
     CHECK_STATUS(1);
-    g_free (unis);
+    freeWchar (unis);
 
     status = GdipGetImagePaletteSize (img, &original_palette_size);
     CHECK_STATUS(1);
@@ -52,7 +52,7 @@ main (int argc, char **argv)
     GdipDisposeImage (img);
     status = GdipLoadImageFromFile (unis, &img);
     CHECK_STATUS(1);
-    g_free (unis);
+    freeWchar (unis);
 
     status = GdipGetImagePaletteSize (img, &reloaded_palette_size);
     CHECK_STATUS(1);
@@ -75,7 +75,7 @@ main (int argc, char **argv)
     unis = createWchar ("test-gsa.png");
     status = GdipCreateBitmapFromFile (unis, &bitmap);
     CHECK_STATUS(1);
-    g_free (unis);
+    freeWchar (unis);
     status = GdipGetImagePixelFormat (bitmap, &pixel_format);
     CHECK_STATUS(1);
     CHECK_ASSERT(pixel_format == PixelFormat32bppARGB);    

--- a/tests/testreversepath.c
+++ b/tests/testreversepath.c
@@ -11,8 +11,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include "testhelpers.h"
 
-#define C(func) assert(func == Ok)
+#define C(func) assert (func == Ok)
 
 #ifdef WIN32
 using namespace Gdiplus;
@@ -25,8 +26,8 @@ static void check_reverse_points(const GpPointF *p1, const GpPointF *p2, int cou
 	p2 += count;
 	while (count--) {
 		p2--;
-		assert (p1->X == p2->X);
-		assert (p1->Y == p2->Y);
+		assertEqualFloat (p1->X, p2->X);
+		assertEqualFloat (p1->Y, p2->Y);
 		p1++;
 	}
 }
@@ -46,30 +47,30 @@ test_gdip_reversepath()
 	C (GdipCreatePath (FillModeAlternate, &path));
 
 	C (GdipGetPointCount (path, &count));
-	assert (count == 0);
+	assertEqualInt (count,  0);
 
 	// Reverse an empty path
 	C (GdipReversePath (path));
 	C (GdipGetPointCount (path, &reverse_count));
-	assert (reverse_count == 0);
+	assertEqualInt (reverse_count, 0);
 
 	// Path with one line
 	C (GdipAddPathLine (path, 0, 10, 1, 11));
 	C (GdipGetPointCount (path, &count));
-	assert (count == 2);
+	assertEqualInt (count,  2);
 	C (GdipGetPathTypes (path, types, count));
 	C (GdipGetPathPoints (path, points, count));
-	assert (types[0] == PathPointTypeStart);
-	assert (types[1] == PathPointTypeLine);
+	assertEqualInt (types[0], PathPointTypeStart);
+	assertEqualInt (types[1], PathPointTypeLine);
 
 	C (GdipReversePath (path));
 	C (GdipGetPointCount (path, &reverse_count));
-	assert (reverse_count == count);
+	assertEqualInt (reverse_count, count);
 	C (GdipGetPathTypes (path, reverse_types, count));
 	C (GdipGetPathPoints (path, reverse_points, count));
 	check_reverse_points (points, reverse_points, count);
-	assert (reverse_types[0] == PathPointTypeStart);
-	assert (reverse_types[1] == PathPointTypeLine);
+	assertEqualInt (reverse_types[0], PathPointTypeStart);
+	assertEqualInt (reverse_types[1], PathPointTypeLine);
 
 	GdipResetPath (path);
 
@@ -77,44 +78,44 @@ test_gdip_reversepath()
 	C (GdipAddPathLine (path, 0, 10, 1, 11));
 	C (GdipClosePathFigure (path));
 	C (GdipGetPointCount (path, &count));
-	assert (count == 2);
+	assertEqualInt (count,  2);
 	C (GdipGetPathTypes (path, types, count));
 	C (GdipGetPathPoints (path, points, count));
-	assert (types[0] == PathPointTypeStart);
-	assert (types[1] == (PathPointTypeLine | PathPointTypeCloseSubpath));
+	assertEqualInt (types[0], PathPointTypeStart);
+	assertEqualInt (types[1], (PathPointTypeLine | PathPointTypeCloseSubpath));
 
 	C (GdipReversePath (path));
 	C (GdipGetPointCount (path, &reverse_count));
-	assert (reverse_count == count);
+	assertEqualInt (reverse_count, count);
 	C (GdipGetPathTypes (path, reverse_types, count));
 	C (GdipGetPathPoints (path, reverse_points, count));
 	check_reverse_points (points, reverse_points, count);
-	assert (reverse_types[0] == PathPointTypeStart);
-	assert (reverse_types[1] == (PathPointTypeLine | PathPointTypeCloseSubpath));
+	assertEqualInt (reverse_types[0], PathPointTypeStart);
+	assertEqualInt (reverse_types[1], (PathPointTypeLine | PathPointTypeCloseSubpath));
 
 	GdipResetPath (path);
 
 	// Rectangle
 	C (GdipAddPathRectangle (path, 200, 201, 60, 61));
 	C (GdipGetPointCount (path, &count));
-	assert (count == 4);
+	assertEqualInt (count,  4);
 	C (GdipGetPathTypes (path, types, count));
 	C (GdipGetPathPoints (path, points, count));
-	assert (types[0] == PathPointTypeStart);
-	assert (types[1] == PathPointTypeLine);
-	assert (types[2] == PathPointTypeLine);
-	assert (types[3] == (PathPointTypeLine | PathPointTypeCloseSubpath));
+	assertEqualInt (types[0], PathPointTypeStart);
+	assertEqualInt (types[1], PathPointTypeLine);
+	assertEqualInt (types[2], PathPointTypeLine);
+	assertEqualInt (types[3], (PathPointTypeLine | PathPointTypeCloseSubpath));
 
 	C (GdipReversePath (path));
 	C (GdipGetPointCount (path, &reverse_count));
-	assert (reverse_count == count);
+	assertEqualInt (reverse_count, count);
 	C (GdipGetPathTypes (path, reverse_types, count));
 	C (GdipGetPathPoints (path, reverse_points, count));
 	check_reverse_points (points, reverse_points, count);
-	assert (reverse_types[0] == PathPointTypeStart);
-	assert (reverse_types[1] == PathPointTypeLine);
-	assert (reverse_types[2] == PathPointTypeLine);
-	assert (reverse_types[3] == (PathPointTypeLine | PathPointTypeCloseSubpath));
+	assertEqualInt (reverse_types[0], PathPointTypeStart);
+	assertEqualInt (reverse_types[1], PathPointTypeLine);
+	assertEqualInt (reverse_types[2], PathPointTypeLine);
+	assertEqualInt (reverse_types[3], (PathPointTypeLine | PathPointTypeCloseSubpath));
 
 	GdipResetPath (path);
 
@@ -122,24 +123,24 @@ test_gdip_reversepath()
 	C (GdipAddPathRectangle (path, 200, 201, 60, 61));
 	C (GdipSetPathMarker (path));
 	C (GdipGetPointCount (path, &count));
-	assert (count == 4);
+	assertEqualInt (count,  4);
 	C (GdipGetPathTypes (path, types, count));
 	C (GdipGetPathPoints (path, points, count));
-	assert (types[0] == PathPointTypeStart);
-	assert (types[1] == PathPointTypeLine);
-	assert (types[2] == PathPointTypeLine);
-	assert (types[3] == (PathPointTypeLine | PathPointTypeCloseSubpath | PathPointTypePathMarker));
+	assertEqualInt (types[0], PathPointTypeStart);
+	assertEqualInt (types[1], PathPointTypeLine);
+	assertEqualInt (types[2], PathPointTypeLine);
+	assertEqualInt (types[3], (PathPointTypeLine | PathPointTypeCloseSubpath | PathPointTypePathMarker));
 
 	C (GdipReversePath (path));
 	C (GdipGetPointCount (path, &reverse_count));
-	assert (reverse_count == count);
+	assertEqualInt (reverse_count, count);
 	C (GdipGetPathTypes (path, reverse_types, count));
 	C (GdipGetPathPoints (path, reverse_points, count));
 	check_reverse_points (points, reverse_points, count);
-	assert (reverse_types[0] == PathPointTypeStart);
-	assert (reverse_types[1] == PathPointTypeLine);
-	assert (reverse_types[2] == PathPointTypeLine);
-	assert (reverse_types[3] == (PathPointTypeLine | PathPointTypeCloseSubpath));
+	assertEqualInt (reverse_types[0], PathPointTypeStart);
+	assertEqualInt (reverse_types[1], PathPointTypeLine);
+	assertEqualInt (reverse_types[2], PathPointTypeLine);
+	assertEqualInt (reverse_types[3], (PathPointTypeLine | PathPointTypeCloseSubpath));
 
 	GdipResetPath (path);
 
@@ -148,24 +149,24 @@ test_gdip_reversepath()
 	C (GdipAddPathEllipse (path, 50, 51, 50, 100));
 	C (GdipAddPathRectangle (path, 200, 201, 60, 61));
 	C (GdipGetPointCount (path, &count));
-	assert (count == 17);
+	assertEqualInt (count,  17);
 	C (GdipGetPathTypes (path, types, count));
 	C (GdipGetPathPoints (path, points, count));
-	assert (types[13] == PathPointTypeStart);
-	assert (types[14] == PathPointTypeLine);
-	assert (types[15] == PathPointTypeLine);
-	assert (types[16] == (PathPointTypeLine | PathPointTypeCloseSubpath));
+	assertEqualInt (types[13], PathPointTypeStart);
+	assertEqualInt (types[14], PathPointTypeLine);
+	assertEqualInt (types[15], PathPointTypeLine);
+	assertEqualInt (types[16], (PathPointTypeLine | PathPointTypeCloseSubpath));
 
 	C (GdipReversePath (path));
 	C (GdipGetPointCount (path, &reverse_count));
-	assert (reverse_count == count);
+	assertEqualInt (reverse_count, count);
 	C (GdipGetPathTypes (path, reverse_types, count));
 	C (GdipGetPathPoints (path, reverse_points, count));
 	check_reverse_points (points, reverse_points, count);
-	assert (reverse_types[0] == types[13]);
-	assert (reverse_types[1] == (types[16] & ~PathPointTypeCloseSubpath));
-	assert (reverse_types[2] == types[15]);
-	assert (reverse_types[3] == (types[14] | PathPointTypeCloseSubpath));
+	assertEqualInt (reverse_types[0], types[13]);
+	assertEqualInt (reverse_types[1], (types[16] & ~PathPointTypeCloseSubpath));
+	assertEqualInt (reverse_types[2], types[15]);
+	assertEqualInt (reverse_types[3], (types[14] | PathPointTypeCloseSubpath));
 
 	GdipResetPath (path);
 
@@ -176,28 +177,28 @@ test_gdip_reversepath()
 	C (GdipAddPathBezier (path, 5, 6, 7, 8, 9, 10, 11, 12));
 	C (GdipClosePathFigure (path));
 	C (GdipGetPointCount (path, &count));
-	assert (count == 6);
+	assertEqualInt (count,  6);
 	C (GdipGetPathTypes (path, types, count));
 	C (GdipGetPathPoints (path, points, count));
-	assert (types[0] == PathPointTypeStart);
-	assert (types[1] == (PathPointTypeLine | PathPointTypePathMarker | PathPointTypeCloseSubpath));
-	assert (types[2] == PathPointTypeStart);
-	assert (types[3] == PathPointTypeBezier);
-	assert (types[4] == PathPointTypeBezier);
-	assert (types[5] == (PathPointTypeBezier | PathPointTypeCloseSubpath));
+	assertEqualInt (types[0], PathPointTypeStart);
+	assertEqualInt (types[1], (PathPointTypeLine | PathPointTypePathMarker | PathPointTypeCloseSubpath));
+	assertEqualInt (types[2], PathPointTypeStart);
+	assertEqualInt (types[3], PathPointTypeBezier);
+	assertEqualInt (types[4], PathPointTypeBezier);
+	assertEqualInt (types[5], (PathPointTypeBezier | PathPointTypeCloseSubpath));
 
 	C (GdipReversePath (path));
 	C (GdipGetPointCount (path, &reverse_count));
-	assert (reverse_count == count);
+	assertEqualInt (reverse_count, count);
 	C (GdipGetPathTypes (path, reverse_types, count));
 	C (GdipGetPathPoints (path, reverse_points, count));
 	check_reverse_points (points, reverse_points, count);
-	assert (reverse_types[0] == types[2]);
-	assert (reverse_types[1] == types[4]);
-	assert (reverse_types[2] == types[3]);
-	assert (reverse_types[3] == (types[5] | PathPointTypePathMarker));
-	assert (reverse_types[4] == types[0]);
-	assert (reverse_types[5] == (types[1] & ~PathPointTypePathMarker));
+	assertEqualInt (reverse_types[0], types[2]);
+	assertEqualInt (reverse_types[1], types[4]);
+	assertEqualInt (reverse_types[2], types[3]);
+	assertEqualInt (reverse_types[3], (types[5] | PathPointTypePathMarker));
+	assertEqualInt (reverse_types[4], types[0]);
+	assertEqualInt (reverse_types[5], (types[1] & ~PathPointTypePathMarker));
 
 	GdipResetPath (path);
 
@@ -208,32 +209,32 @@ test_gdip_reversepath()
 	C (GdipAddPathLine (path, 20, 21, 22, 23));
 	C (GdipAddPathBezier (path, 5, 6, 7, 8, 9, 10, 11, 12));
 	C (GdipGetPointCount (path, &count));
-	assert (count == 8);
+	assertEqualInt (count,  8);
 	C (GdipGetPathTypes (path, types, count));
 	C (GdipGetPathPoints (path, points, count));
-	assert (types[0] == PathPointTypeStart);
-	assert (types[1] == (PathPointTypeLine | PathPointTypePathMarker));
-	assert (types[2] == PathPointTypeStart);
-	assert (types[3] == PathPointTypeLine);
-	assert (types[4] == PathPointTypeLine);
-	assert (types[5] == PathPointTypeBezier);
-	assert (types[6] == PathPointTypeBezier);
-	assert (types[7] == PathPointTypeBezier);
+	assertEqualInt (types[0], PathPointTypeStart);
+	assertEqualInt (types[1], (PathPointTypeLine | PathPointTypePathMarker));
+	assertEqualInt (types[2], PathPointTypeStart);
+	assertEqualInt (types[3], PathPointTypeLine);
+	assertEqualInt (types[4], PathPointTypeLine);
+	assertEqualInt (types[5], PathPointTypeBezier);
+	assertEqualInt (types[6], PathPointTypeBezier);
+	assertEqualInt (types[7], PathPointTypeBezier);
 
 	C (GdipReversePath (path));
 	C (GdipGetPointCount (path, &reverse_count));
-	assert (reverse_count == count);
+	assertEqualInt (reverse_count, count);
 	C (GdipGetPathTypes (path, reverse_types, count));
 	C (GdipGetPathPoints (path, reverse_points, count));
 	check_reverse_points (points, reverse_points, count);
-	assert (reverse_types[0] == PathPointTypeStart);
-	assert (reverse_types[1] == PathPointTypeBezier);
-	assert (reverse_types[2] == PathPointTypeBezier);
-	assert (reverse_types[3] == PathPointTypeBezier);
-	assert (reverse_types[4] == PathPointTypeLine);
-	assert (reverse_types[5] == (PathPointTypeLine | PathPointTypePathMarker));
-	assert (reverse_types[6] == PathPointTypeStart);
-	assert (reverse_types[7] == PathPointTypeLine);
+	assertEqualInt (reverse_types[0], PathPointTypeStart);
+	assertEqualInt (reverse_types[1], PathPointTypeBezier);
+	assertEqualInt (reverse_types[2], PathPointTypeBezier);
+	assertEqualInt (reverse_types[3], PathPointTypeBezier);
+	assertEqualInt (reverse_types[4], PathPointTypeLine);
+	assertEqualInt (reverse_types[5], (PathPointTypeLine | PathPointTypePathMarker));
+	assertEqualInt (reverse_types[6], PathPointTypeStart);
+	assertEqualInt (reverse_types[7], PathPointTypeLine);
 	
 
 	C (GdipDeletePath (path));

--- a/tests/testsolidbrush.c
+++ b/tests/testsolidbrush.c
@@ -35,14 +35,14 @@ static void test_clone ()
     GdipCreateSolidFill (1, &brush);
 
     status = GdipCloneBrush ((GpBrush *) brush, &clone);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (clone && brush != clone);
 
     GdipGetBrushType (clone, &brushType);
-    assert (brushType == BrushTypeSolidColor);
+    assertEqualInt (brushType, BrushTypeSolidColor);
 
     GdipGetSolidFillColor ((GpSolidFill *) clone, &solidColor);
-    assert (solidColor == 1);
+    assertEqualInt (solidColor, 1);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteBrush (clone);
@@ -55,15 +55,15 @@ static void test_createSolidFill ()
     GpBrushType brushType;
 
     status = GdipCreateSolidFill (1, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (brush && "Expected the brush to be initialized.");
 
     status = GdipGetBrushType ((GpBrush *) brush, &brushType);
-    assert (status == Ok);
-    assert (brushType == BrushTypeSolidColor);
+    assertEqualInt (status, Ok);
+    assertEqualInt (brushType, BrushTypeSolidColor);
 
     status = GdipCreateSolidFill (1, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -77,14 +77,14 @@ static void test_getSolidFillColor ()
     GdipCreateSolidFill (1, &brush);
 
     status = GdipGetSolidFillColor (brush, &color);
-    assert (status == Ok);
-    assert (color == 1);
+    assertEqualInt (status, Ok);
+    assertEqualInt (color, 1);
 
     status = GdipGetSolidFillColor (NULL, &color);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetSolidFillColor (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }
@@ -98,13 +98,13 @@ static void test_setSolidFillColor ()
     GdipCreateSolidFill (1, &brush);
 
     status = GdipSetSolidFillColor (brush, 2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetSolidFillColor (brush, &color);
-    assert (color == 2);
+    assertEqualInt (color, 2);
 
     status = GdipSetSolidFillColor (NULL, 1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
 }

--- a/tests/testtexturebrush.c
+++ b/tests/testtexturebrush.c
@@ -28,7 +28,7 @@ static GpImage * getImage ()
     GpStatus status;
     GpBitmap *image;
     status = GdipCreateBitmapFromScan0 (100, 68, 0, PixelFormat32bppRGB, NULL, &image);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     return (GpImage *)image;
 }
@@ -48,21 +48,21 @@ static void verifyTexture (GpTexture *brush, GpWrapMode expectedWrapMode, REAL e
     GdipCreateMatrix (&brushTransform);
 
     status = GdipGetBrushType (brush, &brushType);
-    assert (brushType == BrushTypeTextureFill);
+    assertEqualInt (brushType, BrushTypeTextureFill);
 
     status = GdipGetTextureWrapMode (brush, &wrapMode);
-    assert (status == Ok);
-    assert (wrapMode == expectedWrapMode);
+    assertEqualInt (status, Ok);
+    assertEqualInt (wrapMode, expectedWrapMode);
 
     status = GdipGetTextureImage (brush, &brushImage);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetImageDimension (brushImage, &brushWidth, &brushHeight);
-    assert (brushWidth == expectedBrushWidth);
-    assert (brushHeight == expectedBrushHeight);
+    assertEqualFloat (brushWidth, expectedBrushWidth);
+    assertEqualFloat (brushHeight, expectedBrushHeight);
 
     status = GdipGetTextureTransform (brush, brushTransform);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyMatrix (brushTransform, 1, 0, 0, 1, 0, 0);
 
     GdipDisposeImage (brushImage);
@@ -87,20 +87,20 @@ static void test_clone ()
     GdipCreateTexture (image1, WrapModeTile, &brush);
 
     status = GdipCloneBrush ((GpBrush *) brush, &clone);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (clone && brush != clone);
 
     GdipGetBrushType (clone, &brushType);
-    assert (brushType == BrushTypeTextureFill);
+    assertEqualInt (brushType, BrushTypeTextureFill);
 
     GdipGetTextureImage ((GpTexture *) clone, &image2);
 
     GdipGetImageDimension (image2, &brushWidth, &brushHeight);
-    assert (brushWidth == 100);
-    assert (brushHeight == 68);
+    assertEqualInt (brushWidth, 100);
+    assertEqualInt (brushHeight, 68);
 
     GdipGetTextureWrapMode ((GpTexture *) clone, &wrapMode);
-    assert (wrapMode == WrapModeTile);
+    assertEqualInt (wrapMode, WrapModeTile);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteBrush (clone);
@@ -117,20 +117,20 @@ static void test_createTexture ()
     image = getImage ();
 
     status = GdipCreateTexture (image, WrapModeClamp, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyTexture (brush, WrapModeClamp, 100, 68);
 
     status = GdipCreateTexture (NULL, WrapModeClamp, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateTexture (image, (GpWrapMode)(WrapModeTile - 1), &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture (image, (GpWrapMode)(WrapModeClamp + 1), &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture (image, WrapModeClamp, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
@@ -145,55 +145,55 @@ static void test_createTexture2 ()
     image = getImage ();
 
     status = GdipCreateTexture2 (image, WrapModeTile, 0, 0, 100, 68, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyTexture (brush, WrapModeTile, 100, 68);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, 5, 6, 7, 8, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyTexture (brush, WrapModeClamp, 7, 8);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateTexture2 (NULL, WrapModeClamp, 0, 0, 1, 2, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateTexture2 (image, (WrapMode)(WrapModeTile - 1), 0, 0, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, (WrapMode)(WrapModeClamp + 1), 0, 0, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, -1, 0, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, 0, -1, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, 0, 0, -1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, 0, 0, 0, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, 0, 0, 1, 0, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, 0, 0, 1, -1, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, 0, 0, 101, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, 1, 0, 100, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, 0, 0, 100, 69, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2 (image, WrapModeClamp, 0, 1, 100, 68, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 }
 
 static void test_createTexture2I ()
@@ -205,55 +205,55 @@ static void test_createTexture2I ()
     image = getImage ();
 
     status = GdipCreateTexture2I (image, WrapModeTile, 0, 0, 100, 68, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyTexture (brush, WrapModeTile, 100, 68);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, 5, 6, 7, 8, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyTexture (brush, WrapModeClamp, 7, 8);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateTexture2I (NULL, WrapModeClamp, 0, 0, 1, 2, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateTexture2I (image, (WrapMode)(WrapModeTile - 1), 0, 0, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, (WrapMode)(WrapModeClamp + 1), 0, 0, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, -1, 0, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, 0, -1, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, 0, 0, -1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, 0, 0, 0, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, 0, 0, 1, 0, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, 0, 0, 1, -1, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, 0, 0, 101, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, 1, 0, 100, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, 0, 0, 100, 69, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTexture2I (image, WrapModeClamp, 0, 1, 100, 68, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 }
 
 static void test_createTextureIA ()
@@ -265,49 +265,49 @@ static void test_createTextureIA ()
     image = getImage ();
 
     status = GdipCreateTextureIA (image, NULL, 0, 0, 100, 68, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyTexture (brush, WrapModeTile, 100, 68);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateTextureIA (image, NULL, 5, 6, 7, 8, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyTexture (brush, WrapModeTile, 7, 8);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateTextureIA (NULL, NULL, 0, 0, 1, 2, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateTextureIA (image, NULL, -1, 0, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIA (image, NULL, 0, -1, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIA (image, NULL, 0, 0, -1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIA (image, NULL, 0, 0, 0, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIA (image, NULL, 0, 0, 1, 0, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIA (image, NULL, 0, 0, 1, -1, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIA (image, NULL, 0, 0, 101, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIA (image, NULL, 1, 0, 100, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIA (image, NULL, 0, 0, 100, 69, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIA (image, NULL, 0, 1, 100, 68, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 }
 
 static void test_createTextureIAI ()
@@ -319,49 +319,49 @@ static void test_createTextureIAI ()
     image = getImage ();
 
     status = GdipCreateTextureIAI (image, NULL, 0, 0, 100, 68, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyTexture (brush, WrapModeTile, 100, 68);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateTextureIAI (image, NULL, 5, 6, 7, 8, &brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     verifyTexture (brush, WrapModeTile, 7, 8);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
     status = GdipCreateTextureIAI (NULL, NULL, 0, 0, 1, 2, &brush);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipCreateTextureIAI (image, NULL, -1, 0, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIAI (image, NULL, 0, -1, 1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIAI (image, NULL, 0, 0, -1, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIAI (image, NULL, 0, 0, 0, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIAI (image, NULL, 0, 0, 1, 0, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIAI (image, NULL, 0, 0, 1, -1, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIAI (image, NULL, 0, 0, 101, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIAI (image, NULL, 1, 0, 100, 2, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIAI (image, NULL, 0, 0, 100, 69, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 
     status = GdipCreateTextureIAI (image, NULL, 0, 1, 100, 68, &brush);
-    assert (status == OutOfMemory);
+    assertEqualInt (status, OutOfMemory);
 }
 
 static void test_getTextureImage ()
@@ -377,18 +377,18 @@ static void test_getTextureImage ()
     GdipCreateTexture (image, WrapModeTile, &brush);
 
     status = GdipGetTextureImage (brush, &brushImage1);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (brushImage1 != image && "The texture image should be a clone.");
 
     status = GdipGetTextureImage (brush, &brushImage2);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
     assert (brushImage2 != brushImage1 && "The texture image should be a clone.");
 
     status = GdipGetTextureImage (NULL, &brushImage1);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetTextureImage (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
@@ -408,10 +408,10 @@ static void test_getTextureWrapMode ()
     GdipCreateTexture (image, WrapModeTile, &brush);
 
     status = GdipGetTextureWrapMode (NULL, &wrapMode);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetTextureWrapMode (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
@@ -429,27 +429,27 @@ static void test_setTextureWrapMode ()
     GdipCreateTexture (image, WrapModeTile, &brush);
 
     status = GdipSetTextureWrapMode (brush, WrapModeTileFlipX);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureWrapMode (brush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipX);
+    assertEqualInt (wrapMode, WrapModeTileFlipX);
 
     // Setting to an invalid WrapMode is a nop.
     status = GdipSetTextureWrapMode (brush, (WrapMode)(WrapModeTile - 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureWrapMode (brush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipX);
+    assertEqualInt (wrapMode, WrapModeTileFlipX);
 
     status = GdipSetTextureWrapMode (brush, (WrapMode)(WrapModeClamp + 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureWrapMode (brush, &wrapMode);
-    assert (wrapMode == WrapModeTileFlipX);
+    assertEqualInt (wrapMode, WrapModeTileFlipX);
 
     // Negative tests.
     status = GdipSetTextureWrapMode (NULL, wrapMode);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
@@ -468,10 +468,10 @@ static void test_getTextureTransform ()
     GdipCreateMatrix (&transform);
 
     status = GdipGetTextureTransform (NULL, transform);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipGetTextureTransform (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
@@ -493,7 +493,7 @@ static void test_setTextureTransform ()
     GdipCreateMatrix (&transform);
 
     status = GdipSetTextureTransform (brush, matrix);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     assert (transform != matrix && "Expected new matrix to be a clone.");
@@ -506,10 +506,10 @@ static void test_setTextureTransform ()
 
     // Negative tests.
     status = GdipSetTextureTransform (NULL, transform);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipSetTextureTransform (brush, NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
@@ -534,13 +534,13 @@ static void test_resetTextureTransform ()
     GdipSetTextureTransform (brush, matrix);
 
     status = GdipResetTextureTransform (brush);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 1, 0, 0, 1, 0, 0);
 
     status = GdipResetTextureTransform (NULL);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
@@ -569,7 +569,7 @@ static void test_multiplyTextureTransform ()
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipMultiplyTextureTransform (brush, matrix, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
@@ -578,14 +578,14 @@ static void test_multiplyTextureTransform ()
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipMultiplyTextureTransform (brush, matrix, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
 
     // Null matrix.
     status = GdipMultiplyTextureTransform (brush, NULL, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 11, 16, 19, 28, 32, 46);
@@ -594,7 +594,7 @@ static void test_multiplyTextureTransform ()
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipMultiplyTextureTransform (brush, matrix, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
@@ -603,17 +603,17 @@ static void test_multiplyTextureTransform ()
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipMultiplyTextureTransform (brush, matrix, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 10, 13, 22, 29, 40, 52);
 
     // Negative tests.
     status = GdipMultiplyTextureTransform (NULL, matrix, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipMultiplyTextureTransform (brush, nonInvertibleMatrix, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
@@ -641,7 +641,7 @@ static void test_translateTextureTransform ()
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipTranslateTextureTransform (brush, 5, 6, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 1, 2, 3, 4, 10, 12);
@@ -650,20 +650,20 @@ static void test_translateTextureTransform ()
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipTranslateTextureTransform (brush, 5, 6, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 1, 2, 3, 4, 28, 40);
 
     // Negative tests.
     status = GdipTranslateTextureTransform (NULL, 1, 1, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipTranslateTextureTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipTranslateTextureTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
@@ -689,7 +689,7 @@ static void test_scaleTextureTransform ()
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipScaleTextureTransform (brush, 0.5, 0.75, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 0.5, 1.5, 1.5, 3, 2.5, 4.5);
@@ -698,20 +698,20 @@ static void test_scaleTextureTransform ()
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipScaleTextureTransform (brush, 0.5, 0.75, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 0.5, 1, 2.25, 3, 5, 6);
 
     // Negative tests.
     status = GdipScaleTextureTransform (NULL, 1, 1, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipScaleTextureTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipScaleTextureTransform (brush, 1, 1, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
@@ -737,7 +737,7 @@ static void test_rotateTextureTransform ()
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipRotateTextureTransform (brush, 90, MatrixOrderAppend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, -2, 1, -4, 3, -6, 5);
@@ -746,20 +746,20 @@ static void test_rotateTextureTransform ()
     GdipSetTextureTransform (brush, originalTransform);
 
     status = GdipRotateTextureTransform (brush, 90, MatrixOrderPrepend);
-    assert (status == Ok);
+    assertEqualInt (status, Ok);
 
     GdipGetTextureTransform (brush, transform);
     verifyMatrix (transform, 3, 4, -1, -2, 5, 6);
 
     // Negative tests.
     status = GdipRotateTextureTransform (NULL, 90, MatrixOrderAppend);
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipRotateTextureTransform (brush, 90, (MatrixOrder)(MatrixOrderPrepend - 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     status = GdipRotateTextureTransform (brush, 90, (MatrixOrder)(MatrixOrderAppend + 1));
-    assert (status == InvalidParameter);
+    assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);


### PR DESCRIPTION
The first commit deals with test compilation failures running the tests against GDI+.

The main bulk of this PR is in the 3rd commit, which defines better error messages instead of the default message that doesn’t show much information.

