### PR TITLE
Add some missing status checks

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -801,9 +801,8 @@ GdipCreateBitmapFromScan0 (int width, int height, int stride, PixelFormat format
 	}
 
 	result = gdip_bitmap_new ();
-	if (result == NULL) {
+	if (!result)
 		return OutOfMemory;
-	}
 
 	result->image_format = MEMBMP;
 	result->cairo_format = cairo_format;
@@ -954,6 +953,9 @@ GdipCreateBitmapFromGraphics (int width, int height, GpGraphics *graphics, GpBit
 	gdip_align_stride (stride);
 	
 	result = gdip_bitmap_new ();
+	if (!result)
+		return OutOfMemory;
+
 	result->image_format = MEMBMP;
 	result->cairo_format = CAIRO_FORMAT_ARGB32;
 

--- a/src/lineargradientbrush.c
+++ b/src/lineargradientbrush.c
@@ -612,6 +612,8 @@ GdipCreateLineBrushFromRectWithAngle (GDIPCONST GpRectF *rect, ARGB color1, ARGB
 		return InvalidParameter; // FIXME: should be OutOfMemory to match GDI+ but needs updates in Mono System.Drawing
 
 	linear = gdip_linear_gradient_new ();
+	if (!linear)
+		return OutOfMemory;
 
 	linear->wrapMode = wrapMode;
 	linear->lineColors [0] = color1;

--- a/src/pathgradientbrush.c
+++ b/src/pathgradientbrush.c
@@ -438,6 +438,9 @@ GdipCreatePathGradient (GDIPCONST GpPointF *points, INT count, GpWrapMode wrapMo
 	GdipAddPathLine2 (gppath, points, count);
 
 	gp = gdip_pathgradient_new ();
+	if (!gp)
+		return OutOfMemory;
+
 	gp->boundary = gppath;
 	gp->wrapMode = wrapMode;
 	gp->center = gdip_get_center (points, count);
@@ -501,6 +504,9 @@ GdipCreatePathGradientFromPath (GDIPCONST GpPath *path, GpPathGradient **polyGra
 		return OutOfMemory;
 
 	gp = gdip_pathgradient_new ();
+	if (!gp)
+		return OutOfMemory;
+
 	GdipClonePath ((GpPath*) path, &(gp->boundary));
 	GdipGetPointCount ((GpPath*) path, &count);
 	points = (GpPointF*) GdipAlloc (count * sizeof (GpPointF));

--- a/src/pen.c
+++ b/src/pen.c
@@ -280,7 +280,7 @@ GdipCreatePen2 (GpBrush *brush, REAL width, GpUnit unit, GpPen **pen)
 	if (!brush || !pen)
 		return InvalidParameter;
 
-        *pen = result = gdip_pen_new ();
+	*pen = result = gdip_pen_new ();
 	if (!result)
 		return OutOfMemory;
 


### PR DESCRIPTION
The Clang static analyzer sometimes complains for these patterns (but not all, for some reason).

I fixed a bunch of them by searching for `_new`