### PR TITLE
Fix cloned metafile raw format

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -2185,14 +2185,14 @@ GdipCloneImage (GpImage *image, GpImage **cloneImage)
 
 	switch (image->type){
 	case ImageTypeBitmap:
-               	gdip_bitmap_clone (image, cloneImage);
+		gdip_bitmap_clone (image, cloneImage);
 		gdip_bitmap_setactive(*cloneImage, NULL, 0);
 		return Ok;
 
 	case ImageTypeMetafile:
 		return gdip_metafile_clone ((GpMetafile*)image, (GpMetafile**)cloneImage);
 
-       	case ImageTypeUnknown:
+	case ImageTypeUnknown:
 	default:
 		return Ok;
 	}

--- a/src/metafile.c
+++ b/src/metafile.c
@@ -873,6 +873,7 @@ gdip_metafile_clone (GpMetafile *metafile, GpMetafile **clonedmetafile)
 	if (!mf)
 		return OutOfMemory;
 
+	memcpy (&mf->base.image_format, &metafile->base.image_format, sizeof (GUID));
 	memcpy (&mf->metafile_header, &metafile->metafile_header, sizeof (MetafileHeader));
 	if (metafile->length > 0) {
 		mf->data = GdipAlloc (metafile->length);

--- a/src/metafile.c
+++ b/src/metafile.c
@@ -855,6 +855,8 @@ gdip_metafile_create ()
 {
 	GpMetafile* mf = (GpMetafile*) GdipAlloc (sizeof (GpMetafile));
 	if (mf) {
+		memset (&mf->base, 0, sizeof (GpImage));
+
 		mf->base.type = ImageTypeMetafile;
 		mf->delete = FALSE;
 		mf->data = NULL;
@@ -870,10 +872,13 @@ GpStatus
 gdip_metafile_clone (GpMetafile *metafile, GpMetafile **clonedmetafile)
 {
 	GpMetafile *mf = gdip_metafile_create ();
+	GpImage *base;
 	if (!mf)
 		return OutOfMemory;
 
-	memcpy (&mf->base.image_format, &metafile->base.image_format, sizeof (GUID));
+	gdip_bitmap_clone (&metafile->base, &base);
+	mf->base = *base;
+
 	memcpy (&mf->metafile_header, &metafile->metafile_header, sizeof (MetafileHeader));
 	if (metafile->length > 0) {
 		mf->data = GdipAlloc (metafile->length);

--- a/src/metafile.c
+++ b/src/metafile.c
@@ -877,6 +877,11 @@ gdip_metafile_clone (GpMetafile *metafile, GpMetafile **clonedmetafile)
 	memcpy (&mf->metafile_header, &metafile->metafile_header, sizeof (MetafileHeader));
 	if (metafile->length > 0) {
 		mf->data = GdipAlloc (metafile->length);
+		if (!mf->data) {
+			GdipFree (mf);
+			return OutOfMemory;
+		}
+
 		memcpy (mf->data, metafile->data, metafile->length);
 		mf->length = metafile->length;
 	}

--- a/src/metafile.c
+++ b/src/metafile.c
@@ -877,6 +877,7 @@ gdip_metafile_clone (GpMetafile *metafile, GpMetafile **clonedmetafile)
 		return OutOfMemory;
 
 	gdip_bitmap_clone (&metafile->base, &base);
+	gdip_bitmap_setactive (base, NULL, 0);
 	mf->base = *base;
 
 	memcpy (&mf->metafile_header, &metafile->metafile_header, sizeof (MetafileHeader));

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -1,16 +1,17 @@
 #include <assert.h>
 #include <float.h>
 #include <math.h>
+#include <string.h>
 
 BOOL floatsEqual (float v1, float v2)
 {
-	if (isnan (v1))
-		return isnan (v2);
+    if (isnan (v1))
+        return isnan (v2);
 
-	if (isinf (v1))
-		return isinf (v2);
+    if (isinf (v1))
+        return isinf (v2);
 
-	return fabs (v1 - v2) < 0.0001;
+    return fabs (v1 - v2) < 0.0001;
 }
 
 void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5, REAL e6)
@@ -40,13 +41,13 @@ void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5
 #else
 WCHAR* wcharFromChar(const char *c)
 {
-	size_t length = strlen (c);
+    size_t length = strlen (c);
 
-	WCHAR *wc = (WCHAR *)malloc((length + 1) * sizeof(WCHAR *));
-	swprintf (wc, length + 1, L"%hs", c);
-	wc[length] = 0;
+    WCHAR *wc = (WCHAR *)malloc((length + 1) * sizeof(WCHAR *));
+    swprintf (wc, length + 1, L"%hs", c);
+    wc[length] = 0;
 
-	return wc;
+    return wc;
 }
 
 #define createWchar(c) L ##c
@@ -88,6 +89,87 @@ CLSID icoEncoderClsid = { 0x557cf407, 0x1a04, 0x11d3, { 0x9a, 0x73, 0x0, 0x0, 0x
 CLSID wmfEncoderClsid = { 0x557cf404, 0x1a04, 0x11d3, { 0x9a, 0x73, 0x0, 0x0, 0xf8, 0x1e, 0xf3, 0x2e } };
 CLSID emfEncoderClsid = { 0x557cf403, 0x1a04, 0x11d3, { 0x9a, 0x73, 0x0, 0x0, 0xf8, 0x1e, 0xf3, 0x2e } };
 
-BOOL is_32bit () {
-	return sizeof(int *) == 4;
-} 
+#if defined(USE_WINDOWS_GDIPLUS)
+GUID memoryBmpRawFormat = {0xb96b3caaU, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};
+#endif
+GUID bmpRawFormat = {0xb96b3cabU, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};
+GUID tifRawFormat = {0xb96b3cb1U, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};
+GUID gifRawFormat = {0xb96b3cb0U, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};
+GUID pngRawFormat = {0xb96b3cafU, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};
+GUID jpegRawFormat = {0xb96b3caeU, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};
+GUID icoRawFormat = {0xb96b3cb5U, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};
+GUID wmfRawFormat = {0xb96b3cadU, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};
+GUID emfRawFormat = {0xb96b3cacU, 0x0728U, 0x11d3U, {0x9d, 0x7b, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};
+
+BOOL is_32bit ()
+{
+    return sizeof(int *) == 4;
+}
+static void verifyImage (GpImage *image, ImageType expectedType, GUID expectedRawFormat, PixelFormat expectedPixelFormat, REAL expectedX, REAL expectedY, UINT expectedWidth, UINT expectedHeight, REAL expectedDimensionWidth, REAL expectedDimensionHeight, UINT expectedFlags, UINT expectedPropertyCount, BOOL checkFlags)
+{
+    GpStatus status;
+    ImageType type;
+    GUID rawFormat;
+    PixelFormat pixelFormat;
+    UINT width;
+    UINT height;
+    GpRectF bounds;
+    GpUnit unit;
+    REAL dimensionWidth;
+    REAL dimensionHeight;
+    UINT flags;
+    UINT propertyCount;
+
+    status = GdipGetImageType (image, &type);
+    assertEqualInt (status, Ok);
+    assertEqualInt (type, expectedType);
+
+    status = GdipGetImageRawFormat (image, &rawFormat);
+    assertEqualInt (status, Ok);
+    assert (memcmp ((void *) &rawFormat, (void *) &expectedRawFormat, sizeof (GUID)) == 0);
+
+    status = GdipGetImagePixelFormat (image, &pixelFormat);
+    assertEqualInt (status, Ok);
+    assertEqualInt (pixelFormat, expectedPixelFormat);
+
+    status = GdipGetImageWidth (image, &width);
+    assertEqualInt (status, Ok);
+    assertEqualInt (width, expectedWidth);
+
+    status = GdipGetImageHeight (image, &height);
+    assertEqualInt (status, Ok);
+    assertEqualInt (height, expectedHeight);
+
+    status = GdipGetImageBounds (image, &bounds, &unit);
+    assertEqualInt (status, Ok);
+    assertEqualFloat (bounds.X, expectedX);
+    assertEqualFloat (bounds.Y, expectedY);
+    assertEqualFloat (bounds.Width, (REAL)expectedWidth);
+    assertEqualFloat (bounds.Height, (REAL)expectedHeight);
+    assertEqualInt (unit, UnitPixel);
+
+    // Libgdiplus and GDI+ have different exact degrees of accuracy.
+    // Typically they differ by +-0.02.
+    // This is an acceptable difference.
+    status = GdipGetImageDimension (image, &dimensionWidth, &dimensionHeight);
+    assertEqualInt (status, Ok);
+    assert (fabsf (dimensionWidth - expectedDimensionWidth) <= 0.05);
+    assert (fabsf (dimensionHeight - expectedDimensionHeight) <= 0.05);
+
+    // FIXME: libgdiplus and GDI+ have different results for bitmap images.
+#if !defined(USE_WINDOWS_GDIPLUS)
+    if (checkFlags)
+#endif
+    {
+        status = GdipGetImageFlags (image, &flags);
+        assertEqualInt (status, Ok);
+        assertEqualInt (flags, expectedFlags);
+    }
+
+    status = GdipGetPropertyCount (image, &propertyCount);
+    assertEqualInt (status, Ok);
+    // FIXME: libgdiplus returns 0 for each image.
+#if defined(USE_WINDOWS_GDIPLUS)
+    assertEqualInt (propertyCount, expectedPropertyCount);
+#endif
+}

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -105,7 +105,8 @@ BOOL is_32bit ()
 {
     return sizeof(int *) == 4;
 }
-static void verifyImage (GpImage *image, ImageType expectedType, GUID expectedRawFormat, PixelFormat expectedPixelFormat, REAL expectedX, REAL expectedY, UINT expectedWidth, UINT expectedHeight, REAL expectedDimensionWidth, REAL expectedDimensionHeight, UINT expectedFlags, UINT expectedPropertyCount, BOOL checkFlags)
+
+void verifyImage (GpImage *image, ImageType expectedType, GUID expectedRawFormat, PixelFormat expectedPixelFormat, REAL expectedX, REAL expectedY, UINT expectedWidth, UINT expectedHeight, REAL expectedDimensionWidth, REAL expectedDimensionHeight, UINT expectedFlags, UINT expectedPropertyCount, BOOL checkFlags)
 {
     GpStatus status;
     ImageType type;


### PR DESCRIPTION
Previously this wasn’t being set when we cloned the metafile.