### PR TITLE
Fix GdipGetImageDimension for metafiles to match GDI+

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -1257,8 +1257,11 @@ GdipGetImageDimension (GpImage *image, REAL *width, REAL *height)
 		break;
 	case ImageTypeMetafile: {
 		MetafileHeader *metaheader = gdip_get_metaheader(image);
-		*width = metaheader->Width * METAFILE_DIMENSION_FACTOR / metaheader->DpiX;
-		*height = metaheader->Height * METAFILE_DIMENSION_FACTOR / metaheader->DpiY;
+
+		// The width and height values are returned in 0.01 millimeter units.
+		*width = gdip_unit_conversion (UnitPixel, UnitMillimeter, metaheader->DpiX, gtMemoryBitmap, metaheader->Width) * 100;
+		*height = gdip_unit_conversion (UnitPixel, UnitMillimeter, metaheader->DpiY, gtMemoryBitmap, metaheader->Height) * 100;
+
 		break;
 	}
 	default:

--- a/src/metafile-private.h
+++ b/src/metafile-private.h
@@ -39,8 +39,6 @@
 #define WMF_TYPE_AND_HEADERSIZE_KEY	0x00090001
 #define EMF_EMR_HEADER_KEY		0x1
 
-/* this has to do with 25.4mm in an inch (but why is it multiplied by 100 ?) */
-#define METAFILE_DIMENSION_FACTOR	2540
 #define MM_PER_INCH			25.4f
 
 /* object types */

--- a/src/metafile.c
+++ b/src/metafile.c
@@ -73,11 +73,11 @@ gdip_metafile_SetMapMode (MetafilePlayContext *context, DWORD mode)
 		break;
 	case MM_HIMETRIC:
 		/* 1 logical unit == 0.01 mm */
-		scale = gdip_get_display_dpi () / METAFILE_DIMENSION_FACTOR;
+		scale = gdip_get_display_dpi () / (MM_PER_INCH * 100);
 		break;
 	case MM_LOMETRIC:
 		/* 1 logical unit == 0.1 mm */
-		scale = 10 * gdip_get_display_dpi () / METAFILE_DIMENSION_FACTOR;
+		scale = 10 * gdip_get_display_dpi () / (MM_PER_INCH * 10);
 		break;
 	case MM_TWIPS:
 		/* 1 logical point == 1/1440 inch (1/20 of a "old" printer point ;-) */

--- a/src/metafile.c
+++ b/src/metafile.c
@@ -77,7 +77,7 @@ gdip_metafile_SetMapMode (MetafilePlayContext *context, DWORD mode)
 		break;
 	case MM_LOMETRIC:
 		/* 1 logical unit == 0.1 mm */
-		scale = 10 * gdip_get_display_dpi () / (MM_PER_INCH * 10);
+		scale = gdip_get_display_dpi () / (MM_PER_INCH * 10);
 		break;
 	case MM_TWIPS:
 		/* 1 logical point == 1/1440 inch (1/20 of a "old" printer point ;-) */

--- a/tests/testgpimage.c
+++ b/tests/testgpimage.c
@@ -185,7 +185,7 @@ static void test_loadImageFromFileWmf ()
 {
 	GpImage *image = getImage ("test.wmf");
 
-	verifyImage (image, ImageTypeMetafile, wmfRawFormat, PixelFormat32bppRGB, -4008, -3378, 8016, 6756, 20360.64f, 17160.24f, 327683, 0, TRUE);
+	verifyImage (image, ImageTypeMetafile, wmfRawFormat, PixelFormat32bppRGB, -4008, -3378, 8016, 6756, 20360.638672f, 17160.2383f, 327683, 0, TRUE);
 
 	GdipDisposeImage (image);
 }
@@ -194,7 +194,7 @@ static void test_loadImageFromFileEmf ()
 {
 	GpImage *image = getImage ("test.emf");
 
-	verifyImage (image, ImageTypeMetafile, emfRawFormat, PixelFormat32bppRGB, 0, 0, 100, 100, 1944.44f, 1888.88f, 327683, 0, TRUE);
+	verifyImage (image, ImageTypeMetafile, emfRawFormat, PixelFormat32bppRGB, 0, 0, 100, 100, 1944.444336f, 1888.888794f, 327683, 0, TRUE);
 
 	GdipDisposeImage (image);
 }
@@ -227,7 +227,7 @@ static void test_cloneImage ()
 	status = GdipCloneImage (metafileImage, &clonedImage);
 	assertEqualInt (status, Ok);
 	assert (clonedImage && clonedImage != metafileImage);
-	verifyImage (clonedImage, ImageTypeMetafile, wmfRawFormat, PixelFormat32bppRGB, -4008, -3378, 8016, 6756, 20360.64f, 17160.24f, 327683, 0, TRUE);
+	verifyImage (clonedImage, ImageTypeMetafile, wmfRawFormat, PixelFormat32bppRGB, -4008, -3378, 8016, 6756, 20360.638672f, 17160.238281f, 327683, 0, TRUE);
 	GdipDisposeImage (clonedImage);
 
 	// Negative tests.


### PR DESCRIPTION
Relies on #120

Previously, we’d be off by a factor of about 0.02-0.05.

I looked at the docs and discovered that GdipGetImageDimension for metafiles basically returns the width and height in 0.01 millimetre units.

So to get the dimensions, we can just convert the pixels into millimetres using the DPI, and then multiply that by 100 to get the right units.

This is now exactly the value that GDI+ returns, so we don’t need to nerf the tests for this behaviour difference. I’ve updated the tests to reflect the exact values returned by GDI+, that are now also returns by libgdiplus