### PR TITLE
Handle more allocation failures across the codebase

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -643,6 +643,11 @@ gdip_bitmap_clone (GpBitmap *bitmap, GpBitmap **clonedbitmap)
 	/* Allocate and copy frames, properties and bitmap data */
 	if (bitmap->frames != NULL) {
 		result->frames = GdipAlloc(sizeof (FrameData) * result->num_of_frames);
+		if (!result->frames) {
+			status = OutOfMemory;
+			goto fail;
+		}
+
 		for (frame = 0; frame < result->num_of_frames; frame++) {
 			result->frames[frame].count = bitmap->frames[frame].count;
 			result->frames[frame].frame_dimension = bitmap->frames[frame].frame_dimension;

--- a/src/dstream.c
+++ b/src/dstream.c
@@ -120,6 +120,9 @@ fill_buffer (dstream_private *loader)
 	/* First chunk read */
 	if (nbytes > 0 && loader->keep_exif_buffer && loader->exif_buffer == NULL) {
 		loader->exif_buffer = GdipAlloc (offset);
+		if (!loader->exif_buffer)
+			return;
+
 		loader->exif_datasize = offset;
 		memcpy (loader->exif_buffer, loader->buffer, offset);
 	}

--- a/src/font.c
+++ b/src/font.c
@@ -97,10 +97,11 @@ GdipNewInstalledFontCollection (GpFontCollection **font_collection)
 		FcObjectSetDestroy (os);
     
 		system_fonts = (GpFontCollection *) GdipAlloc (sizeof (GpFontCollection));
-		if (system_fonts) {
-			system_fonts->fontset = col;
-			system_fonts->config = NULL;
-		}
+		if (!system_fonts)
+			return OutOfMemory;
+
+		system_fonts->fontset = col;
+		system_fonts->config = NULL;
 	}
 
 	*font_collection = system_fonts;
@@ -117,10 +118,12 @@ GdipNewPrivateFontCollection (GpFontCollection **font_collection)
 		return InvalidParameter;
 
 	result = (GpFontCollection *) GdipAlloc (sizeof (GpFontCollection));
-	if (result) {
-		result->fontset = NULL;
-		result->config = FcConfigCreate ();
-    	}
+	if (!result)
+		return OutOfMemory;
+
+	result->fontset = NULL;
+	result->config = FcConfigCreate ();
+
 	*font_collection = result;
 	return Ok;
 }
@@ -905,6 +908,9 @@ GdipCreateFont (GDIPCONST GpFontFamily* family, REAL emSize, INT style, Unit uni
 	sizeInPixels = gdip_unit_conversion (unit, UnitPixel, gdip_get_display_dpi(), gtMemoryBitmap, emSize);
 		
 	result = (GpFont *) GdipAlloc (sizeof (GpFont));
+	if (!result)
+		return OutOfMemory;
+
 	result->sizeInPixels = sizeInPixels;
 
 	result->face = GdipAlloc(strlen((char *)str) + 1);
@@ -1148,6 +1154,9 @@ gdip_create_font_from_logfont (HDC hdc, void *lf, GpFont **font, BOOL ucs2)
 		return InvalidParameter;
 
 	GpFont *result = (GpFont*) GdipAlloc (sizeof (GpFont));
+	if (!result)
+		return OutOfMemory;
+
 	LOGFONTA *logfont = (LOGFONTA *)lf;
 
 	if (logfont->lfHeight < 0) {


### PR DESCRIPTION
More occurrences of GdipAlloc without a check after

Some of these can be triggered with invalid data (e.g. in the headers of bitmaps) but others are rare cases. Still good to be careful though