### PR TITLE
Make some definitions public that are needed

### DIFF
--- a/src/bmpcodec.h
+++ b/src/bmpcodec.h
@@ -43,28 +43,6 @@ typedef struct
 
 #define BFT_BITMAP 0x4d42
 
-
-typedef struct {
-  BYTE rgbBlue;
-  BYTE rgbGreen;
-  BYTE rgbRed;
-  BYTE rgbReserved;
-} RGBQUAD, *LPRGBQUAD;
-
-typedef struct {
-    DWORD 	biSize;
-    LONG  	biWidth;
-    LONG  	biHeight;
-    WORD 	biPlanes;
-    WORD 	biBitCount;
-    DWORD 	biCompression;
-    DWORD 	biSizeImage;
-    LONG  	biXPelsPerMeter;
-    LONG  	biYPelsPerMeter;
-    DWORD 	biClrUsed;
-    DWORD 	biClrImportant;
-} BITMAPINFOHEADER, *PBITMAPINFOHEADER, *LPBITMAPINFOHEADER;
-
 typedef long FXPT2DOT30;
 
 typedef struct {
@@ -101,11 +79,6 @@ typedef struct {
 	DWORD	bV4GammaGreen;
 	DWORD	bV4GammaBlue;
 } BITMAPV4HEADER, *PBITMAPV4HEADER;
-
-typedef struct {
-	BITMAPINFOHEADER bmiHeader;
-	RGBQUAD	bmiColors[1];
-} BITMAPINFO, *PBITMAPINFO, *LPBITMAPINFO;
 
 #include "gdiplus-private.h"
 

--- a/src/gdipenums.h
+++ b/src/gdipenums.h
@@ -350,9 +350,12 @@ typedef enum {
 	PixelFormat64bppARGB		= 0x0034400d,
 	PixelFormat64bppPARGB		= 0x001c400e,
 	PixelFormat8bppIndexed		= 0x00030803,
+	PixelFormat32bppCMYK		= 0x0000200F,
 
 	PixelFormatUndefined		= 0,
-	PixelFormatDontCare		= 0
+	PixelFormatDontCare		= 0,
+
+	PixelFormatMax = 16
 } PixelFormat;
 
 typedef enum {

--- a/src/win32structs.h
+++ b/src/win32structs.h
@@ -244,6 +244,32 @@ typedef struct {
 	SHORT	Bottom;
 } PWMFRect16;
 
+typedef struct {
+	BYTE rgbBlue;
+	BYTE rgbGreen;
+	BYTE rgbRed;
+	BYTE rgbReserved;
+} RGBQUAD, *LPRGBQUAD;
+
+typedef struct {
+	DWORD 	biSize;
+	LONG  	biWidth;
+	LONG  	biHeight;
+	WORD 	biPlanes;
+	WORD 	biBitCount;
+	DWORD 	biCompression;
+	DWORD 	biSizeImage;
+	LONG  	biXPelsPerMeter;
+	LONG  	biYPelsPerMeter;
+	DWORD 	biClrUsed;
+	DWORD 	biClrImportant;
+} BITMAPINFOHEADER, *PBITMAPINFOHEADER, *LPBITMAPINFOHEADER;
+
+typedef struct {
+	BITMAPINFOHEADER bmiHeader;
+	RGBQUAD	bmiColors[1];
+} BITMAPINFO, *PBITMAPINFO, *LPBITMAPINFO;
+
 #ifndef __GNUC__
 	#pragma pack(2)
 #endif


### PR DESCRIPTION
These are exposed in GDI+ on Windows, but not in libgdiplus.

This is necessary for some tests that I’m working on - I don’t have time rn to send those in so I’m just sending this PR in so the future one is easier to review with less code moving around.