### PR TITLE
Cleanup codec tests

### DIFF
--- a/tests/testbmpcodec.c
+++ b/tests/testbmpcodec.c
@@ -4,7 +4,7 @@
 #endif
 #endif
 
-#if defined(_WIN32)
+#if defined(USE_WINDOWS_GDIPLUS)
 #include <Windows.h>
 #include <GdiPlus.h>
 
@@ -13,7 +13,7 @@
 #include <GdiPlusFlat.h>
 #endif
 
-#ifdef WIN32
+#ifdef USE_WINDOWS_GDIPLUS
 using namespace Gdiplus;
 using namespace DllExports;
 #endif
@@ -55,50 +55,108 @@ static void createFileSuccess (BYTE *buffer, int length, PixelFormat expectedFor
 	GdipDisposeImage (image);
 }
 
+static void test_validImage ()
+{
+	BYTE image1bppBitmapInfoHeader[] = {
+		'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0,
+		40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 255, 255, 255, 0,
+		128, 0, 0, 0
+	};
+	BYTE hasImageData16bpp[] = {
+		'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0,
+		40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 16, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 255, 255, 255, 0,
+		128, 0, 0, 0
+	};
+	BYTE hasImageData32bpp[] = {
+		'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0,
+		40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 32, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 255, 255, 255, 0,
+		128, 0, 0, 0
+	};
+	BYTE hasImageData64bpp[] = {
+		'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0,
+		40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 64, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 255, 255, 255, 0,
+		128, 0, 0, 0
+	};
+	BYTE hasExtraImageData[] = {
+		'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0,
+		40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 255, 255, 255, 0,
+		128, 0, 0, 0, 1, 2, 3, 4
+	};
+	BYTE planesNotOne[] = {
+		'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0,
+		40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 4, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 255, 255, 255, 0,
+		128, 0, 0, 0
+	};
+	BYTE rle4Non4Bpp[] = {
+		'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0,
+		40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 32, 0, 2, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 255, 255, 255, 0,
+		128, 0, 0, 0
+	};
+	BYTE rle8Non8Bpp[] = {
+		'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0,
+		40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 32, 0, 1, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 255, 255, 255, 0,
+		128, 0, 0, 0
+	};
+
+	createFileSuccess (image1bppBitmapInfoHeader, sizeof(image1bppBitmapInfoHeader), PixelFormat1bppIndexed);
+	createFileSuccess (hasImageData16bpp, sizeof(hasImageData16bpp), PixelFormat32bppRGB);
+	createFileSuccess (hasImageData32bpp, sizeof(hasImageData32bpp), PixelFormat32bppRGB);
+	createFileSuccess (hasImageData64bpp, sizeof(hasImageData64bpp), PixelFormat64bppARGB);
+	createFileSuccess (hasExtraImageData, sizeof(hasExtraImageData), PixelFormat1bppIndexed);
+	createFileSuccess (planesNotOne, sizeof(planesNotOne), PixelFormat1bppIndexed);
+	createFileSuccess (rle4Non4Bpp, sizeof(rle4Non4Bpp), PixelFormat32bppRGB);
+	createFileSuccess (rle8Non8Bpp, sizeof(rle8Non8Bpp), PixelFormat32bppRGB);
+
+}
+
+static void test_invalidFileHeader ()
+{
+	BYTE shortSignature[] = {'B'};
+	BYTE noImageSize[]    = {'B', 'M'};
+	BYTE shortImageSize[] = {'B', 'M', 5, 0, 0};
+	BYTE noReserved1[]    = {'B', 'M', 6, 0, 0, 0};
+	BYTE shortReserved1[] = {'B', 'M', 7, 0, 0, 0, 0};
+	BYTE noReserved2[]    = {'B', 'M', 8, 0, 0, 0, 0, 0};
+	BYTE shortReserved2[] = {'B', 'M', 9, 0, 0, 0, 0, 0, 0};
+	BYTE noOffset[]       = {'B', 'M', 10, 0, 0, 0, 0, 0, 0, 0};
+	BYTE shortOffset[]    = {'B', 'M', 13, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0};
+
+	createFile (shortSignature, sizeof(shortSignature), OutOfMemory);
+	createFile (noImageSize, sizeof(noImageSize), OutOfMemory);
+	createFile (shortImageSize, sizeof(shortImageSize), OutOfMemory);
+	createFile (noReserved1, sizeof(noReserved1), OutOfMemory);
+	createFile (shortReserved1, sizeof(shortReserved1), OutOfMemory);
+	createFile (noReserved2, sizeof(noReserved2), OutOfMemory);
+	createFile (shortReserved2, sizeof(shortReserved2), OutOfMemory);
+	createFile (noOffset, sizeof(noOffset), OutOfMemory);
+	createFile (shortOffset, sizeof(shortOffset), OutOfMemory);
+}
+
 static void test_invalidHeader ()
 {
-	BYTE noHeader[] = 	 						 {0x42, 0x4D};
-	BYTE shortHeader[] = 	 					 {0x42, 0x4D, 13, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0};
-	BYTE noHeaderSize[] =     	 		 {0x42, 0x4D, 14, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0};
-	BYTE zeroHeaderSize[] =          {0x42, 0x4D, 18, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 0, 0, 0, 0};
-	BYTE newFormatNoWidth[] =	       {0x42, 0x4D, 18, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0};
-	BYTE newFormatNoHeight[] =	     {0x42, 0x4D, 22, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0};
-	BYTE os2FormatNoWidthHeight[] =	 {0x42, 0x4D, 18, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 12, 0, 0, 0};
-	BYTE noColorPlanes[] =	         {0x42, 0x4D, 26, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0};
-	BYTE noBitsPerPixel[] =	         {0x42, 0x4D, 28, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0};
-	BYTE noCompression[] =	         {0x42, 0x4D, 30, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0};
-	BYTE noSize[] =	                 {0x42, 0x4D, 34, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0};
-	BYTE noHorizontalResolution[] =  {0x42, 0x4D, 38, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0};
-	BYTE noVerticalResolution[] =    {0x42, 0x4D, 42, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0};
-	BYTE noColors[] =                {0x42, 0x4D, 46, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-	BYTE noImportantColors[] =       {0x42, 0x4D, 50, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-	BYTE noColorEntries[] =          {0x42, 0x4D, 54, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-	BYTE notEnoughColorEntries[] =   {0x42, 0x4D, 58, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-#if defined(USE_WINDOWS_GDIPLUS)
-	BYTE noImageData[] =             {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0};
-#endif
-	BYTE noImageDataBigSize[] =      {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0};
-	BYTE missingImageDataBigSize[] = {0x42, 0x4D, 70, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0, 0, 0, 0, 0};
-	BYTE hasImageData1bpp[] =        {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-	BYTE hasImageData4bpp[] =       {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-	BYTE hasImageData8bpp[] =       {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 8, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-	BYTE hasImageData16bpp[] =       {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 16, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-	BYTE hasImageData32bpp[] =       {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 32, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-	BYTE hasImageData64bpp[] =       {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 64, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-	BYTE hasExtraImageData[] =       {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0, 1, 2, 3, 4};
-	
-	BYTE planesNotOne[] =            {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 4, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-	BYTE invalidBitsPerPixel[] =     {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 10, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-	BYTE rle4Non4Bpp[] =             {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 32, 0, 2, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-	BYTE rle8Non8Bpp[] =             {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 32, 0, 1, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-	BYTE bitfieldsNon16Bpp[] =       {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 32, 0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-#if defined(USE_WINDOWS_GDIPLUS)
-	BYTE bitfields16Bpp[] =          {0x42, 0x4D, 62, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 16, 0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
-#endif
+	BYTE noHeader[]               = {'B', 'M', 14, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0};
+	BYTE zeroHeaderSize[]         = {'B', 'M', 18, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 0, 0, 0, 0, 0};
+	BYTE newFormatNoWidth[]       = {'B', 'M', 18, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0};
+	BYTE newFormatNoHeight[]      = {'B', 'M', 22, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0};
+	BYTE os2FormatNoWidthHeight[] =	{'B', 'M', 18, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 12, 0, 0, 0};
+	BYTE noColorPlanes[]          = {'B', 'M', 26, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0};
+	BYTE noBitsPerPixel[]         = {'B', 'M', 28, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0};
+	BYTE noCompression[]          = {'B', 'M', 30, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0};
+	BYTE noSize[]                 = {'B', 'M', 34, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0};
+	BYTE noHorizontalResolution[] = {'B', 'M', 38, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0};
+	BYTE noVerticalResolution[]   = {'B', 'M', 42, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0};
+	BYTE noColors[]               = {'B', 'M', 46, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+	BYTE noImportantColors[]      = {'B', 'M', 50, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 	createFile (noHeader, sizeof(noHeader), OutOfMemory);
-	createFile (shortHeader, sizeof(shortHeader), OutOfMemory);
-	createFile (noHeaderSize, sizeof(noHeaderSize), OutOfMemory);
 	createFile (zeroHeaderSize, sizeof(zeroHeaderSize), OutOfMemory);
 	createFile (newFormatNoWidth, sizeof(newFormatNoWidth), OutOfMemory);
 	createFile (newFormatNoHeight, sizeof(newFormatNoHeight), OutOfMemory);
@@ -111,6 +169,24 @@ static void test_invalidHeader ()
 	createFile (noVerticalResolution, sizeof(noVerticalResolution), OutOfMemory);
 	createFile (noColors, sizeof(noColors), OutOfMemory);
 	createFile (noImportantColors, sizeof(noImportantColors), OutOfMemory);
+}
+
+static void test_invalidImageData ()
+{
+	BYTE noColorEntries[]         = {'B', 'M', 54, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+	BYTE notEnoughColorEntries[]  = {'B', 'M', 58, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+#if defined(USE_WINDOWS_GDIPLUS)
+	BYTE noImageData[]            = {'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0};
+#endif
+	BYTE noImageDataBigSize[]     = {'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0};
+	BYTE hasImageData4bpp[]       = {'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
+	BYTE hasImageData8bpp[]       = {'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 8, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
+	BYTE invalidBitsPerPixel[]    = {'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 10, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
+	BYTE bitfieldsNon16Bpp[]      = {'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 32, 0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
+#if defined(USE_WINDOWS_GDIPLUS)
+	BYTE bitfields16Bpp[]         = {'B', 'M', 62, 0, 0, 0, 0, 0, 0, 0, 0x3E, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 16, 0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0};
+#endif
+
 	createFile (noColorEntries, sizeof(noColorEntries), OutOfMemory);
 	createFile (notEnoughColorEntries, sizeof(notEnoughColorEntries), OutOfMemory);
 	// FIXME: this should fail with OutOfMemory in libgdiplus.
@@ -118,25 +194,15 @@ static void test_invalidHeader ()
 	createFile (noImageData, sizeof(noImageData), OutOfMemory);
 #endif
 	createFile (noImageDataBigSize, sizeof(noImageDataBigSize), OutOfMemory);
-	createFileSuccess (missingImageDataBigSize, sizeof(missingImageDataBigSize), PixelFormat1bppIndexed);
-	createFileSuccess (hasImageData1bpp, sizeof(hasImageData1bpp), PixelFormat1bppIndexed);
 	createFile (hasImageData4bpp, sizeof(hasImageData4bpp), OutOfMemory);
 	createFile (hasImageData8bpp, sizeof(hasImageData8bpp), OutOfMemory);
-	createFileSuccess (hasImageData16bpp, sizeof(hasImageData16bpp), PixelFormat32bppRGB);
-	createFileSuccess (hasImageData32bpp, sizeof(hasImageData32bpp), PixelFormat32bppRGB);
-	createFileSuccess (hasImageData64bpp, sizeof(hasImageData64bpp), PixelFormat64bppARGB);
-	createFileSuccess (hasExtraImageData, sizeof(hasExtraImageData), PixelFormat1bppIndexed);
-	
-	createFileSuccess (planesNotOne, sizeof(planesNotOne), PixelFormat1bppIndexed);
 	createFile (invalidBitsPerPixel, sizeof(invalidBitsPerPixel), OutOfMemory);
 	createFile (bitfieldsNon16Bpp, sizeof(bitfieldsNon16Bpp), OutOfMemory);
 	
-	// FIXME: this appears to return Ok with libgdiplus.
+	// FIXME: this returns Ok with libgdiplus.
 #if defined(USE_WINDOWS_GDIPLUS)
 	createFile (bitfields16Bpp, sizeof(bitfields16Bpp), OutOfMemory);
 #endif
-	createFileSuccess (rle4Non4Bpp, sizeof(rle4Non4Bpp), PixelFormat32bppRGB);
-	createFileSuccess (rle8Non8Bpp, sizeof(rle8Non8Bpp), PixelFormat32bppRGB);
 }
 
 int
@@ -146,7 +212,10 @@ main (int argc, char**argv)
 	ULONG_PTR gdiplusToken;
 	GdiplusStartup (&gdiplusToken, &gdiplusStartupInput, NULL);
 	
+	test_validImage ();
+	test_invalidFileHeader ();
 	test_invalidHeader ();
+	test_invalidImageData ();
 
 #if !defined(_WIN32)
 	unlink (file);

--- a/tests/testicocodec.c
+++ b/tests/testicocodec.c
@@ -4,7 +4,7 @@
 #endif
 #endif
 
-#if defined(_WIN32)
+#if defined(USE_WINDOWS_GDIPLUS)
 #include <Windows.h>
 #include <GdiPlus.h>
 
@@ -13,7 +13,7 @@
 #include <GdiPlusFlat.h>
 #endif
 
-#ifdef WIN32
+#ifdef USE_WINDOWS_GDIPLUS
 using namespace Gdiplus;
 using namespace DllExports;
 #endif
@@ -46,23 +46,33 @@ static GpImage *createFile (BYTE *buffer, int length, GpStatus expectedStatus)
 
 static void test_invalidHeader ()
 {
-  BYTE noCount[] =        {0, 0, 1, 0};
-  BYTE zeroCount[] =      {0, 0, 1, 0, 0, 0};
-  BYTE noEntries[] =      {0, 0, 1, 0, 1, 0};
-  BYTE noBitmapHeader[] = {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0};
-  BYTE invalidPalette[] = {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4};
-  BYTE noRGBEntries[] =   {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  BYTE fewRGBEntries[] =  {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  BYTE noXorData[] =      {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  BYTE noAndData[] =      {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4};
-
-#if defined(USE_WINDOWS_GDIPLUS)
-  BYTE invalidData[] =   {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0, 0, 0, 0, 0};
-#endif
+  BYTE noCount[]   = {0, 0, 1, 0};
+  BYTE zeroCount[] = {0, 0, 1, 0, 0, 0};
 
   createFile (noCount, sizeof(noCount), OutOfMemory);
   createFile (zeroCount, sizeof(zeroCount), OutOfMemory);
+}
+
+static void test_invalidEntry ()
+{
+  BYTE noEntries[] = {0, 0, 1, 0, 1, 0};
+
   createFile (noEntries, sizeof(noEntries), OutOfMemory);
+}
+
+static void test_invalidImage ()
+{
+  BYTE noBitmapHeader[] = {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0};
+  BYTE invalidPalette[] = {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4};
+  BYTE noRGBEntries[]   = {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  BYTE fewRGBEntries[]  = {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  BYTE noXorData[]      = {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  BYTE noAndData[]      = {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4};
+
+#if defined(USE_WINDOWS_GDIPLUS)
+  BYTE invalidData[]    = {0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 128, 0, 0, 0, 0, 0, 0, 0};
+#endif
+
   createFile (noBitmapHeader, sizeof(noBitmapHeader), OutOfMemory);
   createFile (invalidPalette, sizeof(invalidPalette), OutOfMemory);
   createFile (noRGBEntries, sizeof(noRGBEntries), OutOfMemory);
@@ -84,6 +94,8 @@ main (int argc, char**argv)
   GdiplusStartup (&gdiplusToken, &gdiplusStartupInput, NULL);
   
   test_invalidHeader ();
+  test_invalidEntry ();
+  test_invalidImage ();
   
 #if !defined(_WIN32)
   unlink (file);


### PR DESCRIPTION
For readability, consistency and to make the name of the test function actually make sense

Also adds some more negative tests for parsing BITMAPFILEHEADER