### PR TITLE
Fixed issues that prevented visibly drawing many WMF files

### DIFF
--- a/src/metafile.c
+++ b/src/metafile.c
@@ -599,11 +599,11 @@ gdip_metafile_StretchDIBits (MetafilePlayContext *context, int XDest, int YDest,
 	printf ("\n\t\tClrImportant: %d", lpBitsInfo->bmiHeader.biClrImportant);
 #endif
 	ms.ptr = (BYTE*)lpBitsInfo;
-	if (lpBitsInfo->bmiHeader.biCompression == 0) { // 0 == RGB 
+	if (lpBitsInfo->bmiHeader.biCompression == BI_RGB) {
 		// Per the spec, if compression is RGB ImageSize must be ignored (and it should be zero anyway)
 		// and calculated according to the following formula.
-		ms.size = (((lpBitsInfo->bmiHeader.biWidth * lpBitsInfo->bmiHeader.biPlanes * 
-			lpBitsInfo->bmiHeader.biBitCount + 31) & ~31) / 8) * abs(lpBitsInfo->bmiHeader.biHeight);
+		ms.size = (floor ((lpBitsInfo->bmiHeader.biWidth * lpBitsInfo->bmiHeader.biPlanes * 
+			lpBitsInfo->bmiHeader.biBitCount + 31) / 32) * 4) * abs (lpBitsInfo->bmiHeader.biHeight);
 	} else {
 		ms.size = lpBitsInfo->bmiHeader.biSizeImage;
 	}

--- a/src/wmfcodec.h
+++ b/src/wmfcodec.h
@@ -72,6 +72,7 @@
 #define METAFILE_RECORD_POLYPOLYGON		0x0538
 #define METAFILE_RECORD_ARC			0x0817
 #define METAFILE_RECORD_STRETCHDIBITS		0x0F43
+#define METAFILE_RECORD_DIBSTRETCHBLT		0x0B41
 
 
 #define gdip_read_wmf_data	gdip_read_bmp_data


### PR DESCRIPTION
 * Added a new drawing instruction / record (METAFILE_RECORD_DIBSTRETCHBLT) which is substantially the same as METAFILE_RECORD_STRETCHDIBITS
 * Corrected parsing of certain values so that they're treated as signed instead of unsigned, including adding a GETS macro to complement the existing GETW but returning a SHORT instead of a WORD
 * Fixed scaling for drawing to a specified size and improved translation at the same time
 * Corrected handling of the DIB BitmapInfoHandler ImageSize field -- it now calculates the value when compression is not used (Compression field = 0 / RGB)

_Note:_ these are the extracted WMF changes from https://github.com/mono/libgdiplus/pull/28 + cleanup, let's see what CI says 😄 