### PR TITLE
Make image verification failures easier to spot

### DIFF
--- a/tests/testgifcodec.c
+++ b/tests/testgifcodec.c
@@ -37,10 +37,16 @@ GpImage *image;
 	assertEqualInt (status, expectedStatus); \
 }
 
+#define createFileSuccess(buffer, expectedWidth, expectedHeight) \
+{ \
+  createFile(buffer, Ok); \
+  verifyBitmap (image, gifRawFormat, PixelFormat8bppIndexed, 3, 5, ImageFlagsColorSpaceRGB | ImageFlagsHasRealDPI | ImageFlagsHasRealPixelSize | ImageFlagsReadOnly, 0, TRUE); \
+  GdipDisposeImage (image); \
+}
+
 static void test_validData ()
 {
   GpImage *image;
-  const INT gifFlags = ImageFlagsColorSpaceRGB | ImageFlagsHasRealDPI | ImageFlagsHasRealPixelSize | ImageFlagsReadOnly;
 
   BYTE localColorTable89[]                     = {'G', 'I', 'F', '8', '9', 'a', 3, 0, 5, 0, 0, 0, 0, ',', 0, 0, 0, 0, 3, 0, 5, 0, B8(10000000), 0, 0, 0, 255, 255, 255, 0x02, 0x06, 0x84, 0x03, 0x81, 0x9a, 0x06, 0x05, 0x00, ';'};
   BYTE globalColorTable89[]                    = {'G', 'I', 'F', '8', '9', 'a', 3, 0, 5, 0, B8(10000000), 0, 0, 0, 0, 0, 255, 255, 255, ',', 0, 0, 0, 0, 3, 0, 5, 0, 0, 0x02, 0x06, 0x84, 0x03, 0x81, 0x9a, 0x06, 0x05, 0x00, ';'};
@@ -64,85 +70,31 @@ static void test_validData ()
   BYTE applicationTextControlBlock[]           = {'G', 'I', 'F', '8', '9', 'a', 3, 0, 5, 0, 0, 0, 0, '!', 0xFF, 0x0B, '1', '2', '3', '4', '5', '6', '7', '8', 1, 2, 3, 2, 'H', 'I', 0, ',', 0, 0, 0, 0, 3, 0, 5, 0, B8(10000000), 0, 0, 0, 255, 255, 255, 0x02, 0x06, 0x84, 0x03, 0x81, 0x9a, 0x06, 0x05, 0x00, ';'};
   BYTE commentControlBlock[]                   = {'G', 'I', 'F', '8', '9', 'a', 3, 0, 5, 0, 0, 0, 0, '!', 0xFE, 2, 'H', 'I', 0, ',', 0, 0, 0, 0, 3, 0, 5, 0, B8(10000000), 0, 0, 0, 255, 255, 255, 0x02, 0x06, 0x84, 0x03, 0x81, 0x9a, 0x06, 0x05, 0x00, ';'};
 
-  createFile (localColorTable89, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (globalColorTable89, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (localAndGlobalColorTable89, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (localColorTable87, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (globalColorTable87, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (localAndGlobalColorTable87, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (extraData, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (noColorTables, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (emptyExtensionBlock, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (unknownExtensionBlock87, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (unknownExtensionBlock89, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (graphicsControlBlock, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
+  createFileSuccess (localColorTable89, 3, 5);
+  createFileSuccess (globalColorTable89, 3, 5);
+  createFileSuccess (localAndGlobalColorTable89, 3, 5);
+  createFileSuccess (localColorTable87, 3, 5);
+  createFileSuccess (globalColorTable87, 3, 5);
+  createFileSuccess (localAndGlobalColorTable87, 3, 5);
+  createFileSuccess (extraData, 3, 5);
+  createFileSuccess (noColorTables, 3, 5);
+  createFileSuccess (emptyExtensionBlock, 3, 5);
+  createFileSuccess (unknownExtensionBlock87, 3, 5);
+  createFileSuccess (unknownExtensionBlock89, 3, 5);
+  createFileSuccess (graphicsControlBlock, 3, 5);
 
   // FIXME: it appears that GDI+ allows a graphics control extension block without a
   // terminating 0 byte.
 #if defined(USE_WINDOWS_GDIPLUS)
-  createFile (graphicsControlBlockMissingTerminator, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
+  createFileSuccess (graphicsControlBlockMissingTerminator, 3, 5);
 #endif
 
-  createFile (severalGraphicsControlBlocks, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (misplacedGraphicsControlBlock, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (plainTextControlBlock, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (invalidTextControlBlock, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (applicationTextControlBlock, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
-
-  createFile (commentControlBlock, Ok);
-  verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 3, 5, 3, 5, gifFlags, 0, TRUE);
-  GdipDisposeImage (image);
+  createFileSuccess (severalGraphicsControlBlocks, 3, 5);
+  createFileSuccess (misplacedGraphicsControlBlock, 3, 5);
+  createFileSuccess (plainTextControlBlock, 3, 5);
+  createFileSuccess (invalidTextControlBlock, 3, 5);
+  createFileSuccess (applicationTextControlBlock, 3, 5);
+  createFileSuccess (commentControlBlock, 3, 5);
 }
 
 static void test_invalidHeader ()

--- a/tests/testgpimage.c
+++ b/tests/testgpimage.c
@@ -129,7 +129,7 @@ static void test_loadImageFromFileBmp ()
 	GpImage *image = getImage ("test.bmp");
 
 	// FIXME: bmp image flags are wrong in libgdiplus.
-	verifyImage (image, ImageTypeBitmap, bmpRawFormat, PixelFormat24bppRGB, 0, 0, 100, 68, 100, 68, 77840, 0, FALSE);
+	verifyBitmap (image, bmpRawFormat, PixelFormat24bppRGB, 100, 68, 77840, 0, FALSE);
 
 	GdipDisposeImage (image);
 }
@@ -138,7 +138,7 @@ static void test_loadImageFromFileTif ()
 {
 	GpImage *image = getImage ("test.tif");
 
-	verifyImage (image, ImageTypeBitmap, tifRawFormat, PixelFormat24bppRGB, 0, 0, 100, 68, 100, 68, 77840, 19, TRUE);
+	verifyBitmap (image, tifRawFormat, PixelFormat24bppRGB, 100, 68, 77840, 19, TRUE);
 
 	GdipDisposeImage (image);
 }
@@ -147,7 +147,7 @@ static void test_loadImageFromFileGif ()
 {
 	GpImage *image = getImage ("test.gif");
 
-	verifyImage (image, ImageTypeBitmap, gifRawFormat, PixelFormat8bppIndexed, 0, 0, 100, 68, 100, 68, ImageFlagsColorSpaceRGB | ImageFlagsHasRealDPI | ImageFlagsHasRealPixelSize | ImageFlagsReadOnly, 4, TRUE);
+	verifyBitmap (image, gifRawFormat, PixelFormat8bppIndexed, 100, 68, ImageFlagsColorSpaceRGB | ImageFlagsHasRealDPI | ImageFlagsHasRealPixelSize | ImageFlagsReadOnly, 4, TRUE);
 
 	GdipDisposeImage (image);
 }
@@ -156,7 +156,7 @@ static void test_loadImageFromFilePng ()
 {
 	GpImage *image = getImage ("test.png");
 
-	verifyImage (image, ImageTypeBitmap, pngRawFormat, PixelFormat24bppRGB, 0, 0, 100, 68, 100, 68, 77840, 5, TRUE);
+	verifyBitmap (image, pngRawFormat, PixelFormat24bppRGB, 100, 68, 77840, 5, TRUE);
 
 	GdipDisposeImage (image);
 }
@@ -166,7 +166,7 @@ static void test_loadImageFromFileJpg ()
 	GpImage *image = getImage ("test.jpg");
 
 	// FIXME: jpg image flags are wrong in libgdiplus.
-	verifyImage (image, ImageTypeBitmap, jpegRawFormat, PixelFormat24bppRGB, 0, 0, 100, 68, 100, 68, 73744, 2, FALSE);
+	verifyBitmap (image, jpegRawFormat, PixelFormat24bppRGB, 100, 68, 73744, 2, FALSE);
 
 	GdipDisposeImage (image);
 }
@@ -175,7 +175,7 @@ static void test_loadImageFromFileIcon ()
 {
 	GpImage *image = getImage ("test.ico");
 
-	verifyImage (image, ImageTypeBitmap, icoRawFormat, PixelFormat32bppARGB, 0, 0, 48, 48, 48, 48, 73746, 0, TRUE);
+	verifyBitmap (image, icoRawFormat, PixelFormat32bppARGB, 48, 48, 73746, 0, TRUE);
 
 	GdipDisposeImage (image);
 }
@@ -184,7 +184,7 @@ static void test_loadImageFromFileWmf ()
 {
 	GpImage *image = getImage ("test.wmf");
 
-	verifyImage (image, ImageTypeMetafile, wmfRawFormat, PixelFormat32bppRGB, -4008, -3378, 8016, 6756, 20360.638672f, 17160.2383f, 327683, 0, TRUE);
+	verifyMetafile (image, wmfRawFormat, -4008, -3378, 8016, 6756, 20360.638672f, 17160.2383f);
 
 	GdipDisposeImage (image);
 }
@@ -193,7 +193,7 @@ static void test_loadImageFromFileEmf ()
 {
 	GpImage *image = getImage ("test.emf");
 
-	verifyImage (image, ImageTypeMetafile, emfRawFormat, PixelFormat32bppRGB, 0, 0, 100, 100, 1944.444336f, 1888.888794f, 327683, 0, TRUE);
+	verifyMetafile (image, emfRawFormat, 0, 0, 100, 100, 1944.444336f, 1888.888794f);
 
 	GdipDisposeImage (image);
 }
@@ -211,7 +211,7 @@ static void test_cloneImage ()
 	assertEqualInt (status, Ok);
 	assert (clonedImage && clonedImage != bitmapImage);
 	// FIXME: bmp image flags are wrong in libgdiplus.
-	verifyImage (clonedImage, ImageTypeBitmap, bmpRawFormat, PixelFormat24bppRGB, 0, 0, 100, 68, 100, 68, 77840, 0, FALSE);
+	verifyBitmap (clonedImage, bmpRawFormat, PixelFormat24bppRGB, 100, 68, 77840, 0, FALSE);
 	GdipDisposeImage (clonedImage);
 
 	// ImageTypeBitmap - jpg.
@@ -219,14 +219,14 @@ static void test_cloneImage ()
 	assertEqualInt (status, Ok);
 	assert (clonedImage && clonedImage != jpgImage);
 	// FIXME: jpg image flags are wrong in libgdiplus.
-	verifyImage (clonedImage, ImageTypeBitmap, jpegRawFormat, PixelFormat24bppRGB, 0, 0, 100, 68, 100, 68, 73744, 2, FALSE);
+	verifyBitmap (clonedImage, jpegRawFormat, PixelFormat24bppRGB, 100, 68, 73744, 2, FALSE);
 	GdipDisposeImage (clonedImage);
 
 	// ImageTypeMetafile.
 	status = GdipCloneImage (metafileImage, &clonedImage);
 	assertEqualInt (status, Ok);
 	assert (clonedImage && clonedImage != metafileImage);
-	verifyImage (clonedImage, ImageTypeMetafile, wmfRawFormat, PixelFormat32bppRGB, -4008, -3378, 8016, 6756, 20360.638672f, 17160.238281f, 327683, 0, TRUE);
+	verifyMetafile (clonedImage, wmfRawFormat, -4008, -3378, 8016, 6756, 20360.638672f, 17160.238281f);
 	GdipDisposeImage (clonedImage);
 
 	// Negative tests.
@@ -480,25 +480,25 @@ static void test_getImageThumbnail ()
 	// ImageTypeBitmap - non zero width and height.
 	status = GdipGetImageThumbnail (bitmapImage, 10, 10, &thumbImage, (GetThumbnailImageAbort) callback, (void *) 1);
 	assertEqualInt (status, Ok);
-	verifyImage (thumbImage, ImageTypeBitmap, memoryBmpRawFormat, PixelFormat32bppPARGB, 0, 0, 10, 10, 10, 10, 2, 0, TRUE);
+	verifyBitmap (thumbImage, memoryBmpRawFormat, PixelFormat32bppPARGB, 10, 10, 2, 0, TRUE);
 	GdipDisposeImage (thumbImage);
 
 	// ImageTypeBitmap - zero width and height.
 	status = GdipGetImageThumbnail (bitmapImage, 0, 0, &thumbImage, NULL, NULL);
 	assertEqualInt (status, Ok);
-	verifyImage (thumbImage, ImageTypeBitmap, memoryBmpRawFormat, PixelFormat32bppPARGB, 0, 0, 120, 120, 120, 120, 2, 0, TRUE);
+	verifyBitmap (thumbImage, memoryBmpRawFormat, PixelFormat32bppPARGB, 120, 120, 2, 0, TRUE);
 	GdipDisposeImage (thumbImage);
 
 	// ImageTypeMetafile - non zero width and height.
 	status = GdipGetImageThumbnail (metafileImage, 10, 10, &thumbImage, (GetThumbnailImageAbort) callback, (void *) 1);
 	assertEqualInt (status, Ok);
-	verifyImage (thumbImage, ImageTypeBitmap, memoryBmpRawFormat, PixelFormat32bppARGB, 0, 0, 10, 10, 10, 10, 2, 0, TRUE);
+	verifyBitmap (thumbImage, memoryBmpRawFormat, PixelFormat32bppARGB, 10, 10, 2, 0, TRUE);
 	GdipDisposeImage (thumbImage);
 
 	// ImageTypeMetafile - zero width and height.
 	status = GdipGetImageThumbnail (metafileImage, 0, 0, &thumbImage, NULL, NULL);
 	assertEqualInt (status, Ok);
-	verifyImage (thumbImage, ImageTypeBitmap, memoryBmpRawFormat, PixelFormat32bppARGB, 0, 0, 120, 120, 120, 120, 2, 0, TRUE);
+	verifyBitmap (thumbImage, memoryBmpRawFormat, PixelFormat32bppARGB, 120, 120, 2, 0, TRUE);
 	GdipDisposeImage (thumbImage);
 #else
 	status = GdipGetImageThumbnail (metafileImage, 0, 0, &thumbImage, NULL, NULL);

--- a/tests/testmetafile.c
+++ b/tests/testmetafile.c
@@ -39,13 +39,13 @@ static void test_createMetafileFromFile ()
     // Create from WMF file.
     status = GdipCreateMetafileFromFile (wmfFilePath, &metafile);
     assertEqualInt (status, Ok);
-    verifyImage (metafile, ImageTypeMetafile, wmfRawFormat, PixelFormat32bppRGB, -4008, -3378, 8016, 6756, 20360.638672f, 17160.2383f, 327683, 0, TRUE);
+    verifyMetafile (metafile, wmfRawFormat, -4008, -3378, 8016, 6756, 20360.638672f, 17160.2383f);
     GdipDisposeImage (metafile);
 
     // Create from EMF file.
     status = GdipCreateMetafileFromFile (emfFilePath, &metafile);
     assertEqualInt (status, Ok);
-    verifyImage (metafile, ImageTypeMetafile, emfRawFormat, PixelFormat32bppRGB, 0, 0, 100, 100, 1944.444336f, 1888.888794f, 327683, 0, TRUE);
+    verifyMetafile (metafile, emfRawFormat, 0, 0, 100, 100, 1944.444336f, 1888.888794f);
     GdipDisposeImage (metafile);
 
     // Negative tests.
@@ -69,7 +69,7 @@ static void test_createMetafileFromStream ()
 #if defined(USE_WINDOWS_GDIPLUS)
     int temp = 0;
 #endif
-    
+
     // Negative tests.
     status = GdipCreateMetafileFromStream (NULL, &metafile);
     assertEqualInt (status, InvalidParameter);
@@ -78,7 +78,7 @@ static void test_createMetafileFromStream ()
 #if defined(USE_WINDOWS_GDIPLUS)
     status = GdipCreateMetafileFromStream (&temp, NULL);
     assertEqualInt (status, InvalidParameter);
-    
+
     status = GdipCreateMetafileFromStream (&temp, &metafile);
     assertEqualInt (status, NotImplemented);
 #endif
@@ -115,7 +115,7 @@ static void test_createMetafileFromEmf ()
     // Negative tests.
     status = GdipCreateMetafileFromEmf (NULL, TRUE, &metafile);
     assertEqualInt (status, InvalidParameter);
-    
+
     status = GdipCreateMetafileFromEmf (emfMetafile, TRUE, NULL);
     assertEqualInt (status, InvalidParameter);
 
@@ -138,16 +138,16 @@ static void test_createMetafileFromWmf ()
     status = GdipCreateMetafileFromWmf (wmfMetafile, TRUE, &wmfPlaceableFileHeader, &metafile);
     assertEqualInt (status, Ok);
     GdipDisposeImage (metafile);
-    
+
     status = GdipCreateMetafileFromWmf (wmfMetafile, FALSE, &wmfPlaceableFileHeader, &metafile);
     assertEqualInt (status, Ok);
     GdipDisposeImage (metafile);
-    
+
     // Create from EMF file.
     status = GdipCreateMetafileFromWmf (emfMetafile, TRUE, &wmfPlaceableFileHeader, &metafile);
     assertEqualInt (status, Ok);
     GdipDisposeImage (metafile);
-    
+
     status = GdipCreateMetafileFromWmf (emfMetafile, FALSE, &wmfPlaceableFileHeader, &metafile);
     assertEqualInt (status, Ok);
     GdipDisposeImage (metafile);
@@ -155,10 +155,10 @@ static void test_createMetafileFromWmf ()
     // Negative tests.
     status = GdipCreateMetafileFromWmf (NULL, TRUE, &wmfPlaceableFileHeader, &metafile);
     assertEqualInt (status, InvalidParameter);
-    
+
     status = GdipCreateMetafileFromWmf (wmfMetafile, TRUE, NULL, &metafile);
     assertEqualInt (status, InvalidParameter);
-    
+
     status = GdipCreateMetafileFromWmf (wmfMetafile, TRUE, &wmfPlaceableFileHeader, NULL);
     assertEqualInt (status, InvalidParameter);
 
@@ -173,7 +173,7 @@ static void test_getMetafileHeaderFromWmf ()
     GpMetafile *emfMetafile;
     WmfPlaceableFileHeader wmfPlaceableFileHeader;
     MetafileHeader header;
-    
+
     GdipCreateMetafileFromFile (wmfFilePath, &wmfMetafile);
     GdipCreateMetafileFromFile (emfFilePath, &emfMetafile);
 
@@ -194,7 +194,7 @@ static void test_getMetafileHeaderFromWmf ()
     assertEqualInt (header.Width, 0);
     assertEqualInt (header.Height, 0);
 #endif
-    
+
     // Get from EMF file.
     status = GdipGetMetafileHeaderFromWmf (emfMetafile, &wmfPlaceableFileHeader, &header);
     assertEqualInt (status, Ok);
@@ -232,7 +232,7 @@ static void test_getMetafileHeaderFromEmf ()
     GpMetafile *wmfMetafile;
     GpMetafile *emfMetafile;
     MetafileHeader header;
-    
+
     GdipCreateMetafileFromFile (wmfFilePath, &wmfMetafile);
     GdipCreateMetafileFromFile (emfFilePath, &emfMetafile);
 
@@ -250,7 +250,7 @@ static void test_getMetafileHeaderFromEmf ()
     assertEqualInt (header.Width, 100);
     assertEqualInt (header.Height, 100);
     assertEqualInt (header.EmfPlusHeaderSize, 0);
-    
+
     // Get from WMF file.
     status = GdipGetMetafileHeaderFromEmf (wmfMetafile, &header);
     assertEqualInt (status, InvalidParameter);
@@ -270,7 +270,7 @@ static void test_getMetafileHeaderFromFile ()
 {
     GpStatus status;
     MetafileHeader header;
-    
+
     // Get from WMF file.
     status = GdipGetMetafileHeaderFromFile (wmfFilePath, &header);
     assertEqualInt (status, Ok);
@@ -314,7 +314,7 @@ static void test_getMetafileHeaderFromStream ()
 #if defined(USE_WINDOWS_GDIPLUS)
     int temp = 0;
 #endif
-    
+
     // Negative tests.
     status = GdipGetMetafileHeaderFromStream (NULL, &header);
     assertEqualInt (status, InvalidParameter);
@@ -323,7 +323,7 @@ static void test_getMetafileHeaderFromStream ()
 #if defined(USE_WINDOWS_GDIPLUS)
     status = GdipGetMetafileHeaderFromStream (&temp, NULL);
     assertEqualInt (status, InvalidParameter);
-    
+
     status = GdipGetMetafileHeaderFromStream (&temp, &header);
     assertEqualInt (status, NotImplemented);
 #endif
@@ -338,7 +338,7 @@ static void test_getMetafileHeaderFromMetafile ()
 
     GdipCreateMetafileFromFile (wmfFilePath, &wmfMetafile);
     GdipCreateMetafileFromFile (emfFilePath, &emfMetafile);
-    
+
     // Get from WMF file.
     status = GdipGetMetafileHeaderFromMetafile (wmfMetafile, &header);
     assertEqualInt (status, Ok);
@@ -373,7 +373,7 @@ static void test_getMetafileHeaderFromMetafile ()
 
     status = GdipGetMetafileHeaderFromMetafile (emfMetafile, NULL);
     assertEqualInt (status, InvalidParameter);
-    
+
     GdipDisposeImage (wmfMetafile);
     GdipDisposeImage (emfMetafile);
 }
@@ -412,7 +412,7 @@ static void test_gettHemfFromMetafile ()
     // Negative tests.
     status = GdipGetHemfFromMetafile (NULL, &hemf);
     assertEqualInt (status, InvalidParameter);
-    
+
     status = GdipGetHemfFromMetafile (NULL, &hemf);
     assertEqualInt (status, InvalidParameter);
 
@@ -524,10 +524,10 @@ static void test_recordMetafile ()
     GpRectF zeroWidth = {0, 0, 0, 100};
     GpRectF zeroHeight = {0, 0, 100, 0};
     GpMetafile *metafile;
-    
+
     GdipCreateMetafileFromFile (wmfFilePath, &wmfMetafile);
     GdipCreateMetafileFromFile (emfFilePath, &emfMetafile);
-    
+
     GdipCreateBitmapFromScan0 (10, 10, 0, PixelFormat32bppRGB, NULL, &bitmap);
     GdipGetImageGraphicsContext (bitmap, &graphics);
     GdipGetDC (graphics, &hdc);

--- a/tests/testtiffcodec.c
+++ b/tests/testtiffcodec.c
@@ -40,7 +40,7 @@ GpImage *image;
 #define createFileSuccess(buffer, width, height, flags, propertyCount) \
 { \
 	createFile (buffer, Ok); \
-	verifyImage (image, ImageTypeBitmap, tifRawFormat, PixelFormat24bppRGB, 0, 0, width, height, (REAL) width, (REAL) height, flags, propertyCount, TRUE); \
+	verifyBitmap (image, tifRawFormat, PixelFormat24bppRGB, width, height, flags, propertyCount, TRUE); \
 	GdipDisposeImage (image); \
 }
 


### PR DESCRIPTION
Before there would be no line number for the actual data that caused the verification to fail

We can fix this by turning the function into a macro

Relies on #147