### PR TITLE
Fix crash in GdipPrivateAddMemoryFont on Windows

### DIFF
--- a/src/win32_io.c
+++ b/src/win32_io.c
@@ -23,23 +23,22 @@
 #include "win32_io.h"
 
 #include <windows.h>
-#include <stdio.h>
 #include "gdipenums.h"
 
-int CreateTempFile (char *filename)
+FILE *CreateTempFile (char *filename)
 {
 	TCHAR temppath[MAX_PATH];
 	DWORD ret = 0;
 	
 	ret = GetTempPath (MAX_PATH, temppath);
 	if (ret > MAX_PATH || ret == 0) {
-		return FileNotFound;
+		return NULL;
 	}
 
 	ret = GetTempFileName (temppath, "ff", 0, (LPSTR)filename);
 	if (ret == 0) {
-		return FileNotFound;
+		return NULL;
 	}
 
-	return (int)(intptr_t)fopen (filename, "w");
+	return fopen (filename, "w");
 }

--- a/src/win32_io.h
+++ b/src/win32_io.h
@@ -20,6 +20,8 @@
 *	Frederik Carlier <frederik.carlier@quamotion.mobi>
 */
 
+#include <stdio.h>
+
 // Creates a temporary file. Saves the value of the temporary file in filename,
 // and returns a handle to the temp file.
-int CreateTempFile (char *filename);
+FILE *CreateTempFile (char *filename);


### PR DESCRIPTION
write(3) doesn't accept a FILE* pointer masquerading as an int