### PR TITLE
Update metafile defaults

### DIFF
--- a/src/metafile.c
+++ b/src/metafile.c
@@ -1001,10 +1001,10 @@ gdip_metafile_play_setup (GpMetafile *metafile, GpGraphics *graphics, int x, int
 
 	/* defaults */
 	context->fill_mode = FillModeAlternate;
-	context->map_mode = MM_TEXT;
+	gdip_metafile_SetMapMode (context, MM_TWIPS);
 	context->miter_limit = 10.0f;
-	context->selected_pen = -1;
-	context->selected_brush = -1;
+	context->selected_pen =  ENHMETA_STOCK_OBJECT + BLACK_PEN;
+	context->selected_brush = ENHMETA_STOCK_OBJECT + WHITE_BRUSH;
 	context->selected_font = -1;
 	context->selected_palette = -1;
 


### PR DESCRIPTION
Fixes #211

For the following data:
```

	BYTE rectangle[] = {
		/* -- Placeable Header -- */
		/* Key */          0xD7, 0xCD, 0xC6, 0x9A,
		/* Hmf */          0x00, 0x00,
		/* Bounding Box */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x0F,
		/* Inch */         0xA0, 0x05,
		/* Reserved */     0x00, 0x00, 0x00, 0x00,
		/* Checksum */     0xB1, 0x52,

		/* -- Metafile Header -- */ 
		/* File Type */       0x01, 0x00,
		/* Header Size */     0x09, 0x00,
		/* Version */         0x00, 0x03,
		/* Total Size */      0x09 + 0x07 + 0x07 + 0x03, 0x00, 0x00, 0x00,
		/* Number Objects */  0x00, 0x00,
		/* Max Record Size */ 0x08, 0x00, 0x00, 0x00,
		/* No Parameters */   0x00, 0x00,

		/* -- META_RECTANGLE -- */
		/* Size */       0x07, 0x00, 0x00, 0x00,
		/* Function */   0x1B, 0x04,
		/* BottomRect */ 0x00, 0x08,
		/* RightRect */  0x00, 0x07,
		/* TopRect */    0x00, 0x03,
		/* LeftRect */   0x00, 0x02,
		
		/* -- META_RECTANGLE -- */
		/* Size */       0x07, 0x00, 0x00, 0x00,
		/* Function */   0x1B, 0x04,
		/* BottomRect */ 0x00, 0x02,
		/* RightRect */  0x00, 0x01,
		/* TopRect */    0x00, 0x07,
		/* LeftRect */   0x00, 0x06,
		
		/* -- META_EOF -- */
		/* Size */     0x03, 0x00, 0x00, 0x00,
		/* Function */ 0x00, 0x00
	};
```  

Before:
![simple_libgdiplus](https://user-images.githubusercontent.com/1275900/34614421-54f1b41e-f229-11e7-9c8f-882016bed511.jpeg)

After:
![simple_gdiplus](https://user-images.githubusercontent.com/1275900/34614430-5bd4e120-f229-11e7-8294-8991f24f9778.jpeg)