### PR TITLE
Rewritten memory management of GpPath objects

### DIFF
--- a/src/customlinecap.c
+++ b/src/customlinecap.c
@@ -212,8 +212,8 @@ gdip_custom_linecap_draw (GpGraphics *graphics, GpPen *pen, GpCustomLineCap *cus
 
 		for (i = 0; i < points; i++) {
 			/* Adapted from gdip_plot_path() */
-			GpPointF point = g_array_index (path->points, GpPointF, i);
-			BYTE type = g_array_index (path->types, BYTE, i);
+			GpPointF point = path->points[i];
+			BYTE type = path->types[i];
 			GpPointF pts [3];
 
 			/* mask the bits so that we get only the type value not the other flags */

--- a/src/graphics-cairo.c
+++ b/src/graphics-cairo.c
@@ -425,8 +425,8 @@ gdip_plot_path (GpGraphics *graphics, GpPath *path, BOOL antialiasing)
 	int i, idx = 0;
 
 	for (i = 0; i < length; ++i) {
-		GpPointF pt = g_array_index (path->points, GpPointF, i);
-		BYTE type = g_array_index (path->types, BYTE, i);
+		GpPointF pt = path->points[i];
+		BYTE type = path->types[i];
 		GpPointF pts [3];
 
 		/* mask the bits so that we get only the type value not the other flags */

--- a/src/graphics-path-private.h
+++ b/src/graphics-path-private.h
@@ -42,12 +42,15 @@
 typedef struct _Path {
 	FillMode fill_mode;
 	int count;
-	GByteArray *types;
-	GArray *points;
+	int size;
+	BYTE *types;
+	GpPointF *points;
 	BOOL start_new_fig;	/* Flag to keep track if we need to start a new figure */
 } Path;
 
 BOOL gdip_path_has_curve (GpPath *path) GDIP_INTERNAL;
+BOOL gdip_path_ensure_size (GpPath *path, int size) GDIP_INTERNAL;
+
 
 #include "graphics-path.h"
 

--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -33,29 +33,27 @@
 	#include "text-pango-private.h"
 #endif
 
-VOID
+BOOL
 gdip_path_ensure_size (GpPath *path, int size)
 {
+	BYTE *new_types;
+	GpPointF *new_points;
+
 	if (path->size < size) {
 		if (size < path->size + 64)
 			size = path->size + 64;
-		path->types = gdip_realloc (path->types, size * sizeof (BYTE));
-		path->points = gdip_realloc (path->points, size * sizeof (GpPointF));
-		// TODO: Handle allocation failure
+		new_types = gdip_realloc (path->types, size * sizeof (BYTE));
+		if (!new_types)
+			return FALSE;
+		path->types = new_types;
+		new_points = gdip_realloc (path->points, size * sizeof (GpPointF));
+		if (!new_points)
+			return FALSE;
+		path->points = new_points;
 		path->size = size;
 	}
-}
 
-VOID
-gdip_path_compact (GpPath *path)
-{
-	if (path->size > path->count + 64) {
-		int size = (path->count + 63) & ~63;
-		path->types = gdip_realloc (path->types, size * sizeof (BYTE));
-		path->points = gdip_realloc (path->points, size * sizeof (GpPointF));
-		// TODO: Handle allocation failure
-		path->size = size;
-	}
+	return TRUE;
 }
 
 /* return TRUE if the specified path has (at least one) curves, FALSE otherwise */
@@ -95,7 +93,7 @@ gdip_get_first_point_type (GpPath *path)
 		return PathPointTypeLine;
 }
 
-static void
+static VOID
 append (GpPath *path, float x, float y, PathPointType type, BOOL compress)
 {
 	BYTE t = (BYTE) type;
@@ -125,21 +123,23 @@ append (GpPath *path, float x, float y, PathPointType type, BOOL compress)
 	pt.X = x;
 	pt.Y = y;
 
-	gdip_path_ensure_size (path, path->count + 1);
+	/* all external APIs resize the buffers beforehand and fail gracefully */
+	if (!gdip_path_ensure_size (path, path->count + 1))
+		g_assert(FALSE);
+
 	path->points[path->count] = pt;
 	path->types[path->count] = t;
 	path->count++;
-
 	path->start_new_fig = FALSE;
 }
 
-static void
+static VOID
 append_point (GpPath *path, GpPointF pt, PathPointType type, BOOL compress)
 {
 	append (path, pt.X, pt.Y, type, compress);
 }
 
-static void
+static VOID
 append_bezier (GpPath *path, float x1, float y1, float x2, float y2, float x3, float y3)
 {
 	append (path, x1, y1, PathPointTypeBezier3, FALSE);
@@ -147,7 +147,7 @@ append_bezier (GpPath *path, float x1, float y1, float x2, float y2, float x3, f
 	append (path, x3, y3, PathPointTypeBezier3, FALSE);
 }
 
-static void
+static VOID
 append_curve (GpPath *path, const GpPointF *points, GpPointF *tangents, int offset, int length, _CurveType type)
 {
 	int i;
@@ -202,20 +202,9 @@ GdipCreatePath (FillMode fillMode, GpPath **path)
 		return OutOfMemory;
 
 	result->fill_mode = fillMode;
-	result->size = 64;
-	result->points = GdipAlloc (sizeof (GpPointF) * result->size);
-	if (!result->points) {
-		GdipFree (result);
-		return OutOfMemory;
-	}
-
-	result->types = GdipAlloc (sizeof (BYTE) * result->size);
-	if (!result->types) {
-		GdipFree (result->points);
-		GdipFree (result);
-		return OutOfMemory;
-	}
-
+	result->size = 0;
+	result->points = NULL;
+	result->types = NULL;
 	result->count = 0;
 	result->start_new_fig = TRUE;
 
@@ -260,6 +249,9 @@ GdipCreatePath2 (const GpPointF *points, const BYTE *types, int count, FillMode 
 		GdipFree (new_path);
 		return OutOfMemory;
 	}
+
+	memcpy (new_path->points, points, sizeof (GpPointF) * count);
+	memcpy (new_path->types, types, sizeof (BYTE) * count);
 
 	*path = new_path;
 	
@@ -358,7 +350,13 @@ GdipResetPath (GpPath *path)
 	path->count = 0;
 	path->fill_mode = FillModeAlternate;
 	path->start_new_fig = TRUE;
-	gdip_path_compact(path);
+	path->size = 0;
+	if (path->points != NULL)
+		GdipFree (path->points);
+	if (path->types != NULL)
+		GdipFree (path->types);
+	path->points = NULL;
+	path->types = NULL;
 
 	return Ok;
 }
@@ -646,6 +644,9 @@ GdipAddPathLine (GpPath *path, float x1, float y1, float x2, float y2)
 	if (!path)
 		return InvalidParameter;
 
+	if (!gdip_path_ensure_size (path, path->count + 2))
+		return OutOfMemory;
+
 	/* only the first point can be compressed (i.e. removed if identical to previous) */
 	append (path, x1, y1, PathPointTypeLine, TRUE);
 	append (path, x2, y2, PathPointTypeLine, FALSE);
@@ -662,6 +663,9 @@ GdipAddPathLine2 (GpPath *path, const GpPointF *points, int count)
 	if (!path || !points || (count < 0))
 		return InvalidParameter;
 
+	if (!gdip_path_ensure_size (path, path->count + count))
+		return OutOfMemory;
+
 	/* only the first point can be compressed (i.e. removed if identical to previous) */
 	for (i = 0, tmp = (GpPointF*) points; i < count; i++, tmp++)
 		append (path, tmp->X, tmp->Y, PathPointTypeLine, (i == 0));
@@ -669,7 +673,7 @@ GdipAddPathLine2 (GpPath *path, const GpPointF *points, int count)
 	return Ok;
 }
 
-static void
+static VOID
 append_arc (GpPath *path, BOOL start, float x, float y, float width, float height, float startAngle, float endAngle)
 {
 	float delta, bcp;
@@ -723,7 +727,47 @@ append_arc (GpPath *path, BOOL start, float x, float y, float width, float heigh
 		cy + ry *  sin_beta);
 }
 
-static void
+static int
+count_arcs_points (GpPath *path, float x, float y, float width, float height, float startAngle, float sweepAngle)
+{
+	int i;
+	float drawn = 0;
+	int increment;
+	float endAngle;
+	int count = 1;
+
+	if (fabs (sweepAngle) >= 360)
+		return 13;
+
+	endAngle = startAngle + sweepAngle;
+	increment = (endAngle < startAngle) ? -90 : 90;
+
+	/* i is the number of sub-arcs drawn, each sub-arc can be at most 90 degrees.*/
+	/* there can be no more then 4 subarcs, ie. 90 + 90 + 90 + (something less than 90) */
+	for (i = 0; i < 4; i++) {
+		float current = startAngle + drawn;
+		float additional;
+
+		additional = endAngle - current; /* otherwise, add the remainder */
+		if (fabs (additional) > 90) {
+			additional = increment;
+		} else {
+			/* a near zero value will introduce bad artefact in the drawing (#78999) */
+			if (gdip_near_zero (additional))
+				return count;
+			count += 3;
+			return count;
+		}
+
+		count += 3;
+		drawn += additional;
+	}
+		
+	return count;
+}
+
+
+static VOID
 append_arcs (GpPath *path, float x, float y, float width, float height, float startAngle, float sweepAngle)
 {
 	int i;
@@ -771,8 +815,14 @@ GpStatus WINGDIPAPI
 GdipAddPathArc (GpPath *path, float x, float y, 
 		float width, float height, float startAngle, float sweepAngle)
 {
+	int point_count;
+
 	if (!path)
 		return InvalidParameter;
+
+	point_count = count_arcs_points (path, x, y, width, height, startAngle, sweepAngle);
+	if (!gdip_path_ensure_size (path, path->count + point_count))
+		return OutOfMemory;
 
 	/* draw the arcs */
 	append_arcs (path, x, y, width, height, startAngle, sweepAngle);
@@ -787,6 +837,9 @@ GdipAddPathBezier (GpPath *path,
 {
 	if (!path)
 		return InvalidParameter;
+
+	if (!gdip_path_ensure_size (path, path->count + 4))
+		return OutOfMemory;
 
 	append (path, x1, y1, PathPointTypeLine, TRUE);
 	append_bezier (path, x2, y2, x3, y3, x4, y4);
@@ -806,6 +859,9 @@ GdipAddPathBeziers (GpPath *path, const GpPointF *points, int count)
 	/* first bezier requires 4 points, other 3 more points */
 	if ((count < 4) || ((count % 3) != 1))
 		return InvalidParameter;
+
+	if (!gdip_path_ensure_size (path, path->count + count))
+		return OutOfMemory;
 
 	append_point (path, *tmp, PathPointTypeLine, TRUE);
 	tmp++;
@@ -835,6 +891,9 @@ GdipAddPathCurve2 (GpPath *path, const GpPointF *points, int count, float tensio
 	if (!tangents)
 		return OutOfMemory;
 
+	if (!gdip_path_ensure_size (path, path->count + (3 * (count - 1)) + 1))
+		return OutOfMemory;
+
 	append_curve (path, points, tangents, 0, count - 1, CURVE_OPEN);
 
 	GdipFree (tangents);
@@ -862,6 +921,9 @@ GdipAddPathCurve3 (GpPath *path, const GpPointF *points, int count,
 	if (!tangents)
 		return OutOfMemory;
 
+	if (!gdip_path_ensure_size (path, path->count + (3 * numberOfSegments) + 1))
+		return OutOfMemory;
+
 	append_curve (path, points, tangents, offset, numberOfSegments, CURVE_OPEN);
 
 	GdipFree (tangents);
@@ -887,6 +949,9 @@ GdipAddPathClosedCurve2 (GpPath *path, const GpPointF *points, int count, float 
 	if (!tangents)
 		return OutOfMemory;
 
+	if (!gdip_path_ensure_size (path, path->count + (3 * count) + 1))
+		return OutOfMemory;
+
 	append_curve (path, points, tangents, 0, count - 1, CURVE_CLOSE);
 
 	/* close the path */
@@ -905,6 +970,9 @@ GdipAddPathRectangle (GpPath *path, float x, float y, float width, float height)
 	if ((width == 0.0) || (height == 0.0))
 		return Ok;
 
+	if (!gdip_path_ensure_size (path, path->count + 4))
+		return OutOfMemory;
+
 	append (path, x, y, PathPointTypeStart, FALSE);
 	append (path, x + width, y, PathPointTypeLine, FALSE);
 	append (path, x + width, y + height, PathPointTypeLine, FALSE);
@@ -920,6 +988,9 @@ GdipAddPathRectangles (GpPath *path, const GpRectF *rects, int count)
 
 	if (!path || !rects)
 		return InvalidParameter;
+
+	if (!gdip_path_ensure_size (path, path->count + (4 * count)))
+		return OutOfMemory;
 
 	for (i = 0; i < count; i++) {
 		float x = rects[i].X;
@@ -942,6 +1013,9 @@ GdipAddPathEllipse (GpPath *path, float x, float y, float width, float height)
 
 	if (!path)
 		return InvalidParameter;
+
+	if (!gdip_path_ensure_size (path, path->count + 13))
+		return OutOfMemory;
 
 	/* origin */
 	append (path, cx + rx, cy, PathPointTypeStart, FALSE);
@@ -979,6 +1053,8 @@ GdipAddPathEllipse (GpPath *path, float x, float y, float width, float height)
 GpStatus WINGDIPAPI
 GdipAddPathPie (GpPath *path, float x, float y, float width, float height, float startAngle, float sweepAngle)
 {
+	int point_count;
+
 	float sin_alpha, cos_alpha;
 
 	float rx = width / 2;
@@ -999,6 +1075,12 @@ GdipAddPathPie (GpPath *path, float x, float y, float width, float height, float
 
 	if (!path)
 		return InvalidParameter;
+
+	point_count = count_arcs_points (path, x, y, width, height, startAngle, sweepAngle) + 1;
+	if (fabs (sweepAngle) < 360)
+		point_count += 2;
+	if (!gdip_path_ensure_size (path, path->count + point_count))
+		return OutOfMemory;
 
 	/* move to center */
 	append (path, cx, cy, PathPointTypeStart, FALSE);
@@ -1026,6 +1108,9 @@ GdipAddPathPolygon (GpPath *path, const GpPointF *points, int count)
 
 	if (!path || !points || (count < 3))
 		return InvalidParameter;
+
+	if (!gdip_path_ensure_size (path, path->count + count + 1))
+		return OutOfMemory;
 
 	/* note: polygon points are never compressed (i.e. removed if identical) */
 
@@ -1057,34 +1142,18 @@ GdipAddPathPath (GpPath *path, GDIPCONST GpPath *addingPath, BOOL connect)
 	if (!path || !addingPath)
 		return InvalidParameter;
 
-	length = addingPath->count;
-	if (length < 1)
-		return Ok;
-	
-	pts = gdip_calloc (sizeof (GpPointF), length);
-	if (!pts)
+	if (!gdip_path_ensure_size (path, path->count + addingPath->count))
 		return OutOfMemory;
-	types = gdip_calloc (sizeof (BYTE), length);
-	if (!types) {
-		GdipFree (pts);
-		return OutOfMemory;
-	}
 
-	GdipGetPathPoints ((GpPath*)addingPath, pts, length);
-	GdipGetPathTypes ((GpPath*)addingPath, types, length);
+	memcpy (path->types + path->count, addingPath->types, sizeof (BYTE) * addingPath->count);
+	memcpy (path->points + path->count, addingPath->points, sizeof (GpPointF) * addingPath->count);
 
 	/* We can connect only open figures. If first figure is closed
 	 * it can't be connected.
 	 */
-	first = connect ? gdip_get_first_point_type (path) : PathPointTypeStart;
-
-	append_point (path, pts [0], first, FALSE); 
-
-	for (i = 1; i < length; i++)
-		append_point (path, pts [i], types [i], FALSE);
-
-	GdipFree(pts);
-	GdipFree(types);
+	path->types[path->count] = connect ? gdip_get_first_point_type (path) : PathPointTypeStart;
+	path->start_new_fig = FALSE;
+	path->count += addingPath->count;
 
 	return Ok;
 }
@@ -1163,31 +1232,47 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 #endif
 
 	/* get the font data from the cairo path and translate it as a gdi+ path */
+	status = Ok;
 	cp = cairo_copy_path (cr);
 	if (cp) {
 		int i;
+		int count = 0;
 		for (i=0; i < cp->num_data; i += cp->data[i].header.length) {
-			PathPointType type = PathPointTypeStart;
 			cairo_path_data_t *data = &cp->data[i];
-
-			if ((i < cp->num_data - 1) && (data->header.type == CAIRO_PATH_CLOSE_PATH))
-				type |= PathPointTypeCloseSubpath;
-
 			switch (data->header.type) {
-			case CAIRO_PATH_MOVE_TO:
-				append (path, data[1].point.x, data[1].point.y, type, FALSE);
-				break;
-			case CAIRO_PATH_LINE_TO:
-				append (path, data[1].point.x, data[1].point.y, type | PathPointTypeLine, FALSE);
-				break;
-			case CAIRO_PATH_CURVE_TO:
-				append (path, data[1].point.x, data[1].point.y, PathPointTypeBezier, FALSE);
-				append (path, data[2].point.x, data[2].point.y, PathPointTypeBezier, FALSE);
-				append (path, data[3].point.x, data[3].point.y, type | PathPointTypeBezier, FALSE);
-				break;
-			case CAIRO_PATH_CLOSE_PATH:
-				break;
+			case CAIRO_PATH_MOVE_TO: count++; break;
+			case CAIRO_PATH_LINE_TO: count++; break;
+			case CAIRO_PATH_CURVE_TO: count += 3; break;
+			case CAIRO_PATH_CLOSE_PATH: break;
 			}
+		}
+
+		if (gdip_path_ensure_size (path, path->count + count)) {
+			for (i=0; i < cp->num_data; i += cp->data[i].header.length) {
+				PathPointType type = PathPointTypeStart;
+				cairo_path_data_t *data = &cp->data[i];
+
+				if ((i < cp->num_data - 1) && (data->header.type == CAIRO_PATH_CLOSE_PATH))
+					type |= PathPointTypeCloseSubpath;
+
+				switch (data->header.type) {
+				case CAIRO_PATH_MOVE_TO:
+					append (path, data[1].point.x, data[1].point.y, type, FALSE);
+					break;
+				case CAIRO_PATH_LINE_TO:
+					append (path, data[1].point.x, data[1].point.y, type | PathPointTypeLine, FALSE);
+					break;
+				case CAIRO_PATH_CURVE_TO:
+					append (path, data[1].point.x, data[1].point.y, PathPointTypeBezier, FALSE);
+					append (path, data[2].point.x, data[2].point.y, PathPointTypeBezier, FALSE);
+					append (path, data[3].point.x, data[3].point.y, type | PathPointTypeBezier, FALSE);
+					break;
+				case CAIRO_PATH_CLOSE_PATH:
+					break;
+				}
+			}
+		} else {
+			status = OutOfMemory;
 		}
 
 		cairo_path_destroy (cp);
@@ -1199,7 +1284,7 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 	GdipFree (utf8);
 	cairo_destroy (cr);
 	cairo_surface_destroy (cs);
-	return Ok;
+	return status;
 }
 
 /* MonoTODO - same limitations as GdipAddString */
@@ -1236,6 +1321,9 @@ GdipAddPathLine2I (GpPath* path, const GpPoint *points, int count)
 	if (!path || !points || (count < 0))
 		return InvalidParameter;
 
+	if (!gdip_path_ensure_size (path, path->count + count))
+		return OutOfMemory;
+
 	/* only the first point can be compressed (i.e. removed if identical to previous) */
 	for (i = 0, tmp = (GpPoint*) points; i < count; i++, tmp++)
 		append (path, tmp->X, tmp->Y, PathPointTypeLine, (i == 0));
@@ -1267,6 +1355,9 @@ GdipAddPathBeziersI (GpPath *path, const GpPoint *points, int count)
 	/* first bezier requires 4 points, other 3 more points */
 	if ((count < 4) || ((count % 3) != 1))
 		return InvalidParameter;
+
+	if (!gdip_path_ensure_size (path, path->count + count))
+		return OutOfMemory;
 
 	tmp = (GpPoint*) points;
 	append (path, tmp->X, tmp->Y, PathPointTypeLine, TRUE);
@@ -1394,6 +1485,9 @@ GdipAddPathPolygonI (GpPath *path, const GpPoint *points, int count)
 
 	if (!path || !points || (count < 3))
 		return InvalidParameter;
+
+	if (!gdip_path_ensure_size (path, path->count + count + 1))
+		return OutOfMemory;
 
 	/* note: polygon points are never compressed (i.e. removed if identical) */
 

--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -21,7 +21,7 @@
  * Authors:
  *      Duncan Mak (duncan@ximian.com)
  *      Ravindra (rkumar@novell.com)
- *	Sebastien Pouliot  <sebastien@ximian.com>
+ *	    Sebastien Pouliot  <sebastien@ximian.com>
  */
  
 #include "graphics-path-private.h"
@@ -33,46 +33,29 @@
 	#include "text-pango-private.h"
 #endif
 
-static GArray *
-array_to_g_array (const GpPointF *pt, int length)
+VOID
+gdip_path_ensure_size (GpPath *path, int size)
 {
-	GArray *p = g_array_sized_new (FALSE, TRUE, sizeof (GpPointF), length);
-	g_array_append_vals (p, pt, length);
-	return p;
+	if (path->size < size) {
+		if (size < path->size + 64)
+			size = path->size + 64;
+		path->types = gdip_realloc (path->types, size * sizeof (BYTE));
+		path->points = gdip_realloc (path->points, size * sizeof (GpPointF));
+		// TODO: Handle allocation failure
+		path->size = size;
+	}
 }
 
-static GpPointF *
-g_array_to_array (GArray *p)
+VOID
+gdip_path_compact (GpPath *path)
 {
-	int length = p->len;
-	GpPointF *pts = (GpPointF *) GdipAlloc (sizeof (GpPointF) * length);
-	if (!pts)
-		return NULL;
-
-	memcpy (pts, p->data, p->len * sizeof (GpPointF));        
-	
-    return pts;
-}
-
-static BYTE *
-g_byte_array_to_array (GByteArray *p)
-{
-	int length = p->len;
-	BYTE *types = (BYTE*) GdipAlloc (sizeof (BYTE) * length);
-	if (!types)
-		return NULL;
-
-	memcpy (types, p->data, p->len * sizeof (BYTE));
-
-	return types;
-}
-
-static GByteArray *
-array_to_g_byte_array (const BYTE *types, int count)
-{
-	GByteArray *p = g_byte_array_sized_new (count);
-	g_byte_array_append (p, types, count);
-	return p;
+	if (path->size > path->count + 64) {
+		int size = (path->count + 63) & ~63;
+		path->types = gdip_realloc (path->types, size * sizeof (BYTE));
+		path->points = gdip_realloc (path->points, size * sizeof (GpPointF));
+		// TODO: Handle allocation failure
+		path->size = size;
+	}
 }
 
 /* return TRUE if the specified path has (at least one) curves, FALSE otherwise */
@@ -85,7 +68,7 @@ gdip_path_has_curve (GpPath *path)
 		return FALSE;
 
 	for (i = 0; i < path->count; i++) {
-		if (g_array_index (path->types, BYTE, i) == PathPointTypeBezier)
+		if (path->types[i] == PathPointTypeBezier)
 			return TRUE;
 	}
 
@@ -105,7 +88,7 @@ gdip_get_first_point_type (GpPath *path)
 		return PathPointTypeStart;
 
 	/* check if the previous point is a closure */
-	type = g_array_index (path->types, BYTE, path->count - 1);
+	type = path->types[path->count - 1];
 	if (type & PathPointTypeCloseSubpath)
 		return PathPointTypeStart;
 	else
@@ -121,10 +104,10 @@ append (GpPath *path, float x, float y, PathPointType type, BOOL compress)
 	/* in some case we're allowed to compress identical points */
 	if (compress && (path->count > 0)) {
 		/* points (X, Y) must be identical */
-		GpPointF lastPoint = g_array_index (path->points, GpPointF, path->count - 1);
+		GpPointF lastPoint = path->points[path->count - 1];
 		if ((lastPoint.X == x) && (lastPoint.Y == y)) {
 			/* types need not be identical but must handle closed subpaths */
-			PathPointType last_type = g_array_index (path->types, BYTE, path->count - 1);
+			PathPointType last_type = path->types[path->count - 1];
 			if ((last_type & PathPointTypeCloseSubpath) != PathPointTypeCloseSubpath)
 				return;
 		}
@@ -134,7 +117,7 @@ append (GpPath *path, float x, float y, PathPointType type, BOOL compress)
 		t = PathPointTypeStart;
 	/* if we closed a subpath, then start new figure and append */
 	else if (path->count > 0) {
-		type = g_array_index (path->types, BYTE, path->count - 1);
+		type = path->types[path->count - 1];
 		if (type & PathPointTypeCloseSubpath)
 			t = PathPointTypeStart;
 	}
@@ -142,8 +125,9 @@ append (GpPath *path, float x, float y, PathPointType type, BOOL compress)
 	pt.X = x;
 	pt.Y = y;
 
-	g_array_append_val (path->points, pt);
-	g_byte_array_append (path->types, &t, 1);
+	gdip_path_ensure_size (path, path->count + 1);
+	path->points[path->count] = pt;
+	path->types[path->count] = t;
 	path->count++;
 
 	path->start_new_fig = FALSE;
@@ -218,14 +202,16 @@ GdipCreatePath (FillMode fillMode, GpPath **path)
 		return OutOfMemory;
 
 	result->fill_mode = fillMode;
-	result->points = g_array_new (FALSE, FALSE, sizeof (GpPointF));
+	result->size = 64;
+	result->points = GdipAlloc (sizeof (GpPointF) * result->size);
 	if (!result->points) {
 		GdipFree (result);
 		return OutOfMemory;
 	}
 
-	result->types = g_byte_array_new ();
+	result->types = GdipAlloc (sizeof (BYTE) * result->size);
 	if (!result->types) {
+		GdipFree (result->points);
 		GdipFree (result);
 		return OutOfMemory;
 	}
@@ -241,8 +227,7 @@ GdipCreatePath (FillMode fillMode, GpPath **path)
 GpStatus WINGDIPAPI
 GdipCreatePath2 (const GpPointF *points, const BYTE *types, int count, FillMode fillMode, GpPath **path)
 {
-	GArray *pts;
-	GByteArray *t;
+	GpPath *new_path;
 
 	if (!gdiplusInitialized)
 		return GdiplusNotInitialized;
@@ -255,27 +240,28 @@ GdipCreatePath2 (const GpPointF *points, const BYTE *types, int count, FillMode 
 	 * invalid. Some cases are like last type being PathPointTypeStart or
 	 * PathPointTypeCloseSubpath etc.
 	 */
-	pts = array_to_g_array (points, count);
-	if (!pts)
-		return OutOfMemory;
 
-	t = array_to_g_byte_array (types, count);
-	if (!t) {
-		g_array_free (pts, TRUE);
+	new_path = (GpPath *) GdipAlloc (sizeof (GpPath));
+	if (!new_path) {
 		return OutOfMemory;
 	}
 
-	*path = (GpPath *) GdipAlloc (sizeof (GpPath));
-	if (!*path) {
-		g_array_free (pts, TRUE);
-		g_byte_array_free (t, TRUE);
+	new_path->fill_mode = fillMode;
+	new_path->count = count;
+	new_path->size = (count + 63) & ~63;
+	new_path->points = GdipAlloc (sizeof (GpPointF) * new_path->size);
+	if (!new_path->points) {
+		GdipFree (new_path);
+		return OutOfMemory;
+	}
+	new_path->types = GdipAlloc (sizeof (BYTE) * new_path->size);
+	if (!new_path->types) {
+		GdipFree (new_path->points);
+		GdipFree (new_path);
 		return OutOfMemory;
 	}
 
-	(*path)->fill_mode = fillMode;
-	(*path)->count = count;
-	(*path)->points = pts;
-	(*path)->types = t;
+	*path = new_path;
 	
 	return Ok;
 }
@@ -322,24 +308,22 @@ GdipClonePath (GpPath *path, GpPath **clonePath)
 
 	result->fill_mode = path->fill_mode;
 	result->count = path->count;
-	result->points = g_array_new (FALSE, FALSE, sizeof (GpPointF));
+	result->size = path->size;
+	result->points = GdipAlloc (sizeof (GpPointF) * result->size);
 	if (!result->points) {
 		GdipFree (result);
 		return OutOfMemory;
 	}
 
-	result->types = g_byte_array_new ();
+	result->types = GdipAlloc (sizeof (BYTE) * result->size);
 	if (!result->types) {
+		GdipFree (result->points);
 		GdipFree (result);
 		return OutOfMemory;
 	}
 
-	for (i = 0; i < path->count; i++) {
-		point = g_array_index (path->points, GpPointF, i);
-		type = g_array_index (path->types, BYTE, i);
-		g_array_append_val (result->points, point);
-		g_byte_array_append (result->types, &type, 1);
-	}
+	memcpy (result->points, path->points, sizeof (GpPointF) * path->count);
+	memcpy (result->types, path->types, sizeof (BYTE) * path->count);
 
 	result->start_new_fig = path->start_new_fig;
 
@@ -354,11 +338,11 @@ GdipDeletePath (GpPath *path)
 		return InvalidParameter;
 
 	if (path->points != NULL)
-		g_array_free (path->points, TRUE);
+		GdipFree (path->points);
 	path->points = NULL;
 
 	if (path->types != NULL)
-		g_byte_array_free (path->types, TRUE);
+		GdipFree (path->types);
 	path->types = NULL;
 
 	GdipFree (path);
@@ -371,17 +355,10 @@ GdipResetPath (GpPath *path)
 	if (path == NULL)
 		return InvalidParameter;
 
-	if (path->points != NULL)
-		g_array_free (path->points, TRUE);
-
-	if (path->types != NULL)
-		g_byte_array_free (path->types, TRUE);
-
 	path->count = 0;
-	path->points = g_array_new (FALSE, FALSE, sizeof (GpPointF));
-	path->types = g_byte_array_new ();
 	path->fill_mode = FillModeAlternate;
 	path->start_new_fig = TRUE;
+	gdip_path_compact(path);
 
 	return Ok;
 }
@@ -407,8 +384,7 @@ GdipGetPathTypes (GpPath *path, BYTE *types, int count)
 	if (count > path->count)
 		count = path->count;
 
-	for (i = 0; i < count; i++)
-		types [i] = path->types->data [i];
+	memcpy (types, path->types, sizeof (BYTE) * count);
 	
 	return Ok;
 }
@@ -424,11 +400,7 @@ GdipGetPathPoints (GpPath *path, GpPointF *points, int count)
 	if (count > path->count)
 		count = path->count;
 
-	for (i = 0; i < count; i++) {
-		GpPointF point = g_array_index (path->points, GpPointF, i);
-		points [i].X = point.X;
-		points [i].Y = point.Y;
-	}
+	memcpy (points, path->points, sizeof (GpPointF) * count);
 
 	return Ok;
 }
@@ -441,8 +413,11 @@ GdipGetPathPointsI (GpPath *path, GpPoint *points, int count)
 	if (!path || !points || (count < 1))
 		return InvalidParameter;
 
+	if (count > path->count)
+		count = path->count;
+
 	for (i = 0; i < count; i++) {
-		GpPoint point = g_array_index (path->points, GpPoint, i);
+		GpPointF point = path->points[i];
 		points [i].X = (int) point.X;
 		points [i].Y = (int) point.Y; 
 	}
@@ -478,19 +453,11 @@ GdipGetPathData (GpPath *path, GpPathData *pathData)
 	if (!path || !pathData)
 		return InvalidParameter;
 
-	pathData->Points = g_array_to_array (path->points);
-	if (!pathData->Points)
-		return OutOfMemory;
+	if (pathData->Count > path->count)
+		pathData->Count = path->count;
 
-	pathData->Types = g_byte_array_to_array (path->types);
-	if (!pathData->Types) {
-		GdipFree (pathData->Points);
-		pathData->Points = NULL;
-		return OutOfMemory;
-	}
-
-	/* don't return the count unless we have the data */
-	pathData->Count = path->count;
+	memcpy (pathData->Points, path->points, sizeof (GpPointF) * pathData->Count);
+	memcpy (pathData->Types, path->types, sizeof (BYTE) * pathData->Count);
 
 	return Ok;
 }
@@ -513,8 +480,7 @@ GdipClosePathFigure (GpPath *path)
 		return InvalidParameter;
 
 	if (path->count > 0) {
-		BYTE *last = &g_array_index (path->types, BYTE, path->count - 1);
-		*last |= PathPointTypeCloseSubpath;
+		path->types[path->count - 1] |= PathPointTypeCloseSubpath;
 	}
 	path->start_new_fig = TRUE;
 
@@ -525,9 +491,6 @@ GpStatus WINGDIPAPI
 GdipClosePathFigures (GpPath *path)
 {
 	int index = 0;
-	BYTE currentType;
-	BYTE lastType;
-	GByteArray *oldTypes;
 
 	if (!path)
 		return InvalidParameter;
@@ -536,32 +499,15 @@ GdipClosePathFigures (GpPath *path)
 	if (path->count <= 1)
 		return Ok;
 
-	oldTypes = path->types;
-	path->types = g_byte_array_new ();
-
-	lastType = g_array_index (oldTypes, BYTE, index);
-	index++;
-
 	for (index = 1; index < path->count; index++) {
-		currentType = g_array_index (oldTypes, BYTE, index);
-		/* we dont close on the first point */
-		if ((currentType == PathPointTypeStart) && (index > 1)) {
-			lastType |= PathPointTypeCloseSubpath;
-			g_byte_array_append (path->types, &lastType, 1);
+		if (path->types[index] == PathPointTypeStart) {
+			path->types[index - 1] |= PathPointTypeCloseSubpath;
 		}
-		else
-			g_byte_array_append (path->types, &lastType, 1);
-
-		lastType = currentType;
 	}
 
 	/* close at the end */
-	lastType |= PathPointTypeCloseSubpath;
-	g_byte_array_append (path->types, &lastType, 1);
-
+	path->types[index - 1] |= PathPointTypeCloseSubpath;
 	path->start_new_fig = TRUE;
-
-	g_byte_array_free (oldTypes, TRUE);
 
 	return Ok;
 }
@@ -569,21 +515,13 @@ GdipClosePathFigures (GpPath *path)
 GpStatus WINGDIPAPI
 GdipSetPathMarker (GpPath *path)
 {
-	BYTE current;
-
 	if (!path)
 		return InvalidParameter;
 
 	if (path->count == 0)
 		return Ok;
 
-	current = g_array_index (path->types, BYTE, path->count - 1);
-
-	g_byte_array_remove_index (path->types, path->count - 1);
-
-	current |= PathPointTypePathMarker;
-
-	g_byte_array_append (path->types, &current, 1);
+	path->types[path->count - 1] |= PathPointTypePathMarker;
 
 	return Ok;
 }
@@ -592,31 +530,13 @@ GpStatus WINGDIPAPI
 GdipClearPathMarkers (GpPath *path)
 {
 	int i;
-	BYTE current;
-	GByteArray *cleared;
 
 	if (!path)
 		return InvalidParameter;
 
-	/* shortcut to avoid allocations */
-	if (path->count == 0)
-		return Ok;
-
-	cleared = g_byte_array_new ();
-
 	for (i = 0; i < path->count; i++) {
-		current = g_array_index (path->types, BYTE, i);
-
-		/* take out the marker if there is one */
-		if (current & PathPointTypePathMarker)
-			current &= ~PathPointTypePathMarker;
-		
-		g_byte_array_append (cleared, &current, 1);
+		path->types[i] &= ~PathPointTypePathMarker;
 	}
-
-	/* replace the existing with the cleared array */
-	g_byte_array_free (path->types, TRUE);
-	path->types = cleared;
 
 	return Ok;
 }
@@ -625,47 +545,30 @@ GdipClearPathMarkers (GpPath *path)
  * Append old_types[start, end] to new_types, adjusting flags.
  */
 static void
-reverse_subpath_adjust_flags (int start, int end, GByteArray *old_types, GByteArray *new_types, BOOL *prev_had_marker)
+reverse_subpath_adjust_flags (int start, int end, BYTE *types, BOOL *prev_had_marker)
 {
 	BYTE t, prev_last;
 	int i;
 	
 	/* Copy all but PathPointTypeStart */
 	if (end != start)
-		g_byte_array_append (new_types, old_types->data + start + 1, end - start);
-	
+		memmove (types + start, types + start + 1, (end - start) * sizeof (BYTE));
+
 	/* Append PathPointTypeStart */
-	t = PathPointTypeStart;
-	g_byte_array_append (new_types, &t, 1);
-	
-	g_assert (new_types->len == end + 1);
-	
-	prev_last = g_array_index (old_types, BYTE, end);
-	
+	prev_last = types[end];
+	types[end] = PathPointTypeStart;
+
 	/* Remove potential flags from our future start point */
 	if (end != start)
-		new_types->data[end - 1] &= PathPointTypePathTypeMask;
+		types[end - 1] &= PathPointTypePathTypeMask;
 	/* Set the flags on our to-be-last point */
-	if (prev_last & PathPointTypeDashMode)
-		new_types->data[start] |= PathPointTypeDashMode;
-	if (prev_last & PathPointTypeCloseSubpath)
-		new_types->data[start] |= PathPointTypeCloseSubpath;
-	
-	/*
-	 * Swap markers
-	 */
-	for (i = start + 1; i < end; i++) {
-		if (g_array_index (old_types, BYTE, i - 1) & PathPointTypePathMarker)
-			new_types->data[i] |= PathPointTypePathMarker;
-		else
-			new_types->data[i] &= ~PathPointTypePathMarker;
-	}
-	
+	types[start] |= prev_last & (PathPointTypeDashMode | PathPointTypeCloseSubpath);
+
 	/* If the last point of the previous subpath had a marker, we inherit it */
 	if (*prev_had_marker)
-		new_types->data[start] |= PathPointTypePathMarker;
+		types[start] |= PathPointTypePathMarker;
 	else
-		new_types->data[start] &= ~PathPointTypePathMarker;
+		types[start] &= ~PathPointTypePathMarker;
 	
 	*prev_had_marker = ((prev_last & PathPointTypePathMarker) == PathPointTypePathMarker);
 }
@@ -689,37 +592,31 @@ GdipReversePath (GpPath *path)
 	/* PathTypes reversal */
 
 	/* First adjust the flags for each subpath */
-	types = g_byte_array_sized_new (length);
-	if (!types)
-		return OutOfMemory;
-
 	for (i = 1; i < length; i++) {
-		BYTE t = g_array_index (path->types, BYTE, i);
+		BYTE t = path->types[i];
 		if ((t & PathPointTypePathTypeMask) == PathPointTypeStart) {
-			reverse_subpath_adjust_flags (start, i - 1, path->types, types, &prev_had_marker);
+			reverse_subpath_adjust_flags (start, i - 1, path->types, &prev_had_marker);
 			start = i;
 		}
 	}
 	if (start < length - 1)
-		reverse_subpath_adjust_flags (start, length - 1, path->types, types, &prev_had_marker);
+		reverse_subpath_adjust_flags (start, length - 1, path->types, &prev_had_marker);
 
 	/* Then reverse the resulting array */
 	for (i = 0; i < (length >> 1); i++) {
-		BYTE *a = &g_array_index (types, BYTE, i);
-		BYTE *b = &g_array_index (types, BYTE, length - i - 1);
+		BYTE *a = path->types + i;
+		BYTE *b = path->types + length - i - 1;
 		BYTE temp = *a;
 		*a = *b;
 		*b = temp;
 	}
-	g_byte_array_free (path->types, TRUE);
-	path->types = types;
 
 	/* PathPoints reversal
 	 * note: if length is odd then the middle point doesn't need to switch side
 	 */
 	for (i = 0; i < (length >> 1); i++) {
-		GpPointF *first = &g_array_index (path->points, GpPointF, i);
-		GpPointF *last = &g_array_index (path->points, GpPointF, length - i - 1);
+		GpPointF *first = path->points + i;
+		GpPointF *last = path->points + length - i - 1;
 
 		GpPointF temp;
 		temp.X = first->X;
@@ -739,7 +636,7 @@ GdipGetPathLastPoint (GpPath *path, GpPointF *lastPoint)
 	if (!path || !lastPoint || (path->count <= 0))
 		return InvalidParameter;
 
-	*lastPoint = g_array_index (path->points, GpPointF, path->count - 1);
+	*lastPoint = path->points[path->count - 1];
 	return Ok;
 }
 
@@ -1223,7 +1120,7 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 		return OutOfMemory;
 	}
 
-	utf8 = (BYTE*) ucs2_to_utf8 ((const gunichar2 *)string, -1);
+	utf8 = (BYTE*) ucs2_to_utf8 (string, -1);
 	if (!utf8) {
 		cairo_destroy (cr);
 		cairo_surface_destroy (cs);
@@ -1521,7 +1418,7 @@ GdipAddPathPolygonI (GpPath *path, const GpPoint *points, int count)
 /* nr_curve_flatten comes from Sodipodi's libnr (public domain) available from http://www.sodipodi.com/ */
 /* Mono changes: converted to float (from double), added recursion limit, use GArray */
 static BOOL
-nr_curve_flatten (float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3, float flatness, int level, GArray *points)
+nr_curve_flatten (float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3, float flatness, int level, GpPath *flat_path)
 {
 	float dx1_0, dy1_0, dx2_0, dy2_0, dx3_0, dy3_0, dx2_3, dy2_3, d3_0_2;
 	float s1_q, t1_q, s2_q, t2_q, v2_q;
@@ -1562,11 +1459,7 @@ nr_curve_flatten (float x0, float y0, float x1, float y1, float x2, float y2, fl
 
  nosubdivide:
 	{
-	GpPointF pt;
-
-	pt.X = x3;
-	pt.Y = y3;
-	g_array_append_val (points, pt);
+	append (flat_path, x3, y3, PathPointTypeLine, FALSE);
 	return TRUE;
 	}
  subdivide:
@@ -1585,52 +1478,36 @@ nr_curve_flatten (float x0, float y0, float x1, float y1, float x2, float y2, fl
 	xttt = (x0tt + x1tt) * 0.5;
 	yttt = (y0tt + y1tt) * 0.5;
 
-	if (!nr_curve_flatten (x0, y0, x00t, y00t, x0tt, y0tt, xttt, yttt, flatness, level+1, points)) return FALSE;
-	if (!nr_curve_flatten (xttt, yttt, x1tt, y1tt, x11t, y11t, x3, y3, flatness, level+1, points)) return FALSE;
+	if (!nr_curve_flatten (x0, y0, x00t, y00t, x0tt, y0tt, xttt, yttt, flatness, level+1, flat_path)) return FALSE;
+	if (!nr_curve_flatten (xttt, yttt, x1tt, y1tt, x11t, y11t, x3, y3, flatness, level+1, flat_path)) return FALSE;
 	return TRUE;
 }
 
 static BOOL
-gdip_convert_bezier_to_lines (GpPath *path, int index, float flatness, GArray *flat_points, GByteArray *flat_types)
+gdip_convert_bezier_to_lines (GpPath *path, int index, float flatness, GpPath *flat_path)
 {
-	GArray *points;
 	GpPointF start, first, second, end;
 	GpPointF pt;
 	BYTE type;
 	int i;
+	int points_len = 0;
+	int saved_count;
 
 	if ((index <= 0) || (index + 2 >= path->count))
 		return FALSE; /* bad path data */
 
-	start = g_array_index (path->points, GpPointF, index - 1);
-	first = g_array_index (path->points, GpPointF, index);
-	second = g_array_index (path->points, GpPointF, index + 1);
-	end = g_array_index (path->points, GpPointF, index + 2);
+	start = path->points[index - 1];
+	first = path->points[index];
+	second = path->points[index + 1];
+	end = path->points[index + 2];
 
-	/* we can't add points directly to the original list as we could end up with too much recursion */
-	points = g_array_new (FALSE, FALSE, sizeof (GpPointF));
-	if (!nr_curve_flatten (start.X, start.Y, first.X, first.Y, second.X, second.Y, end.X, end.Y, flatness, 0, points)) {
+	saved_count = flat_path->count;
+	if (!nr_curve_flatten (start.X, start.Y, first.X, first.Y, second.X, second.Y, end.X, end.Y, flatness, 0, flat_path)) {
 		/* curved path is too complex (i.e. would result in too many points) to render as a polygon */
-		g_array_free (points, TRUE);
+		flat_path->count = saved_count;
 		return FALSE;
 	}
 
-	/* recursion was within limits, append the result to the original supplied list */
-	if (points->len > 0) {
-		g_array_append_val (flat_points, g_array_index (points, GpPointF, 0));
-		type = PathPointTypeLine;
-		g_byte_array_append (flat_types, &type, 1);
-	}
-
-	/* always PathPointTypeLine */
-	type = PathPointTypeLine;
-	for (i = 1; i < points->len; i++) {
-		pt = g_array_index (points, GpPointF, i);
-		g_array_append_val (flat_points, pt);
-		g_byte_array_append (flat_types, &type, 1);
-	}
-
-	g_array_free (points, TRUE);
 	return TRUE;
 }
 
@@ -1638,6 +1515,7 @@ GpStatus WINGDIPAPI
 GdipFlattenPath (GpPath *path, GpMatrix *matrix, float flatness)
 {
 	GpStatus status = Ok;
+	GpPath *flat_path;
 	GArray *points;
 	GByteArray *types;
 	int i;
@@ -1656,64 +1534,52 @@ GdipFlattenPath (GpPath *path, GpMatrix *matrix, float flatness)
 	if (!gdip_path_has_curve (path))
 		return status;
 
-	points = g_array_new (FALSE, FALSE, sizeof (GpPointF));
-	types = g_byte_array_new ();
+	status = GdipCreatePath (path->fill_mode, &flat_path);
+	if (status != Ok)
+		return status;
 
 	/* Iterate the current path and replace each bezier with multiple lines */
 	for (i = 0; i < path->count; i++) {
-		GpPointF point = g_array_index (path->points, GpPointF, i);
-		BYTE type = g_array_index (path->types, BYTE, i);
+		GpPointF point = path->points[i];
+		BYTE type = path->types[i];
 
 		/* PathPointTypeBezier3 has the same value as PathPointTypeBezier */
 		if ((type & PathPointTypeBezier) == PathPointTypeBezier) {
-			if (!gdip_convert_bezier_to_lines (path, i, fabs (flatness), points, types)) {
+			if (!gdip_convert_bezier_to_lines (path, i, fabs (flatness), flat_path)) {
 				/* uho, too much recursion - do not pass go, do not collect 200$ */
 				GpPointF pt;
 
 				/* free the the partial flat */
-				g_array_free (points, TRUE);
-				g_byte_array_free (types, TRUE);
+				GdipResetPath (flat_path);
 
 				/* mimic MS behaviour when recursion becomes a problem */
 				/* note: it's not really an empty rectangle as the last point isn't closing */
-				points = g_array_new (FALSE, FALSE, sizeof (GpPointF));
-				types = g_byte_array_new ();
 
-				pt.X = pt.Y = 0;
-				type = PathPointTypeStart;
-				g_array_append_val (points, pt);
-				g_byte_array_append (types, &type, 1);
-
-				type = PathPointTypeLine;
-				g_array_append_val (points, pt);
-				g_byte_array_append (types, &type, 1);
-
-				g_array_append_val (points, pt);
-				g_byte_array_append (types, &type, 1);
-
-				g_array_append_val (points, pt);
-				g_byte_array_append (types, &type, 1);
+				append (flat_path, 0, 0, PathPointTypeStart, FALSE);
+				append (flat_path, 0, 0, PathPointTypeLine, FALSE);
+				append (flat_path, 0, 0, PathPointTypeLine, FALSE);
+				append (flat_path, 0, 0, PathPointTypeLine, FALSE);
 				break;
 			}
 			/* beziers have 4 points: the previous one, the current and the next two */
 			i += 2;
 		} else {
 			/* no change required, just copy the point */
-			g_array_append_val (points, point);
-			g_byte_array_append (types, &type, 1);
+			append_point(flat_path, point, type, FALSE);
 		}
 	}
 
 	/* free original path points and types */
 	if (path->points != NULL)
-		g_array_free (path->points, TRUE);
+		GdipFree (path->points);
 	if (path->types != NULL)
-		g_byte_array_free (path->types, TRUE);
+		GdipFree (path->types);
 
 	/* transfer new path informations */
-	path->points = points;
-	path->types = types;
-	path->count = points->len;
+	path->points = flat_path->points;
+	path->types = flat_path->types;
+	path->count = flat_path->count;
+	path->size = flat_path->size;
 
 	/* note: no error code is given for excessive recursion */
 	return Ok;
@@ -1824,34 +1690,17 @@ GdipWarpPath (GpPath *path, GpMatrix *matrix, const GpPointF *points, int count,
 GpStatus WINGDIPAPI 
 GdipTransformPath (GpPath* path, GpMatrix *matrix)
 {
-	PointF *points;
-	int count;
-	GpStatus s;
-
 	if (!path)
 		return InvalidParameter;
 
-	count = path->count;
-	if (count == 0)
+	if (path->count == 0)
 		return Ok; /* GdipTransformMatrixPoints would fail */
 
 	/* avoid allocation/free/calculation for null/identity matrix */
 	if (gdip_is_matrix_empty (matrix))
 		return Ok;
 
-	points = g_array_to_array (path->points);
-	if (!points)
-		return OutOfMemory;
-
-	s = GdipTransformMatrixPoints (matrix, points, count);
-
-	path->points = array_to_g_array (points, count);
-
-	GdipFree (points);
-	if (!path->points)
-		return OutOfMemory;
-
-	return s;
+	return GdipTransformMatrixPoints (matrix, path->points, path->count);
 }
 
 GpStatus WINGDIPAPI 
@@ -1890,7 +1739,7 @@ GdipGetPathWorldBounds (GpPath *path, GpRectF *bounds, const GpMatrix *matrix, c
 		int i;
 		GpPointF points;
 
-		points = g_array_index (workpath->points, GpPointF, 0);
+		points = workpath->points[0];
 		bounds->X = points.X;		/* keep minimum X here */
 		bounds->Y = points.Y;		/* keep minimum Y here */
 		if (workpath->count == 1) {
@@ -1905,7 +1754,7 @@ GdipGetPathWorldBounds (GpPath *path, GpRectF *bounds, const GpMatrix *matrix, c
 		bounds->Height = points.Y;	/* keep maximum Y here */
 
 		for (i = 1; i < workpath->count; i++) {
-			points = g_array_index (workpath->points, GpPointF, i);
+			points = workpath->points[i];
 			if (points.X < bounds->X)
 				bounds->X = points.X;
 			if (points.Y < bounds->Y)

--- a/src/graphics-pathiterator.c
+++ b/src/graphics-pathiterator.c
@@ -135,9 +135,9 @@ GdipPathIterCopyData (GpPathIterator *iterator, int *resultCount, GpPointF *poin
 		return Ok;
 	}
 
-	memcpy (points, iterator->path->points + startIndex, (endIndex - startIndex) * sizeof (GpPointF));
-	memcpy (types, iterator->path->types + startIndex, (endIndex - startIndex) * sizeof (BYTE));
-	*resultCount = endIndex - startIndex;
+	memcpy (points, iterator->path->points + startIndex, (endIndex - startIndex + 1) * sizeof (GpPointF));
+	memcpy (types, iterator->path->types + startIndex, (endIndex - startIndex + 1) * sizeof (BYTE));
+	*resultCount = endIndex - startIndex + 1;
 
 	return Ok;
 }

--- a/src/graphics-pathiterator.c
+++ b/src/graphics-pathiterator.c
@@ -94,7 +94,7 @@ GdipPathIterGetSubpathCount (GpPathIterator *iterator, int *count)
 		BYTE type;
 		/* Number of subpaths = Number of starting points */
 		for (i = 0; i < iterator->path->count; i++) {
-			type = g_array_index (iterator->path->types, BYTE, i);
+			type = iterator->path->types[i];
 			if (type == PathPointTypeStart)
 				numSubpaths++;
 		}
@@ -135,12 +135,9 @@ GdipPathIterCopyData (GpPathIterator *iterator, int *resultCount, GpPointF *poin
 		return Ok;
 	}
 
-	for (i = startIndex, j = 0; i <= endIndex; i++, j++) {
-		points [j] = g_array_index (iterator->path->points, GpPointF, i);
-		types [j] = g_array_index (iterator->path->types, BYTE, i);
-	}
-
-	*resultCount = j;
+	memcpy (points, iterator->path->points + startIndex, (endIndex - startIndex) * sizeof (GpPointF));
+	memcpy (types, iterator->path->types + startIndex, (endIndex - startIndex) * sizeof (BYTE));
+	*resultCount = endIndex - startIndex;
 
 	return Ok;
 }
@@ -155,8 +152,8 @@ GdipPathIterEnumerate (GpPathIterator *iterator, int *resultCount, GpPointF *poi
 
 	if (iterator->path) {
 		for (; i < count && i < iterator->path->count; i++) {
-			points [i] = g_array_index (iterator->path->points, GpPointF, i);
-			types [i] = g_array_index (iterator->path->types, BYTE, i);
+			points [i] = iterator->path->points[i];
+			types [i] = iterator->path->types[i];
 		}
 	}
 
@@ -179,48 +176,19 @@ GdipPathIterHasCurve (GpPathIterator *iterator, BOOL *curve)
 GpStatus
 GdipPathIterNextMarkerPath (GpPathIterator *iterator, int *resultCount, GpPath *path)
 {
-	int index = 0;
-	BYTE type;
-	GpPointF point;
+	int start, end;
+	GpStatus status;
 
-	if (!iterator || !resultCount)
-		return InvalidParameter;
-
-	/* There are no paths or markers or we are done with all the markers */
-	if (!path || !iterator->path || (iterator->path->count == 0) ||
-	    (iterator->markerPosition == iterator->path->count)) {
-		*resultCount = 0;
-		return Ok;
+	status = GdipPathIterNextMarker (iterator, resultCount, &start, &end);
+	if (status == Ok && *resultCount > 0) {
+		GdipResetPath (path);
+		gdip_path_ensure_size (path, *resultCount);
+		memcpy (path->types, iterator->path->types + start, sizeof (BYTE) * *resultCount);
+		memcpy (path->points, iterator->path->points + start, sizeof (GpPointF) * *resultCount);
+		path->count = *resultCount;
 	}
 
-	/* Clear the existing values from path */
-	if (path->count > 0) {
-		g_array_free (path->points, TRUE);
-		g_byte_array_free (path->types, TRUE);
-
-		path->points = g_array_new (FALSE, FALSE, sizeof (GpPointF));
-		path->types = g_byte_array_new ();
-		path->count = 0;
-	}
-
-	for (index = iterator->markerPosition; index < iterator->path->count; index++) {
-		type = g_array_index (iterator->path->types, BYTE, index);
-		point = g_array_index (iterator->path->points, GpPointF, index);
-		g_array_append_val (path->points, point);
-		g_byte_array_append (path->types, &type, 1);
-		path->count++;
-
-		/* Copy the marker and stop copying the points when we reach a marker type */
-		if (type & PathPointTypePathMarker) {
-			index++;
-			break;
-		}
-	}
-
-	*resultCount = index - iterator->markerPosition;
-	iterator->markerPosition = index;
-
-	return Ok;
+	return status;
 }
 
 GpStatus
@@ -234,7 +202,7 @@ GdipPathIterNextMarker (GpPathIterator *iterator, int *resultCount, int *startIn
 
 	/* There are no markers or we are done with all the markers */
 	if (!iterator->path || (iterator->path->count == 0) ||
-	    (iterator->markerPosition == iterator->path->count)) {
+	    (iterator->markerPosition >= iterator->path->count)) {
 		/* we don't touch startIndex and endIndex in this case */
 		*resultCount = 0;
 		return Ok;
@@ -242,7 +210,7 @@ GdipPathIterNextMarker (GpPathIterator *iterator, int *resultCount, int *startIn
 	
 	/* Check for next marker */
 	for (index = iterator->markerPosition; index < iterator->path->count; index++) {
-		type = g_array_index (iterator->path->types, BYTE, index);
+		type = iterator->path->types[index];
 		if (type & PathPointTypePathMarker) {
 			index++;
 			break;
@@ -277,13 +245,13 @@ GdipPathIterNextPathType (GpPathIterator *iterator, int *resultCount, BYTE *path
 
 	/* Pathtype position lags behind subpath position */
 	else if (iterator->pathTypePosition < iterator->subpathPosition) {
-		lastTypeSeen = g_array_index (iterator->path->types, BYTE, iterator->pathTypePosition + 1);
+		lastTypeSeen = iterator->path->types[iterator->pathTypePosition + 1];
 		/* Mask the flags */
 		lastTypeSeen &= PathPointTypePathTypeMask;
 
 		/* Check for the change in type */
 		for (index = iterator->pathTypePosition + 2; index < iterator->subpathPosition; index++) {
-			currentType = g_array_index (iterator->path->types, BYTE, index);
+			currentType = iterator->path->types[index];
 			currentType &= PathPointTypePathTypeMask;
 
 			if (currentType != lastTypeSeen)
@@ -316,65 +284,19 @@ GdipPathIterNextPathType (GpPathIterator *iterator, int *resultCount, BYTE *path
 GpStatus
 GdipPathIterNextSubpathPath (GpPathIterator *iterator, int *resultCount, GpPath *path, BOOL *isClosed)
 {
-	int index = 0;
-	GpPointF point;
-	BYTE currentType;
+	int start, end;
+	GpStatus status;
 
-	if (!iterator || !resultCount || !isClosed)
-		return InvalidParameter;
-
-	/* There are no subpaths or we are done with all the subpaths */
-	if (!path || !iterator->path || (iterator->path->count == 0) || 
-	    (iterator->subpathPosition == iterator->path->count)) {
-		*resultCount = 0;
-		*isClosed = TRUE;
-		return Ok;
+	status = GdipPathIterNextSubpath (iterator, resultCount, &start, &end, isClosed);
+	if (status == Ok && *resultCount > 0) {
+		GdipResetPath (path);
+		gdip_path_ensure_size (path, *resultCount);
+		memcpy (path->types, iterator->path->types + start, sizeof (BYTE) * *resultCount);
+		memcpy (path->points, iterator->path->points + start, sizeof (GpPointF) * *resultCount);
+		path->count = *resultCount;
 	}
 
-	/* Clear the existing values from path */
-	if (path->count > 0) {
-		g_array_free (path->points, TRUE);
-		g_byte_array_free (path->types, TRUE);
-
-		path->points = g_array_new (FALSE, FALSE, sizeof (GpPointF));
-		path->types = g_byte_array_new ();
-		path->count = 0;
-	}
-
-	/* Copy the starting point */
-	currentType = g_array_index (iterator->path->types, BYTE, iterator->subpathPosition);
-	point = g_array_index (iterator->path->points, GpPointF, iterator->subpathPosition);
-	g_array_append_val (path->points, point);
-	g_byte_array_append (path->types, &currentType, 1);
-	path->count++;
-
-	/* Check for next start point */
-	for (index = iterator->subpathPosition + 1; index < iterator->path->count; index++) {
-		currentType = g_array_index (iterator->path->types, BYTE, index);
-
-		/* Copy the start point till next start point */
-		if (currentType == PathPointTypeStart)
-			break;
-
-		point = g_array_index (iterator->path->points, GpPointF, index);
-		g_array_append_val (path->points, point);
-		g_byte_array_append (path->types, &currentType, 1);
-		path->count++;
-	}
-
-	*resultCount = index - iterator->subpathPosition;
-	/* set positions for next iteration */
-	iterator->pathTypePosition = iterator->subpathPosition;
-	iterator->subpathPosition = index;
-
-	/* Check if last subpath was closed */
-	currentType = g_array_index (iterator->path->types, BYTE, index - 1);
-	if (currentType & PathPointTypeCloseSubpath)
-		*isClosed = TRUE;
-	else
-		*isClosed = FALSE;
-
-	return Ok;
+	return status;
 }
 
 GpStatus
@@ -397,7 +319,7 @@ GdipPathIterNextSubpath (GpPathIterator *iterator, int *resultCount, int *startI
 
 	/* Check for next start point */
 	for (index = iterator->subpathPosition + 1; index < iterator->path->count; index++) {
-		currentType = g_array_index (iterator->path->types, BYTE, index);
+		currentType = iterator->path->types[index];
 		if (currentType == PathPointTypeStart)
 			break;
 	}
@@ -410,7 +332,7 @@ GdipPathIterNextSubpath (GpPathIterator *iterator, int *resultCount, int *startI
 	iterator->subpathPosition = index;
 
 	/* check if last subpath was closed */
-	currentType = g_array_index (iterator->path->types, BYTE, index - 1);
+	currentType = iterator->path->types[index - 1];
 	if (currentType & PathPointTypeCloseSubpath)
 		*isClosed = TRUE;
 	else

--- a/src/pathgradientbrush.c
+++ b/src/pathgradientbrush.c
@@ -479,12 +479,12 @@ GdipCreatePathGradient (GDIPCONST GpPointF *points, INT count, GpWrapMode wrapMo
 	gp->centerColor = MAKE_ARGB_ARGB(255,0,0,0); /* black center color */
     
 	/* set the bounding rectangle */
-	point = g_array_index (gp->boundary->points, GpPointF, 0);
+	point = gp->boundary->points[0];
 	/* set the first point as the edge of the rectangle */
 	gp->rectangle.X = point.X;
 	gp->rectangle.Y = point.Y;
 	for (i = 1; i < gp->boundary->count; i++) {
-		point = g_array_index (gp->boundary->points, GpPointF, i);
+		point = gp->boundary->points[i];
 		gdip_rect_expand_by (&gp->rectangle, &point);
 	}
 

--- a/src/region-bitmap.c
+++ b/src/region-bitmap.c
@@ -22,6 +22,7 @@
 
 #include "region-private.h"
 #include "graphics-path-private.h"
+#include "graphics-cairo-private.h"
 
 // #define DEBUG_REGION
 
@@ -489,8 +490,8 @@ gdip_region_bitmap_from_path (GpPath *path)
 
 	idx = 0;
 	for (i = 0; i < length; ++i) {
-		GpPointF pt = g_array_index (path->points, GpPointF, i);
-		BYTE type = g_array_index (path->types, BYTE, i);
+		GpPointF pt = path->points[i];
+		BYTE type = path->types[i];
 		GpPointF pts [3];
 		/* mask the bits so that we get only the type value not the other flags */
 		switch (type & PathPointTypePathTypeMask) {

--- a/src/region-path-tree.c
+++ b/src/region-path-tree.c
@@ -240,13 +240,13 @@ gdip_region_serialize_tree (GpPathTree *tree, BYTE *buffer, UINT bufferSize, UIN
 		buffer += len;
 		*sizeFilled += len;
 		/* types */
-		len = tree->path->types->len;
-		memcpy (buffer, tree->path->types->data, len);
-		buffer += tree->path->types->len;
+		len = tree->path->count;
+		memcpy (buffer, tree->path->types, len);
+		buffer += len;
 		*sizeFilled += len;
 		/* points */
-		len = tree->path->points->len * sizeof (GpPointF);
-		memcpy (buffer, tree->path->points->data, len);
+		len = tree->path->count * sizeof (GpPointF);
+		memcpy (buffer, tree->path->points, len);
 		buffer += len;
 		*sizeFilled += len;
 	} else {
@@ -319,7 +319,7 @@ gdip_region_translate_tree (GpPathTree *tree, float dx, float dy)
 	if (tree->path) {
 		int i;
 		for (i = 0; i < tree->path->count; i++) {
-			GpPointF *point = &g_array_index (tree->path->points, GpPointF, i);
+			GpPointF *point = tree->path->points + i;
 			point->X += dx;
 			point->Y += dy;
 		}

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -17,6 +17,7 @@ testgeneral
 testgifcodec
 testgpimage
 testgraphics
+testgraphicspath
 testgdi
 testhatchbrush
 testicocodec

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,7 +17,7 @@ LDADDS =					\
 	-lm
 
 noinst_PROGRAMS =			\
-	testadjustablearrowcap testbitmap testbits testbmpcodec testbrush testclip testcodecs testcustomlinecap testemfcodec testfont testgeneral testgifcodec testgpimage testgraphics testhatchbrush testicocodec testimageattributes testjpegcodec testlineargradientbrush testmatrix testmetafile testpathgradientbrush testpen testpng testpngcodec testregion testreversepath testsolidbrush teststringformat testtext testtexturebrush testtiffcodec testwmfcodec
+	testadjustablearrowcap testbitmap testbits testbmpcodec testbrush testclip testcodecs testcustomlinecap testemfcodec testfont testgeneral testgifcodec testgpimage testgraphics testgraphicspath testhatchbrush testicocodec testimageattributes testjpegcodec testlineargradientbrush testmatrix testmetafile testpathgradientbrush testpen testpng testpngcodec testregion testreversepath testsolidbrush teststringformat testtext testtexturebrush testtiffcodec testwmfcodec
 
 if HAS_X11
 noinst_PROGRAMS += testgdi
@@ -112,6 +112,12 @@ testgraphics_SOURCES =		\
 
 testgraphics_DEPENDENCIES = $(TEST_DEPS)
 testgraphics_LDADD = $(LDADDS)
+
+testgraphicspath_SOURCES =		\
+	testgraphicspath.c
+
+testgraphicspath_DEPENDENCIES = $(TEST_DEPS)
+testgraphicspath_LDADD = $(LDADDS)
 
 testhatchbrush_SOURCES =		\
 	testhatchbrush.c
@@ -243,6 +249,7 @@ EXTRA_DIST =			\
 	$(testgifcodec_SOURCES) \
 	$(testgpimage_SOURCES) \
 	$(testgraphics_SOURCES)	\
+	$(testgraphicspath_SOURCES) \
 	$(testhatchbrush_SOURCES)	\
 	$(testicocodec_SOURCES) \
 	$(testimageattributes_SOURCES) \
@@ -278,6 +285,7 @@ TESTS = \
 	testgeneral \
 	testgpimage \
 	testgraphics \
+	testgraphicspath \
 	testhatchbrush \
 	testicocodec \
 	testimageattributes \

--- a/tests/testgraphicspath.c
+++ b/tests/testgraphicspath.c
@@ -65,12 +65,10 @@ static void test_createPath ()
 int
 main (int argc, char**argv)
 {
-  GdiplusStartupInput gdiplusStartupInput;
-  ULONG_PTR gdiplusToken;
-  GdiplusStartup (&gdiplusToken, &gdiplusStartupInput, NULL);
+	STARTUP;
 
   test_createPath ();
 
-  GdiplusShutdown (gdiplusToken);
+  SHUTDOWN;
   return 0;
 }

--- a/tests/testgraphicspath.c
+++ b/tests/testgraphicspath.c
@@ -1,0 +1,76 @@
+#ifdef _WIN32
+#ifndef __cplusplus
+#error Please compile with a C++ compiler.
+#endif
+#endif
+
+#if defined(USE_WINDOWS_GDIPLUS)
+#include <Windows.h>
+#include <GdiPlus.h>
+
+#pragma comment(lib, "gdiplus.lib")
+#else
+#include <GdiPlusFlat.h>
+#endif
+
+#if defined(USE_WINDOWS_GDIPLUS)
+using namespace Gdiplus;
+using namespace DllExports;
+#endif
+
+#include <assert.h>
+#include "testhelpers.h"
+
+#define verifyPath(path, expectedFillMode) \
+{ \
+  GpStatus status; \
+  FillMode fillMode; \
+ \
+  status = GdipGetPathFillMode (path, &fillMode); \
+  assertEqualInt (status, Ok); \
+  assertEqualInt (fillMode, expectedFillMode); \
+}
+
+static void test_createPath ()
+{
+	GpStatus status;
+  GpPath *path;
+
+  // FillModeAlternate.
+  status = GdipCreatePath (FillModeAlternate, &path);
+  assertEqualInt (status, Ok);
+  verifyPath (path, FillModeAlternate);
+
+  GdipDeletePath (path);
+
+  // FillModeWinding.
+  status = GdipCreatePath (FillModeWinding, &path);
+  assertEqualInt (status, Ok);
+  verifyPath (path, FillModeWinding);
+
+  GdipDeletePath (path);
+
+  // Invalid FillMode.
+  status = GdipCreatePath ((FillMode)(FillModeWinding + 1), &path);
+  assertEqualInt (status, Ok);
+  verifyPath (path, (FillMode)(FillModeWinding + 1));
+
+  GdipDeletePath (path);
+
+  // Negative tests.
+  status = GdipCreatePath (FillModeWinding, NULL);
+  assertEqualInt (status, InvalidParameter);
+}
+
+int
+main (int argc, char**argv)
+{
+  GdiplusStartupInput gdiplusStartupInput;
+  ULONG_PTR gdiplusToken;
+  GdiplusStartup (&gdiplusToken, &gdiplusStartupInput, NULL);
+
+  test_createPath ();
+
+  GdiplusShutdown (gdiplusToken);
+  return 0;
+}


### PR DESCRIPTION
* Fixes issues #223, #224 and #225.
* Introduces out of memory checks for the path APIs.
* Optimises lot of the APIs to prevent unnecessary allocations, frees and copying. 