### PR TITLE
Implement gdip_get_display_dpi on Windows using older Win32 API.

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -25,7 +25,7 @@
  */
 
 #ifdef WIN32
-#include "win32_io.h"
+#include "win32-private.h"
 #endif
 
 #include <cairo-features.h>

--- a/src/general.c
+++ b/src/general.c
@@ -31,14 +31,12 @@
 #include "graphics-private.h"
 #include "font-private.h"
 #include "carbon-private.h"
+#ifdef WIN32
+#include "win32-private.h"
+#endif
 
 /* large table to avoid a division and three multiplications when premultiplying alpha into R, G and B */
 #include "alpha-premul-table.inc"
-
-#ifdef WIN32
-// For GetDpiForMonitor.
-#include "ShellScalingAPI.h"
-#endif
 
 static BOOL startup = FALSE;
 static BOOL suppressBackgroundThread = FALSE;
@@ -202,17 +200,7 @@ gdip_get_display_dpi ()
 			dpis = 96.0f;
 		}
 #elif WIN32
-		UINT dpiX, dpiY;
-		HMONITOR monitor;
-		HRESULT res;
-
-		/* Read the dpi from the main monitor, or use a a default of 96.0f. */
-		monitor = MonitorFromWindow (NULL, MONITOR_DEFAULTTOPRIMARY);
-		res = GetDpiForMonitor (monitor, MDT_DEFAULT, &dpiX, &dpiY);
-		if (res == S_OK)
-			dpis = dpiX;
-		else
-			dpis = 96.0f;
+		dpis = gdip_get_display_dpi_win32 ();
 #else
 		dpis = 96.0f;
 #endif

--- a/src/win32-private.c
+++ b/src/win32-private.c
@@ -20,7 +20,7 @@
 *	Frederik Carlier <frederik.carlier@quamotion.mobi>
 */
 
-#include "win32_io.h"
+#include "win32-private.h"
 
 #include <windows.h>
 #include "gdipenums.h"
@@ -41,4 +41,14 @@ FILE *CreateTempFile (char *filename)
 	}
 
 	return fopen (filename, "w");
+}
+
+int gdip_get_display_dpi_win32 ()
+{
+	int dpis;
+	HDC dc;
+	dc = GetDC (0);
+	dpis = GetDeviceCaps (dc, LOGPIXELSX);
+	ReleaseDC (0, dc);
+	return dpis;
 }

--- a/src/win32-private.h
+++ b/src/win32-private.h
@@ -25,3 +25,5 @@
 // Creates a temporary file. Saves the value of the temporary file in filename,
 // and returns a handle to the temp file.
 FILE *CreateTempFile (char *filename);
+
+int gdip_get_display_dpi_win32 ();


### PR DESCRIPTION
A more sensible version of https://github.com/mono/libgdiplus/pull/228.