### PR TITLE
Transform path in GdipSetClipPath by clip_matrix if necessary.

### DIFF
--- a/src/region-bitmap.c
+++ b/src/region-bitmap.c
@@ -615,21 +615,29 @@ gdip_region_bitmap_get_smallest_rect (GpRegionBitmap *bitmap, GpRect *rect)
 	int last_x = -1;			/* empty (right) columns */
 	int i = 0;
 	int original_size = SHAPE_SIZE(bitmap);
-	int old_width_byte = bitmap->Width >> 3;
 	int x = 0, y = 0;
+	int k;
 
 	while (i < original_size) {
-		if (bitmap->Mask [i++] != 0) {
-			if (x < first_x)
-				first_x = x;
-			if (x > last_x)
-				last_x = x;
-			if (y < first_y)
-				first_y = y;
-			if (y > last_y)
-				last_y = y;
+		if (bitmap->Mask [i] != 0) {
+			for (k = 0; k < 8; k++) {
+				if ((bitmap->Mask [i] & (1 << k)) != 0) {
+					if (x < first_x)
+						first_x = x;
+					if (x > last_x)
+						last_x = x;
+					if (y < first_y)
+						first_y = y;
+					if (y > last_y)
+						last_y = y;				
+				}
+				x++;
+			}
+		} else {
+			x += 8;
 		}
-		if (++x == old_width_byte) {
+		i++;		
+		if (x == bitmap->Width) {
 			x = 0;
 			y++;
 		}
@@ -640,9 +648,9 @@ gdip_region_bitmap_get_smallest_rect (GpRegionBitmap *bitmap, GpRect *rect)
 		rect->X = rect->Y = rect->Width = rect->Height = 0;
 	} else {
 		// convert to pixel values
-		rect->X = bitmap->X + (first_x << 3);
+		rect->X = bitmap->X + first_x;
 		rect->Y = bitmap->Y + first_y;
-		rect->Width = abs (((last_x + 1) << 3) - first_x);
+		rect->Width = last_x - first_x + 1;
 		rect->Height = last_y - first_y + 1;
 	}
 }

--- a/tests/testclip.c
+++ b/tests/testclip.c
@@ -144,6 +144,61 @@ test_gdip_clip()
 	GdipFree (scan0);
 }
 
+static void
+test_gdip_clip_transform()
+{
+	GpBitmap *bitmap = 0;
+	GpGraphics *graphics;
+	GpRegion *clip;
+	GpPath *path;
+	GpRectF bounds;
+	static const int width = 100;
+	static const int height = 100;
+	BYTE *scan0 = (BYTE*) GdipAlloc (width * height * 4);
+	BOOL is_infinite = 0;
+
+	C (GdipCreateBitmapFromScan0 (100, 100, 100 * 4, PixelFormat32bppARGB, scan0, &bitmap));
+	C (GdipGetImageGraphicsContext (bitmap, &graphics));
+
+	// Check the clipping region is infinite
+	C (GdipCreateRegion(&clip));
+	C (GdipGetClip(graphics, clip));
+	C (GdipIsInfiniteRegion(clip, graphics, &is_infinite));
+	assert (is_infinite);
+
+	// Transform the world
+	C (GdipTranslateWorldTransform(graphics, 50.f, 0.f, MatrixOrderAppend));
+
+	// Test setting clip as rectangle
+	C (GdipSetClipRect(graphics, 10, 10, 60, 60, CombineModeReplace));
+	C (GdipGetClipBounds(graphics, &bounds));
+	assert (bounds.X == 10);
+	assert (bounds.Y == 10);
+	assert (bounds.Width == 60);
+	assert (bounds.Height == 60);
+
+	// Test setting clip as path with rectangle
+	C (GdipCreatePath(FillModeWinding, &path));
+	C (GdipAddPathRectangle(path, 10, 10, 60, 60));
+	C (GdipGetPathWorldBounds(path, &bounds, NULL, NULL));
+	assert (bounds.X == 10);
+	assert (bounds.Y == 10);
+	assert (bounds.Width == 60);
+	assert (bounds.Height == 60);
+	C (GdipSetClipPath(graphics, path, CombineModeReplace));
+	C (GdipGetClipBounds(graphics, &bounds));
+	assert (bounds.X == 10);
+	assert (bounds.Y == 10);
+	assert (bounds.Width == 60);
+	assert (bounds.Height == 60);
+
+	C (GdipDeleteRegion (clip));
+	C (GdipDeleteGraphics (graphics));
+	C (GdipDisposeImage (bitmap));
+
+	GdipFree (scan0);
+}
+
 int
 main(int argc, char**argv)
 {
@@ -152,6 +207,7 @@ main(int argc, char**argv)
 	GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
 
 	test_gdip_clip();
+	test_gdip_clip_transform();
 
 	GdiplusShutdown(gdiplusToken);
 	return 0;


### PR DESCRIPTION
- Possible fix for https://github.com/dotnet/corefx/issues/27320.
- Needs unit tests.
- The metafile code doesn't make sense, I am aware of that. It is copied from `GdipSetClipRegion` and the `metafile_SetClip*` functions are not implemented anyway.