### PR TITLE
Fix font behaviour on Windows

### DIFF
--- a/src/win32-private.c
+++ b/src/win32-private.c
@@ -40,7 +40,7 @@ FILE *CreateTempFile (char *filename)
 		return NULL;
 	}
 
-	return fopen (filename, "w");
+	return fopen (filename, "wb");
 }
 
 int gdip_get_display_dpi_win32 ()

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -52,7 +52,7 @@ void verifyMatrix (GpMatrix *matrix, REAL e1, REAL e2, REAL e3, REAL e4, REAL e5
     }
 }
 
-#if !defined(_WIN32)
+#if !defined(USE_WINDOWS_GDIPLUS)
 #define createWchar(c) g_utf8_to_utf16 (c, -1, NULL, NULL, NULL);
 #define freeWchar(c) g_free(c)
 #define wcharFromChar(c) createWchar(c)


### PR DESCRIPTION
- Font files are binary so don't corrupt them in fopen
- The type of WCHAR * is guint32, not wchar_t on Windows libgdiplus.