### PR TITLE
Fix DrawString alignment with pango text rendering.

### DIFF
--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -1231,21 +1231,24 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 		return status;
 	}
 
-	if (layoutRect)
-		cairo_move_to (cr, layoutRect->X, layoutRect->Y + font->sizeInPixels);
-
 #ifdef USE_PANGO_RENDERING
 	{
 	GpRectF box;
+	GpPointF box_offset;
 	PangoLayout* layout; 
 
 	cairo_save (cr);
-	layout = gdip_pango_setup_layout ((GpGraphics *)cr, string, length, font, layoutRect, &box, format, NULL);
+	layout = gdip_pango_setup_layout ((GpGraphics *)cr, string, length, font, layoutRect, &box, &box_offset, format, NULL);
+	if (layoutRect)
+		cairo_move_to (cr, layoutRect->X + box_offset.X, layoutRect->Y + box_offset.X);
 	pango_cairo_layout_path (cr, layout);
 	g_object_unref (layout);
 	cairo_restore (cr);
 	}
 #else
+	if (layoutRect)
+		cairo_move_to (cr, layoutRect->X, layoutRect->Y + font->sizeInPixels);
+
 	cairo_set_font_face (cr, gdip_get_cairo_font_face (font));
 	cairo_set_font_size (cr, font->sizeInPixels);
 	/* TODO - deal with layoutRect, format... ideally we would be calling a subset

--- a/src/text-pango-private.h
+++ b/src/text-pango-private.h
@@ -47,7 +47,7 @@
 
 
 PangoLayout* gdip_pango_setup_layout (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, int length, GDIPCONST GpFont *font,
-	GDIPCONST RectF *rc, RectF *box, GDIPCONST GpStringFormat *format, int **charsRemoved);
+	GDIPCONST RectF *rc, RectF *box, PointF *box_offset, GDIPCONST GpStringFormat *format, int **charsRemoved);
 
 GpStatus pango_DrawString (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, int length, GDIPCONST GpFont *font,
 	GDIPCONST RectF *rc, GDIPCONST GpStringFormat *format, GpBrush *brush) GDIP_INTERNAL;


### PR DESCRIPTION
There are two code path where we need to do some custom text alignment outside of the `pango_layout_*` functions:

- Line alignment (vertical alignment when the text is rendered in horizontal direction)
- Alignment in conjunction with no-wrap flag, which is not directly supported by Pango

In both cases it is necessary to add the computed alignment offset before doing the actual rendering with `pango_cairo_show_layout`. This wasn't done before, so DrawString effectively ignored StringFormat->LineAlignment.
