### PR TITLE
Don't listen to PS_JOIN_MASK in createPen

### DIFF
--- a/src/metafile.c
+++ b/src/metafile.c
@@ -495,23 +495,6 @@ gdip_metafile_CreatePenIndirect (MetafilePlayContext *context, DWORD style, DWOR
 	GdipSetPenStartCap (pen, line_cap);
 	GdipSetPenEndCap (pen, line_cap);
 
-	s = (style & PS_JOIN_MASK);
-	switch (s) {
-	default:
-		g_warning ("Invalid pen join, style %d, (style & PS_JOIN_MASK) %d", style, s);
-		/* fall through */
-	case PS_JOIN_ROUND:
-		line_join = LineJoinRound;
-		break;
-	case PS_JOIN_BEVEL:
-		line_join = LineJoinBevel;
-		break;
-	case PS_JOIN_MITER:
-		line_join = LineJoinMiter;
-		break;
-	}
-	GdipSetPenLineJoin (pen, line_join);
-
 	context->created.type = METAOBJECT_TYPE_PEN;
 	context->created.ptr = pen;
 	return Ok;


### PR DESCRIPTION
Example bytes: 

```cpp

	BYTE rectangleWithCustomBrush[] = {
		/* -- Placeable Header -- */
		/* Key */          0xD7, 0xCD, 0xC6, 0x9A,
		/* Hmf */          0x00, 0x00,
		/* Bounding Box */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x0F,
		/* Inch */         0xA0, 0x05,
		/* Reserved */     0x00, 0x00, 0x00, 0x00,
		/* Checksum */     0xB1, 0x52,

		/* -- Metafile Header -- */ 
		/* File Type */       0x01, 0x00,
		/* Header Size */     0x09, 0x00,
		/* Version */         0x00, 0x03,
		/* Total Size */      0x09 + 0x08 + 0x04 + 0x07 + 0x04 + 0x07 + 0x03, 0x00, 0x00, 0x00,
		/* Number Objects */  0x02, 0x00,
		/* Max Record Size */ 0x08, 0x00, 0x00, 0x00,
		/* No Parameters */   0x00, 0x00,

		/* -- META_CREATEPENINDIRECT -- */
		/* Size */      0x08, 0x00, 0x00, 0x00,
		/* Function */  0xFA, 0x02,
		/* Pen Style */ 0x00, 0x00,
		/* Width */     0x3F, 0x00, 0x00, 0x00,
		/* ColorRef */  0x00, 0x00, 0xFF, 0x00,

		/* -- META_SELECTOBJECT -- */
		/* Size */         0x04, 0x00, 0x00, 0x00,
		/* Function */     0x2D, 0x01,
		/* Object Index */ 0x00, 0x00,

		/* -- META_CREATEBRUSHINDIRECT -- */
		/* Size */       0x07, 0x00, 0x00, 0x00,
		/* Function */   0xFC, 0x02,
		/* BrushStyle */ 0x02, 0x00,
		/* ColorRef */   0x00, 0xFF, 0x00, 0xFF,
		/* HatchStyle */ 0x04, 0x00,

		/* -- META_SELECTOBJECT -- */
		/* Size */         0x04, 0x00, 0x00, 0x00,
		/* Function */     0x2D, 0x01,
		/* Object Index */ 0x01, 0x00,

		/* -- META_RECTANGLE -- */
		/* Size */       0x07, 0x00, 0x00, 0x00,
		/* Function */   0x1B, 0x04,
		/* BottomRect */ 0x00, 0x08,
		/* RightRect */  0x00, 0x07,
		/* TopRect */    0x00, 0x03,
		/* LeftRect */   0x00, 0x02,
    
		/* -- META_EOF -- */
		/* Size */     0x03, 0x00, 0x00, 0x00,
		/* Function */ 0x00, 0x00
	};
```

Before:
![libgdiplus](https://user-images.githubusercontent.com/1275900/38079210-40d61292-3336-11e8-8670-0935e22490b3.png)

After:
![gdiplus](https://user-images.githubusercontent.com/1275900/38079245-57d3057c-3336-11e8-8631-69fea11a0129.png)
