### PR TITLE
Use our own pango font maps to support custom fonts and use FontConfig backend on macOS by default

### DIFF
--- a/src/font-private.h
+++ b/src/font-private.h
@@ -39,6 +39,7 @@
 
 #ifdef USE_PANGO_RENDERING
 	#include <pango/pangofc-font.h>
+	#include <pango/pangofc-fontmap.h>
 	#include <pango/pangocairo.h>
 #endif
 
@@ -58,6 +59,7 @@ struct _Font {
 };
 
 void gdip_font_clear_pattern_cache (void) GDIP_INTERNAL;
+void gdip_delete_system_fonts (void) GDIP_INTERNAL;
 
 #ifdef USE_PANGO_RENDERING
 

--- a/src/font.c
+++ b/src/font.c
@@ -74,6 +74,12 @@ gdip_fontfamily_new ()
 
 static GpFontCollection *system_fonts = NULL;
 
+void
+gdip_delete_system_fonts (void)
+{
+	GdipDeletePrivateFontCollection(&system_fonts);
+}
+
 // coverity[+alloc : arg-*0]
 GpStatus WINGDIPAPI
 GdipNewInstalledFontCollection (GpFontCollection **font_collection)
@@ -108,6 +114,10 @@ GdipNewInstalledFontCollection (GpFontCollection **font_collection)
 
 		system_fonts->fontset = col;
 		system_fonts->config = NULL;
+
+#if USE_PANGO_RENDERING
+		system_fonts->pango_font_map = pango_cairo_font_map_new_for_font_type (CAIRO_FONT_TYPE_FT);
+#endif
 	}
 
 	*font_collection = system_fonts;
@@ -130,6 +140,11 @@ GdipNewPrivateFontCollection (GpFontCollection **font_collection)
 	result->fontset = NULL;
 	result->config = FcConfigCreate ();
 
+#if USE_PANGO_RENDERING
+	result->pango_font_map = pango_cairo_font_map_new_for_font_type (CAIRO_FONT_TYPE_FT);
+	pango_fc_font_map_set_config ((PangoFcFontMap *)result->pango_font_map, result->config);
+#endif
+
 	*font_collection = result;
 	return Ok;
 }
@@ -142,6 +157,12 @@ GdipDeletePrivateFontCollection (GpFontCollection **font_collection)
 		return InvalidParameter;
 
 	if (*font_collection) {
+#if USE_PANGO_RENDERING
+		if ((*font_collection)->pango_font_map != NULL) {
+			g_object_unref ((*font_collection)->pango_font_map);
+			(*font_collection)->pango_font_map = NULL;
+		}
+#endif
 		if ((*font_collection)->fontset != NULL) {
 			FcFontSetDestroy ((*font_collection)->fontset);
 			(*font_collection)->fontset = NULL;
@@ -195,6 +216,7 @@ GdipCloneFontFamily (GpFontFamily *fontFamily, GpFontFamily **clonedFontFamily)
 	if (!result)
 		return OutOfMemory;
 
+	result->collection = fontFamily->collection;
 	result->height = fontFamily->height;
 	result->linespacing = fontFamily->linespacing;
 	result->celldescent = fontFamily->celldescent;
@@ -392,9 +414,16 @@ static GHashTable *patterns_hashtable = NULL;
 static GpStatus
 create_fontfamily_from_name (char* name, GpFontFamily **fontFamily)
 {
-	GpStatus status = FontFamilyNotFound;
+	GpStatus status;
 	GpFontFamily *ff = NULL;
 	FcPattern *pat = NULL;
+	GpFontCollection *font_collection;
+
+	status = GdipNewInstalledFontCollection (&font_collection);
+	if (status != Ok) {
+		return status;
+	}
+	status = FontFamilyNotFound;
 
 #if GLIB_CHECK_VERSION(2,32,0)
 	g_mutex_lock (&patterns_mutex);
@@ -421,6 +450,7 @@ create_fontfamily_from_name (char* name, GpFontFamily **fontFamily)
 		if (ff) {
 			ff->pattern = pat;
 			ff->allocated = FALSE;
+			ff->collection = font_collection;
 			status = Ok;
 		} else 
 			status = OutOfMemory;
@@ -484,6 +514,7 @@ create_fontfamily_from_collection (char* name, GpFontCollection *font_collection
 
 				result->pattern = *gpfam;
 				result->allocated = FALSE;
+				result->collection = font_collection;
 
 				*fontFamily = result;
 				return Ok;
@@ -705,7 +736,8 @@ PangoFontDescription*
 gdip_get_pango_font_description (GpFont *font)
 {
 	if (!font->pango) {
-		font->pango = pango_font_description_from_string ((char*)font->face);
+		font->pango = pango_font_description_new ();
+		pango_font_description_set_family (font->pango, (char *)font->face);
 		pango_font_description_set_size (font->pango, font->emSize * PANGO_SCALE);
 
 		if (font->style & FontStyleBold)
@@ -724,7 +756,7 @@ gdip_get_fontfamily_details (GpFontFamily *family, FontStyle style)
 	GpStatus status = GdipCreateFont (family, 8.0f, style, UnitPoint, &font);
 
 	if ((status == Ok) && font) {
-		PangoFontMap *map = pango_cairo_font_map_get_default (); /* owned by pango */
+		PangoFontMap *map = family->collection->pango_font_map;
 #if PANGO_VERSION_CHECK(1,22,0)
 		PangoContext *context = pango_font_map_create_context (PANGO_FONT_MAP (map));
 #else
@@ -735,12 +767,12 @@ gdip_get_fontfamily_details (GpFontFamily *family, FontStyle style)
 		FT_Face face = pango_fc_font_lock_face ((PangoFcFont*)pf);
 		if (face) {
 			gdip_get_fontfamily_details_from_freetype (family, face);
-
 			pango_fc_font_unlock_face ((PangoFcFont*)pf);
 		} else {
 			status = FontFamilyNotFound;
 		}
 
+		g_object_unref (pf);
 		g_object_unref (context);
 	}
 

--- a/src/fontcollection-private.h
+++ b/src/fontcollection-private.h
@@ -40,6 +40,9 @@
 struct _FontCollection {
 	FcFontSet*	fontset;
 	FcConfig*	config;		/* Only for private collections */
+#ifdef USE_PANGO_RENDERING
+	PangoFontMap*	pango_font_map;
+#endif
 };
 
 #include "fontcollection.h"

--- a/src/fontfamily-private.h
+++ b/src/fontfamily-private.h
@@ -38,7 +38,8 @@
 #include "gdiplus-private.h"
 
 struct _FontFamily {
-        FcPattern*	pattern;
+	struct _FontCollection *collection;
+	FcPattern*	pattern;
 	BOOL		allocated;
 	short 		height;
 	short 		linespacing;

--- a/src/general.c
+++ b/src/general.c
@@ -82,6 +82,7 @@ WINGDIPAPI GdiplusShutdown (ULONG_PTR token)
 	if (startup) {
 		releaseCodecList ();
 		gdip_font_clear_pattern_cache ();
+		gdip_delete_system_fonts ();
 #if HAVE_FCFINI
 		FcFini ();
 #endif

--- a/src/text-pango.c
+++ b/src/text-pango.c
@@ -29,6 +29,8 @@
 #include "graphics-cairo-private.h"
 #include "brush-private.h"
 #include "font-private.h"
+#include "fontfamily-private.h"
+#include "fontcollection-private.h"
 
 int
 utf8_length_for_ucs2_string (GDIPCONST WCHAR *stringUnicode, int offset, int length)
@@ -220,10 +222,11 @@ gdip_pango_setup_layout (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, i
 		fmt = (GpStringFormat *)format;
 	}
 
-	layout = pango_cairo_create_layout (graphics->ct);
+	context = pango_font_map_create_context (font->family->collection->pango_font_map);
+	pango_cairo_update_context (graphics->ct, context);
 
-	/* context is owned by Pango (i.e. not referenced counted) do not free */
-	context = pango_layout_get_context (layout);
+	layout = pango_layout_new (context);
+	g_object_unref (context);
 
 	pango_layout_set_font_description (layout, gdip_get_pango_font_description ((GpFont*) font));
 


### PR DESCRIPTION
Fixes issue #237.

Pango has three backends - CoreText, Win32 and FontConfig. By default it tries to select the one that is most appropriate for the platform. However the current libgdiplus code depends on FontConfig and FreeType directly, so we need to force the use of FontConfig backend. Additionally it fixes an issue with custom fonts, which use custom FcConfig objects that were not properly propagated to Pango. Lastly, it fixes a memory leak in gdip_get_fontfamily_details.