### PR TITLE
Override inc language classification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 *.sh	crlf=input
-
+*.inc	linguist-language=C


### PR DESCRIPTION
`alpha-premul-table.inc` is classified as PHP, that amounts to 13.4% of the code:

![image](https://user-images.githubusercontent.com/33230602/38056427-12c3094c-32e5-11e8-89db-0684b5608859.png)

With this override, linguist will classify the inc file as C.

Related issue https://github.com/github/linguist/issues/4082.