### PR TITLE
Add initial tests for GdipMeasureString and fix Pango text backend to pass them

### DIFF
--- a/src/text-pango.c
+++ b/src/text-pango.c
@@ -486,7 +486,7 @@ gdip_pango_setup_layout (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, i
 	case StringAlignmentNear:
 		break;
 	case StringAlignmentCenter:
-		box_offset->Y += (FrameHeight - box->Height) * .5;
+		box_offset->Y += (FrameHeight - box->Height) * 0.5;
 		break;
 	case StringAlignmentFar:
 		box_offset->Y += (FrameHeight - box->Height);
@@ -500,7 +500,7 @@ gdip_pango_setup_layout (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, i
 				box_offset->X += (FrameWidth - box->Width);
 			break;
 		case StringAlignmentCenter:
-			box_offset->X += (FrameWidth - box->Width) * .5;
+			box_offset->X += (FrameWidth - box->Width) * 0.5;
 			break;
 		case StringAlignmentFar:
 			if (!(fmt->formatFlags & StringFormatFlagsDirectionRightToLeft))

--- a/src/text-pango.c
+++ b/src/text-pango.c
@@ -264,7 +264,7 @@ gdip_pango_setup_layout (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, i
 
 	/* with GDI+ the API not the renderer makes the direction decision */
 	pango_layout_set_auto_dir (layout, FALSE);	
-	if (!(fmt->formatFlags & StringFormatFlagsDirectionRightToLeft) != !(fmt->formatFlags & StringFormatFlagsDirectionVertical)) {
+	if (fmt->formatFlags & StringFormatFlagsDirectionRightToLeft) {
 		pango_context_set_base_dir (context, PANGO_DIRECTION_WEAK_RTL);
 		pango_layout_context_changed (layout);
 
@@ -481,10 +481,10 @@ gdip_pango_setup_layout (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, i
 	case StringAlignmentNear:
 		break;
 	case StringAlignmentCenter:
-		box_offset->Y += (rc->Height - box->Height) / 2;
+		box_offset->Y += (FrameHeight - box->Height) * .5;
 		break;
 	case StringAlignmentFar:
-		box_offset->Y += (rc->Height - box->Height);
+		box_offset->Y += (FrameHeight - box->Height);
 		break;
 	}
 
@@ -492,14 +492,14 @@ gdip_pango_setup_layout (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, i
 		switch (fmt->alignment) {
 		case StringAlignmentNear:
 			if (fmt->formatFlags & StringFormatFlagsDirectionRightToLeft)
-				box_offset->X += (rc->Width - box->Width);
+				box_offset->X += (FrameWidth - box->Width);
 			break;
 		case StringAlignmentCenter:
-			box->X += (rc->Width - box->Width) / 2;
+			box_offset->X += (FrameWidth - box->Width) * .5;
 			break;
 		case StringAlignmentFar:
 			if (!(fmt->formatFlags & StringFormatFlagsDirectionRightToLeft))
-				box_offset->X += (rc->Width - box->Width);
+				box_offset->X += (FrameWidth - box->Width);
 			break;
 		}
 	}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,7 +17,7 @@ LDADDS =					\
 	-lm
 
 noinst_PROGRAMS =			\
-	testadjustablearrowcap testbitmap testbits testbmpcodec testbrush testclip testcustomlinecap testemfcodec testfont testgeneral testgifcodec testgpimage testgraphics testhatchbrush testicocodec testimageattributes testlineargradientbrush testmatrix testmetafile testpathgradientbrush testpen testpng testpngcodec testregion testreversepath testsolidbrush teststringformat testtexturebrush testtiffcodec testwmfcodec
+	testadjustablearrowcap testbitmap testbits testbmpcodec testbrush testclip testcustomlinecap testemfcodec testfont testgeneral testgifcodec testgpimage testgraphics testhatchbrush testicocodec testimageattributes testlineargradientbrush testmatrix testmetafile testpathgradientbrush testpen testpng testpngcodec testregion testreversepath testsolidbrush teststringformat testtext testtexturebrush testtiffcodec testwmfcodec
 
 if HAS_X11
 noinst_PROGRAMS += testgdi
@@ -173,6 +173,12 @@ teststringformat_SOURCES =		\
 teststringformat_DEPENDENCIES = $(TEST_DEPS)
 teststringformat_LDADD = $(LDADDS)
 
+testtext_SOURCES =		\
+	testtext.c
+
+testtext_DEPENDENCIES = $(TEST_DEPS)
+testtext_LDADD = $(LDADDS)
+
 testtexturebrush_SOURCES =		\
 	testtexturebrush.c
 
@@ -239,6 +245,7 @@ EXTRA_DIST =			\
 	$(testsolidbrush_SOURCES)	\
 	$(teststringformat_SOURCES)	\
 	$(testtexturebrush_SOURCES)	\
+	$(testtext_SOURCES)	\
 	$(testtiffcodec_SOURCES) \
 	$(testwmfcodec_SOURCES)
 
@@ -271,6 +278,7 @@ TESTS = \
 	testsolidbrush \
 	teststringformat \
 	testtexturebrush \
+	testtext \
 	testtiffcodec \
 	testwmfcodec \
 	$(NULL)

--- a/tests/testtext.c
+++ b/tests/testtext.c
@@ -82,14 +82,14 @@ static void test_measure_string(void)
 	set_rect_empty (&bounds);
 	status = GdipMeasureString (graphics, teststring1, 3, font, &rect, format, &bounds, &glyphs, &lines);
 	expect (Ok, status);
-	TODO expect (3, glyphs);
+	expect (3, glyphs);
 	expect (2, lines);
 
 	// ...and lastly check the correct results for adding another character past the last new line
 	set_rect_empty (&bounds);
 	status = GdipMeasureString (graphics, teststring1, 4, font, &rect, format, &bounds, &glyphs, &lines);
 	expect (Ok, status);
-	TODO expect (4, glyphs);
+	expect (4, glyphs);
 	expect (3, lines);
 
 	// Attempt to fit 3 glyphs / 2 lines into a bounding box from 2 glyphs / 1 line
@@ -97,7 +97,7 @@ static void test_measure_string(void)
 	set_rect_empty (&bounds);
 	status = GdipMeasureString (graphics, teststring1, 3, font, &rect, format, &bounds, &glyphs, &lines);
 	expect (Ok, status);
-	expect (2, glyphs);
+	TODO expect (2, glyphs);
 	TODO expect (1, lines);
 
 	GdipDeleteGraphics (graphics);

--- a/tests/testtext.c
+++ b/tests/testtext.c
@@ -28,7 +28,6 @@ using namespace DllExports;
 #define expect(expected, got) ok((got) == (expected), "Expected %d, got %d\n", (INT)(expected), (INT)(got))
 #define expectf_(expected, got, precision) ok(fabs((expected) - (got)) <= (precision), "Expected %f, got %f\n", (expected), (got))
 #define expectf(expected, got) expectf_((expected), (got), 0.001)
-#define TODO if (0)
 #define set_rect_empty(r) (r)->X = (r)->Y = (r)->Width = (r)->Height = 0
 
 #ifdef USE_PANGO_RENDERING
@@ -97,8 +96,8 @@ static void test_measure_string(void)
 	set_rect_empty (&bounds);
 	status = GdipMeasureString (graphics, teststring1, 3, font, &rect, format, &bounds, &glyphs, &lines);
 	expect (Ok, status);
-	TODO expect (2, glyphs);
-	TODO expect (1, lines);
+	expect (2, glyphs);
+	expect (1, lines);
 
 	GdipDeleteGraphics (graphics);
 	GdipDeleteFont (font);

--- a/tests/testtext.c
+++ b/tests/testtext.c
@@ -1,0 +1,214 @@
+#ifdef WIN32
+#ifndef __cplusplus
+#error Please compile with a C++ compiler.
+#endif
+#endif
+
+#if defined(USE_WINDOWS_GDIPLUS)
+#include <Windows.h>
+#include <GdiPlus.h>
+
+#pragma comment(lib, "gdiplus")
+#else
+#include <GdiPlusFlat.h>
+#endif
+
+#if defined(USE_WINDOWS_GDIPLUS)
+using namespace Gdiplus;
+using namespace DllExports;
+#endif
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "testhelpers.h"
+#include "../config.h"
+
+#define ok(expected, ...) if (!(expected)) { printf(__VA_ARGS__); assert(expected); }
+#define expect(expected, got) ok((got) == (expected), "Expected %d, got %d\n", (INT)(expected), (INT)(got))
+#define expectf_(expected, got, precision) ok(fabs((expected) - (got)) <= (precision), "Expected %f, got %f\n", (expected), (got))
+#define expectf(expected, got) expectf_((expected), (got), 0.001)
+#define TODO if (0)
+#define set_rect_empty(r) (r)->X = (r)->Y = (r)->Width = (r)->Height = 0
+
+#ifdef USE_PANGO_RENDERING
+
+static void test_measure_string(void)
+{
+	GpStringFormat *format;
+	GpImage *image;
+	GpGraphics *graphics;
+	GpFontFamily *family;
+	GpFont *font;
+	GpStatus status;
+	GpRectF rect, bounds, saved_bounds;
+	const WCHAR teststring1[] = { 'M', '\n', '\n', 'M', 0 };
+	int glyphs;
+	int lines;
+
+	status = GdipCreateStringFormat (0, 0, &format);
+	expect (Ok, status);
+	status = GdipGetGenericFontFamilySansSerif (&family);
+	expect (Ok, status);
+	status = GdipCreateFont (family, 10, FontStyleRegular, UnitPixel, &font);
+	expect (Ok, status);
+	status = GdipCreateBitmapFromScan0 (400, 400, 0, PixelFormat32bppRGB, NULL, &image);
+	expect (Ok, status);
+	status = GdipGetImageGraphicsContext (image, &graphics);
+	expect (Ok, status);
+	ok (graphics != NULL, "Expected graphics to be initialized\n");
+
+	rect.X = 5.0;
+	rect.Y = 5.0;
+	rect.Width = 200.0;
+	rect.Height = 200.0;
+	set_rect_empty (&bounds);
+	status = GdipMeasureString (graphics, teststring1, 1, font, &rect, format, &bounds, &glyphs, &lines);
+	expect (Ok, status);
+	expectf (5.0, bounds.X);
+	expectf (5.0, bounds.Y);
+	expect (1, glyphs);
+	expect (1, lines);
+
+	// New lines count as fitted code points
+	set_rect_empty (&bounds);
+	status = GdipMeasureString (graphics, teststring1, 2, font, &rect, format, &bounds, &glyphs, &lines);
+	expect (Ok, status);
+	expect (2, glyphs);
+	expect (1, lines);
+	saved_bounds = bounds;
+
+	// Multiple new lines are counted as code points and lines
+	set_rect_empty (&bounds);
+	status = GdipMeasureString (graphics, teststring1, 3, font, &rect, format, &bounds, &glyphs, &lines);
+	expect (Ok, status);
+	TODO expect (3, glyphs);
+	expect (2, lines);
+
+	// ...and lastly check the correct results for adding another character past the last new line
+	set_rect_empty (&bounds);
+	status = GdipMeasureString (graphics, teststring1, 4, font, &rect, format, &bounds, &glyphs, &lines);
+	expect (Ok, status);
+	TODO expect (4, glyphs);
+	expect (3, lines);
+
+	// Attempt to fit 3 glyphs / 2 lines into a bounding box from 2 glyphs / 1 line
+	rect = saved_bounds;
+	set_rect_empty (&bounds);
+	status = GdipMeasureString (graphics, teststring1, 3, font, &rect, format, &bounds, &glyphs, &lines);
+	expect (Ok, status);
+	expect (2, glyphs);
+	TODO expect (1, lines);
+
+	GdipDeleteGraphics (graphics);
+	GdipDeleteFont (font);
+	GdipDeleteFontFamily (family);
+	GdipDeleteStringFormat (format);
+	GdipDisposeImage (image);
+}
+
+static void test_measure_string_alignment(void)
+{
+	GpStringFormat *format;
+	GpImage *image;
+	GpGraphics *graphics;
+	GpFontFamily *family;
+	GpFont *font;
+	GpStatus status;
+	GpRectF rect, bounds;
+	const WCHAR teststring1[] = { 'M', 0 };
+	INT i;
+	static const struct test_data
+	{
+		INT flags;
+		StringAlignment alignment, line_alignment;
+		REAL x_xx, x_x0;
+		REAL y_yy, y_y0;
+		REAL right_xx, right_x0;
+		REAL bottom_yy, bottom_y0;
+	} td[] =
+	{
+		{ 0, StringAlignmentNear, StringAlignmentNear, 0, 0, 0, 0, 1., 0, 1., 0 },
+		{ 0, StringAlignmentCenter, StringAlignmentNear, -.5, 100, 0, 0, .5, 100, 1., 0 },
+		{ 0, StringAlignmentFar, StringAlignmentNear, -1., 200, 0, 0, 0, 200, 1., 0 },
+		{ 0, StringAlignmentNear, StringAlignmentCenter, 0, 0, -.5, 50, 1., 0, .5, 50 },
+		{ 0, StringAlignmentCenter, StringAlignmentCenter, -.5, 100, -.5, 50, .5, 100, .5, 50 },
+		{ 0, StringAlignmentFar, StringAlignmentCenter, -1., 200, -.5, 50, 0, 200, .5, 50 },
+		{ 0, StringAlignmentNear, StringAlignmentFar, 0, 0, -1., 100, 1., 0, 0, 100 },
+		{ 0, StringAlignmentCenter, StringAlignmentFar, -.5, 100, -1., 100, .5, 100, 0, 100 },
+		{ 0, StringAlignmentFar, StringAlignmentFar, -1., 200, -1., 100, 0, 200, 0, 100 },
+
+		{ StringFormatFlagsDirectionVertical, StringAlignmentNear, StringAlignmentNear, 0, 0, 0, 0, 1., 0, 1., 0 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentNear, StringAlignmentCenter, -.5, 100, 0, 0, .5, 100, 1., 0 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentNear, StringAlignmentFar, -1., 200, 0, 0, 0, 200, 1., 0 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentCenter, StringAlignmentNear, 0, 0, -.5, 50, 1., 0, .5, 50 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentCenter, StringAlignmentCenter, -.5, 100, -.5, 50, .5, 100, .5, 50 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentCenter, StringAlignmentFar, -1., 200, -.5, 50, 0, 200, .5, 50 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentFar, StringAlignmentNear, 0, 0, -1., 100, 1., 0, 0, 100 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentFar, StringAlignmentCenter, -.5, 100, -1., 100, .5, 100, 0, 100 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentFar, StringAlignmentFar, -1., 200, -1., 100, 0, 200, 0, 100 },
+
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentFar, StringAlignmentNear, 0, 0, 0, 0, 1., 0, 1., 0 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentCenter, StringAlignmentNear, -.5, 100, 0, 0, .5, 100, 1., 0 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentNear, StringAlignmentNear, -1., 200, 0, 0, 0, 200, 1., 0 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentFar, StringAlignmentCenter, 0, 0, -.5, 50, 1., 0, .5, 50 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentCenter, StringAlignmentCenter, -.5, 100, -.5, 50, .5, 100, .5, 50 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentNear, StringAlignmentCenter, -1., 200, -.5, 50, 0, 200, .5, 50 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentFar, StringAlignmentFar, 0, 0, -1., 100, 1., 0, 0, 100 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentCenter, StringAlignmentFar, -.5, 100, -1., 100, .5, 100, 0, 100 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentNear, StringAlignmentFar, -1., 200, -1., 100, 0, 200, 0, 100 },
+	};
+
+
+	status = GdipCreateStringFormat (0, 0, &format);
+	expect (Ok, status);
+	status = GdipGetGenericFontFamilySansSerif (&family);
+	expect (Ok, status);
+	status = GdipCreateFont (family, 10, FontStyleRegular, UnitPixel, &font);
+	expect (Ok, status);
+	status = GdipCreateBitmapFromScan0 (400, 400, 0, PixelFormat32bppRGB, NULL, &image);
+	expect (Ok, status);
+	status = GdipGetImageGraphicsContext (image, &graphics);
+	expect (Ok, status);
+	ok (graphics != NULL, "Expected graphics to be initialized\n");
+
+	for (i = 0; i < sizeof(td) / sizeof(td[0]); i++) {
+		GdipSetStringFormatFlags (format, td[i].flags);
+		GdipSetStringFormatAlign (format, td[i].alignment);
+		GdipSetStringFormatLineAlign (format, td[i].line_alignment);
+
+		rect.X = 5.0;
+		rect.Y = 10.0;
+		rect.Width = 200.0;
+		rect.Height = 100.0;
+		set_rect_empty (&bounds);
+		status = GdipMeasureString (graphics, teststring1, 1, font, &rect, format, &bounds, NULL, NULL);
+		expect (Ok, status);
+		expectf_ (td[i].x_x0 + td[i].x_xx * bounds.Width + 5., bounds.X, 0.6);
+		expectf_ (td[i].y_y0 + td[i].y_yy * bounds.Height + 10., bounds.Y, 0.6);
+		expectf_ (td[i].right_x0 + td[i].right_xx * bounds.Width + 5., bounds.X + bounds.Width, 0.6);
+		expectf_ (td[i].bottom_y0 + td[i].bottom_yy * bounds.Height + 10., bounds.Y + bounds.Height, 0.6);
+	}
+
+	GdipDeleteGraphics (graphics);
+	GdipDeleteFont (font);
+	GdipDeleteFontFamily (family);
+	GdipDeleteStringFormat (format);
+	GdipDisposeImage (image);
+}
+
+#endif
+
+int
+main (int argc, char**argv)
+{
+	STARTUP;
+
+#ifdef USE_PANGO_RENDERING
+	test_measure_string ();
+	test_measure_string_alignment ();
+#endif
+
+	SHUTDOWN;
+	return 0;
+}

--- a/tests/testtext.c
+++ b/tests/testtext.c
@@ -127,35 +127,35 @@ static void test_measure_string_alignment(void)
 		REAL bottom_yy, bottom_y0;
 	} td[] =
 	{
-		{ 0, StringAlignmentNear, StringAlignmentNear, 0, 0, 0, 0, 1., 0, 1., 0 },
-		{ 0, StringAlignmentCenter, StringAlignmentNear, -.5, 100, 0, 0, .5, 100, 1., 0 },
-		{ 0, StringAlignmentFar, StringAlignmentNear, -1., 200, 0, 0, 0, 200, 1., 0 },
-		{ 0, StringAlignmentNear, StringAlignmentCenter, 0, 0, -.5, 50, 1., 0, .5, 50 },
-		{ 0, StringAlignmentCenter, StringAlignmentCenter, -.5, 100, -.5, 50, .5, 100, .5, 50 },
-		{ 0, StringAlignmentFar, StringAlignmentCenter, -1., 200, -.5, 50, 0, 200, .5, 50 },
-		{ 0, StringAlignmentNear, StringAlignmentFar, 0, 0, -1., 100, 1., 0, 0, 100 },
-		{ 0, StringAlignmentCenter, StringAlignmentFar, -.5, 100, -1., 100, .5, 100, 0, 100 },
-		{ 0, StringAlignmentFar, StringAlignmentFar, -1., 200, -1., 100, 0, 200, 0, 100 },
+		{ 0, StringAlignmentNear, StringAlignmentNear, 0, 0, 0, 0, -1.0, 0, -1.0, 0 },
+		{ 0, StringAlignmentCenter, StringAlignmentNear, -0.5, 100, 0, 0, 0.5, 100, -1.0, 0 },
+		{ 0, StringAlignmentFar, StringAlignmentNear, -1.0, 200, 0, 0, 0, 200, -1.0, 0 },
+		{ 0, StringAlignmentNear, StringAlignmentCenter, 0, 0, -0.5, 50, -1.0, 0, 0.5, 50 },
+		{ 0, StringAlignmentCenter, StringAlignmentCenter, -0.5, 100, -0.5, 50, 0.5, 100, 0.5, 50 },
+		{ 0, StringAlignmentFar, StringAlignmentCenter, -1.0, 200, -0.5, 50, 0, 200, 0.5, 50 },
+		{ 0, StringAlignmentNear, StringAlignmentFar, 0, 0, -1.0, 100, -1.0, 0, 0, 100 },
+		{ 0, StringAlignmentCenter, StringAlignmentFar, -0.5, 100, -1.0, 100, 0.5, 100, 0, 100 },
+		{ 0, StringAlignmentFar, StringAlignmentFar, -1.0, 200, -1.0, 100, 0, 200, 0, 100 },
 
-		{ StringFormatFlagsDirectionVertical, StringAlignmentNear, StringAlignmentNear, 0, 0, 0, 0, 1., 0, 1., 0 },
-		{ StringFormatFlagsDirectionVertical, StringAlignmentNear, StringAlignmentCenter, -.5, 100, 0, 0, .5, 100, 1., 0 },
-		{ StringFormatFlagsDirectionVertical, StringAlignmentNear, StringAlignmentFar, -1., 200, 0, 0, 0, 200, 1., 0 },
-		{ StringFormatFlagsDirectionVertical, StringAlignmentCenter, StringAlignmentNear, 0, 0, -.5, 50, 1., 0, .5, 50 },
-		{ StringFormatFlagsDirectionVertical, StringAlignmentCenter, StringAlignmentCenter, -.5, 100, -.5, 50, .5, 100, .5, 50 },
-		{ StringFormatFlagsDirectionVertical, StringAlignmentCenter, StringAlignmentFar, -1., 200, -.5, 50, 0, 200, .5, 50 },
-		{ StringFormatFlagsDirectionVertical, StringAlignmentFar, StringAlignmentNear, 0, 0, -1., 100, 1., 0, 0, 100 },
-		{ StringFormatFlagsDirectionVertical, StringAlignmentFar, StringAlignmentCenter, -.5, 100, -1., 100, .5, 100, 0, 100 },
-		{ StringFormatFlagsDirectionVertical, StringAlignmentFar, StringAlignmentFar, -1., 200, -1., 100, 0, 200, 0, 100 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentNear, StringAlignmentNear, 0, 0, 0, 0, -1.0, 0, -1.0, 0 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentNear, StringAlignmentCenter, -0.5, 100, 0, 0, 0.5, 100, -1.0, 0 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentNear, StringAlignmentFar, -1.0, 200, 0, 0, 0, 200, -1.0, 0 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentCenter, StringAlignmentNear, 0, 0, -0.5, 50, 1.0, 0, 0.5, 50 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentCenter, StringAlignmentCenter, -0.5, 100, -0.5, 50, 0.5, 100, 0.5, 50 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentCenter, StringAlignmentFar, -1.0, 200, -0.5, 50, 0, 200, 0.5, 50 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentFar, StringAlignmentNear, 0, 0, -1.0, 100, -1.0, 0, 0, 100 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentFar, StringAlignmentCenter, -0.5, 100, -1.0, 100, 0.5, 100, 0, 100 },
+		{ StringFormatFlagsDirectionVertical, StringAlignmentFar, StringAlignmentFar, -1.0, 200, -1.0, 100, 0, 200, 0, 100 },
 
-		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentFar, StringAlignmentNear, 0, 0, 0, 0, 1., 0, 1., 0 },
-		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentCenter, StringAlignmentNear, -.5, 100, 0, 0, .5, 100, 1., 0 },
-		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentNear, StringAlignmentNear, -1., 200, 0, 0, 0, 200, 1., 0 },
-		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentFar, StringAlignmentCenter, 0, 0, -.5, 50, 1., 0, .5, 50 },
-		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentCenter, StringAlignmentCenter, -.5, 100, -.5, 50, .5, 100, .5, 50 },
-		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentNear, StringAlignmentCenter, -1., 200, -.5, 50, 0, 200, .5, 50 },
-		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentFar, StringAlignmentFar, 0, 0, -1., 100, 1., 0, 0, 100 },
-		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentCenter, StringAlignmentFar, -.5, 100, -1., 100, .5, 100, 0, 100 },
-		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentNear, StringAlignmentFar, -1., 200, -1., 100, 0, 200, 0, 100 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentFar, StringAlignmentNear, 0, 0, 0, 0, -1.0, 0, -1.0, 0 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentCenter, StringAlignmentNear, -0.5, 100, 0, 0, 0.5, 100, -1.0, 0 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentNear, StringAlignmentNear, -1.0, 200, 0, 0, 0, 200, -1.0, 0 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentFar, StringAlignmentCenter, 0, 0, -0.5, 50, -1.0, 0, 0.5, 50 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentCenter, StringAlignmentCenter, -0.5, 100, -0.5, 50, 0.5, 100, 0.5, 50 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentNear, StringAlignmentCenter, -1.0, 200, -0.5, 50, 0, 200, 0.5, 50 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentFar, StringAlignmentFar, 0, 0, -1.0, 100, -1.0, 0, 0, 100 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentCenter, StringAlignmentFar, -0.5, 100, -1.0, 100, 0.5, 100, 0, 100 },
+		{ StringFormatFlagsDirectionRightToLeft, StringAlignmentNear, StringAlignmentFar, -1.0, 200, -1.0, 100, 0, 200, 0, 100 }
 	};
 
 
@@ -183,10 +183,10 @@ static void test_measure_string_alignment(void)
 		set_rect_empty (&bounds);
 		status = GdipMeasureString (graphics, teststring1, 1, font, &rect, format, &bounds, NULL, NULL);
 		expect (Ok, status);
-		expectf_ (td[i].x_x0 + td[i].x_xx * bounds.Width + 5., bounds.X, 0.6);
-		expectf_ (td[i].y_y0 + td[i].y_yy * bounds.Height + 10., bounds.Y, 0.6);
-		expectf_ (td[i].right_x0 + td[i].right_xx * bounds.Width + 5., bounds.X + bounds.Width, 0.6);
-		expectf_ (td[i].bottom_y0 + td[i].bottom_yy * bounds.Height + 10., bounds.Y + bounds.Height, 0.6);
+		expectf_ (td[i].x_x0 + td[i].x_xx * bounds.Width + 5.0, bounds.X, 0.6);
+		expectf_ (td[i].y_y0 + td[i].y_yy * bounds.Height + 10.0, bounds.Y, 0.6);
+		expectf_ (td[i].right_x0 + td[i].right_xx * bounds.Width + 5.0, bounds.X + bounds.Width, 0.6);
+		expectf_ (td[i].bottom_y0 + td[i].bottom_yy * bounds.Height + 10.0, bounds.Y + bounds.Height, 0.6);
 	}
 
 	GdipDeleteGraphics (graphics);


### PR DESCRIPTION
Unfortunately the Cairo text backend is too broken for the tests to be enabled there, so I initially enable them only when Pango text backend is used. Even now some of the tests are disabled because of small issues in the Pango code.