### PR TITLE
Actually implement RegionTypeInfinite

### DIFF
--- a/src/region-private.h
+++ b/src/region-private.h
@@ -72,7 +72,7 @@ struct _Region {
     GpRegionBitmap*	bitmap;
 };
 
-BOOL gdip_is_InfiniteRegion (GpRegion *region) GDIP_INTERNAL;
+BOOL gdip_is_InfiniteRegion (const GpRegion *region) GDIP_INTERNAL;
 BOOL gdip_is_Point_in_RectF_inclusive (float x, float y, GpRectF* rect) GDIP_INTERNAL;
 
 void gdip_clear_region (GpRegion *region) GDIP_INTERNAL;


### PR DESCRIPTION
~Depends on #327 which depends on #326 which depends on #286~

I’ve implemented this pr for several reasons:

## Compatability
On its own this PR slightly increases compatibility with GDI+ as infinite regions are encoded in the data as a type of 0x10000003 instead of a type 0x10000001 and a rectangle with infinite size.
However, this now allows us to differentiate between infinite and non-infinite regions which, in a future PR will be used to increase the compatability with GdipGetRegionData even more

## Performance

The cost of creating a `new Region()` is now cheaper and avoids allocations by creating an infinite rect and putting it in an array.

In the future this flag can easily be used in other settings to increase performance

## Correctness
Fixes #391
Fixes #335
Fixes #337
Fixes #341
Fixes #343
Fixes #344
Fixes #350
Fixes #353
Fixes #355
Fixes #356
Contributes to #336
Contributes to #338
Contributes to #339
Contributes to #342
