### PR TITLE
Fix GdipIsRegionEmpty for negative rects

### DIFF
--- a/src/region.c
+++ b/src/region.c
@@ -151,7 +151,7 @@ gdip_is_region_empty (GpRegion *region)
 			return TRUE;
 
 		gdip_get_bounds (region->rects, region->cnt, &rect);
-		return ((rect.Width == 0) || (rect.Height == 0));
+		return ((rect.Width <= 0) || (rect.Height <= 0));
 	case RegionTypePath:
 		/* check for an existing, but empty, path list */
 		if (!region->tree)

--- a/tests/testregion.c
+++ b/tests/testregion.c
@@ -83,13 +83,13 @@ static void test_createRegionRect ()
 	// Negative width.
 	status = GdipCreateRegionRect (&negativeWidthRect, &region);
 	assertEqualInt (status, Ok);
-	verifyRegion (region, 1, 2, -3, 4, FALSE, FALSE);
+	verifyRegion (region, 1, 2, -3, 4, TRUE, FALSE);
 	GdipDeleteRegion (region);
 
 	// Negative height.
 	status = GdipCreateRegionRect (&negativeHeightRect, &region);
 	assertEqualInt (status, Ok);
-	verifyRegion (region, 1, 2, 3, -4, FALSE, FALSE);
+	verifyRegion (region, 1, 2, 3, -4, TRUE, FALSE);
 	GdipDeleteRegion (region);
 
 	// Zero.
@@ -131,13 +131,13 @@ static void test_createRegionRectI ()
 	// Negative width.
 	status = GdipCreateRegionRectI (&negativeWidthRect, &region);
 	assertEqualInt (status, Ok);
-	verifyRegion (region, 1, 2, -3, 4, FALSE, FALSE);
+	verifyRegion (region, 1, 2, -3, 4, TRUE, FALSE);
 	GdipDeleteRegion (region);
 
 	// Negative height.
 	status = GdipCreateRegionRectI (&negativeHeightRect, &region);
 	assertEqualInt (status, Ok);
-	verifyRegion (region, 1, 2, 3, -4, FALSE, FALSE);
+	verifyRegion (region, 1, 2, 3, -4, TRUE, FALSE);
 	GdipDeleteRegion (region);
 
 	// Zero.


### PR DESCRIPTION
Found when running the region tests against Windows GDI+