### PR TITLE
Cleanup graphics draw/fill functions to avoid code duplication

### DIFF
--- a/src/general-private.h
+++ b/src/general-private.h
@@ -110,6 +110,7 @@ int utf8_encode_ucs2char (gunichar2 unichar, unsigned char *dest) GDIP_INTERNAL;
 
 /* for drawing curves */
 GpPointF *convert_points (const GpPoint *points, int count) GDIP_INTERNAL;
+GpRectF *convert_rects (const GpRect *rect, int count) GDIP_INTERNAL;
 GpPointF *gdip_closed_curve_tangents (int terms, const GpPointF *points, int count, float tension) GDIP_INTERNAL;
 GpPointF *gdip_open_curve_tangents (int terms,  const GpPointF *points, int count, float tension) GDIP_INTERNAL;
 

--- a/src/general.c
+++ b/src/general.c
@@ -228,12 +228,26 @@ convert_points (const GpPoint *point, int count)
 	if (!retval)
 		return NULL;
 
-		for (i = 0; i < count; i++) {
-			retval [i].X = (float) point [i].X;
-			retval [i].Y = (float) point [i].Y;
-		}
+	for (i = 0; i < count; i++) {
+		retval [i].X = (float) point [i].X;
+		retval [i].Y = (float) point [i].Y;
+	}
 
-		return retval;
+	return retval;
+}
+
+GpRectF *
+convert_rects (const GpRect *rect, int count)
+{
+	int i;
+	GpRectF *retval = (GpRectF *) GdipAlloc (sizeof (GpRectF) * count);
+	if (!retval)
+		return NULL;
+
+	for (i = 0; i < count; i++)
+		gdip_RectF_from_Rect (&rect[i], &retval[i]);
+
+	return retval;
 }
 
 GpPointF *

--- a/src/graphics-cairo-private.h
+++ b/src/graphics-cairo-private.h
@@ -31,15 +31,6 @@
 #define C1	0.552285
 
 /*
- * Cairo use doubles almost everywhere so we can define most int-based functions to the float based one
- */
-#define cairo_DrawLineI		cairo_DrawLine
-#define cairo_DrawPieI		cairo_DrawPie
-#define cairo_FillPieI		cairo_FillPie
-#define cairo_DrawRectangleI	cairo_DrawRectangle
-#define cairo_FillRectangleI	cairo_FillRectangle
-
-/*
  * Handling of pens with a width greater than 1 is not identical between GDI+ and Cairo
  *
  * On cairo >= 1.12 pen adjustment is not required or tons of tests senstive to this break.
@@ -56,44 +47,23 @@ GpStatus gdip_plot_path (GpGraphics *graphics, GpPath *path, BOOL antialiasing) 
 
 GpStatus cairo_DrawArc (GpGraphics *graphics, GpPen *pen, float x, float y, float width, float height, float startAngle, 
 	float sweepAngle) GDIP_INTERNAL;
-GpStatus cairo_DrawArcI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height, float startAngle, 
-	float sweepAngle) GDIP_INTERNAL;
 
-GpStatus cairo_DrawBezier (GpGraphics *graphics, GpPen *pen, float x1, float y1, float x2, float y2, float x3, float y3, 
-	float x4, float y4) GDIP_INTERNAL;
-GpStatus cairo_DrawBezierI (GpGraphics *graphics, GpPen *pen, int x1, int y1, int x2, int y2, int x3, int y3, 
-	int x4, int y4) GDIP_INTERNAL;
 GpStatus cairo_DrawBeziers (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count) GDIP_INTERNAL;
-GpStatus cairo_DrawBeziersI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count) GDIP_INTERNAL;
 
 GpStatus cairo_DrawClosedCurve2 (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count, 
 	float tension) GDIP_INTERNAL;
-GpStatus cairo_DrawClosedCurve2I (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count, 
-	float tension) GDIP_INTERNAL;
 GpStatus cairo_FillClosedCurve2 (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *points, int count, 
-	float tension) GDIP_INTERNAL;
-GpStatus cairo_FillClosedCurve2I (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPoint *points, int count, 
 	float tension) GDIP_INTERNAL;
 GpStatus cairo_DrawCurve3 (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPointF *points, int count, int offset, 
 	int numOfSegments, float tension) GDIP_INTERNAL;
-GpStatus cairo_DrawCurve3I (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPoint *points, int count, int offset,
-	int numOfSegments, float tension) GDIP_INTERNAL;
 
 GpStatus cairo_DrawEllipse (GpGraphics *graphics, GpPen *pen, float x, float y, float width, float height) GDIP_INTERNAL;
-GpStatus cairo_DrawEllipseI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height) GDIP_INTERNAL;
 GpStatus cairo_FillEllipse (GpGraphics *graphics, GpBrush *brush, float x, float y, float width, float height) GDIP_INTERNAL;
-GpStatus cairo_FillEllipseI (GpGraphics *graphics, GpBrush *brush, int x, int y, int width, int height) GDIP_INTERNAL;
 
-GpStatus cairo_DrawLine (GpGraphics *graphics, GpPen *pen, float x1, float y1, float x2, float y2) GDIP_INTERNAL;
 GpStatus cairo_DrawLines (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count) GDIP_INTERNAL;
-GpStatus cairo_DrawLinesI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count) GDIP_INTERNAL;
 
-GpStatus cairo_DrawRectangle (GpGraphics *graphics, GpPen *pen, float x, float y, float width, float height) GDIP_INTERNAL;
-GpStatus cairo_FillRectangle (GpGraphics *graphics, GpBrush *brush, float x, float y, float width, float height) GDIP_INTERNAL;
 GpStatus cairo_DrawRectangles (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRectF *rects, int count) GDIP_INTERNAL;
-GpStatus cairo_DrawRectanglesI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRect *rects, int count) GDIP_INTERNAL;
 GpStatus cairo_FillRectangles (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpRectF *rects, int count) GDIP_INTERNAL;
-GpStatus cairo_FillRectanglesI (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpRect *rects, int count) GDIP_INTERNAL;
 
 GpStatus cairo_DrawPath (GpGraphics *graphics, GpPen *pen, GpPath *path) GDIP_INTERNAL;
 GpStatus cairo_FillPath (GpGraphics *graphics, GpBrush *brush, GpPath *path) GDIP_INTERNAL;
@@ -104,10 +74,7 @@ GpStatus cairo_FillPie (GpGraphics *graphics, GpBrush *brush, float x, float y, 
 	float startAngle, float sweepAngle) GDIP_INTERNAL;
 
 GpStatus cairo_DrawPolygon (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count) GDIP_INTERNAL;
-GpStatus cairo_DrawPolygonI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count) GDIP_INTERNAL;
 GpStatus cairo_FillPolygon (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *points, int count, 
-	FillMode fillMode) GDIP_INTERNAL;
-GpStatus cairo_FillPolygonI (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPoint *points, int count, 
 	FillMode fillMode) GDIP_INTERNAL;
 
 GpStatus cairo_FillRegion (GpGraphics *graphics, GpBrush *brush, GpRegion *region) GDIP_INTERNAL;

--- a/src/graphics-cairo.c
+++ b/src/graphics-cairo.c
@@ -266,29 +266,6 @@ cairo_DrawArc (GpGraphics *graphics, GpPen *pen, float x, float y, float width, 
 	return stroke_graphics_with_pen (graphics, pen);
 }
 
-GpStatus
-cairo_DrawArcI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height, float startAngle, float sweepAngle)
-{
-	return cairo_DrawArc (graphics, pen, x, y, width, height, startAngle, sweepAngle);
-}
-
-GpStatus 
-cairo_DrawBezier (GpGraphics *graphics, GpPen *pen, float x1, float y1, float x2, float y2, float x3, float y3, 
-	float x4, float y4)
-{
-	/* We use graphics->copy_of_ctm matrix for path creation. We should have it set already. */
-	gdip_cairo_move_to (graphics, x1, y1, TRUE, TRUE);
-	gdip_cairo_curve_to (graphics, x2, y2, x3, y3, x4, y4, TRUE, TRUE);
-
-	return stroke_graphics_with_pen (graphics, pen);
-}
-
-GpStatus
-cairo_DrawBezierI (GpGraphics *graphics, GpPen *pen, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4)
-{
-	return cairo_DrawBezier (graphics, pen, x1, y1, x2, y2, x3, y3, x4, y4);
-}
-
 GpStatus 
 cairo_DrawBeziers (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count)
 {
@@ -304,23 +281,6 @@ cairo_DrawBeziers (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points,
 
 	return stroke_graphics_with_pen (graphics, pen);
 }
-
-GpStatus
-cairo_DrawBeziersI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count)
-{
-	int i, j, k;
-		
-	/* We use graphics->copy_of_ctm matrix for path creation. We should have it set already. */
-	gdip_cairo_move_to (graphics, points [0].X, points [0].Y, TRUE, TRUE);
-
-	for (i = 0, j = 1, k = 2; i < count - 3; i += 3, j += 3, k += 3) {
-	gdip_cairo_curve_to (graphics, points [i].X, points [i].Y, points [j].X, points [j].Y,
-		points [k].X, points [k].Y, TRUE, TRUE);
-	}
-
-	return stroke_graphics_with_pen (graphics, pen);
-}
-
 
 static void
 make_curve (GpGraphics *graphics, GDIPCONST GpPointF *points, GpPointF *tangents, int offset, int length,
@@ -378,19 +338,6 @@ cairo_DrawClosedCurve2 (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *po
 }
 
 GpStatus
-cairo_DrawClosedCurve2I (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count, float tension)
-{
-	GpStatus status;
-	GpPointF *pt = convert_points (points, count);
-	if (!pt)
-		return OutOfMemory;
-
-	status = cairo_DrawClosedCurve2 (graphics, pen, pt, count, tension);
-	GdipFree (pt);
-	return status;
-}
-
-GpStatus
 cairo_FillClosedCurve2 (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *points, int count, float tension)
 {
 	GpStatus status;
@@ -402,19 +349,6 @@ cairo_FillClosedCurve2 (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF
 	status = fill_graphics_with_brush (graphics, brush, FALSE);
 
 	GdipFree (tangents);
-	return status;
-}
-
-GpStatus
-cairo_FillClosedCurve2I (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPoint *points, int count, float tension)
-{
-	GpStatus status;
-	GpPointF *pt = convert_points (points, count);
-	if (!pt)
-		return OutOfMemory;
-
-	status = GdipFillClosedCurve2 (graphics, brush, pt, count, tension);
-	GdipFree (pt);
 	return status;
 }
 
@@ -434,20 +368,6 @@ cairo_DrawCurve3 (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPointF *points, 
 	return status;
 }
 
-GpStatus
-cairo_DrawCurve3I (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPoint *points, int count, int offset, int numOfSegments,
-	float tension)
-{
-	GpStatus status;
-	GpPointF *pt = convert_points (points, count);
-	if (!pt)
-		return OutOfMemory;
-
-	status = cairo_DrawCurve3 (graphics, pen, pt, count, offset, numOfSegments, tension);
-	GdipFree (pt);
-	return status;
-}
-
 /*
  * Ellipses
  */
@@ -462,12 +382,6 @@ cairo_DrawEllipse (GpGraphics *graphics, GpPen *pen, float x, float y, float wid
 }
 
 GpStatus
-cairo_DrawEllipseI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height)
-{
-	return cairo_DrawEllipse (graphics, pen, x, y, width, height);
-}
-
-GpStatus
 cairo_FillEllipse (GpGraphics *graphics, GpBrush *brush, float x, float y, float width, float height)
 {
 	/* We use graphics->copy_of_ctm matrix for path creation. We should have it set already. */
@@ -476,59 +390,8 @@ cairo_FillEllipse (GpGraphics *graphics, GpBrush *brush, float x, float y, float
 	return fill_graphics_with_brush (graphics, brush, FALSE);
 }
 
-GpStatus
-cairo_FillEllipseI (GpGraphics *graphics, GpBrush *brush, int x, int y, int width, int height)
-{
-	return cairo_FillEllipse (graphics, brush, x, y, width, height);
-}
-
-GpStatus
-cairo_DrawLine (GpGraphics *graphics, GpPen *pen, float x1, float y1, float x2, float y2)
-{
-	GpStatus ret;
-
-	/* We use graphics->copy_of_ctm matrix for path creation. We should have it set already. */
-	gdip_cairo_move_to (graphics, x1, y1, TRUE, TRUE);
-	gdip_cairo_line_to (graphics, x2, y2, TRUE, TRUE);
-
-	ret = stroke_graphics_with_pen (graphics, pen);
-
-	gdip_pen_draw_custom_start_cap (graphics, pen, x1, y1, x2, y2);
-	gdip_pen_draw_custom_end_cap (graphics, pen, x2, y2, x1, y1);
-
-	return ret;
-}
-
 GpStatus 
 cairo_DrawLines (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count)
-{
-	int i;
-	float last_x, last_y, prev_x, prev_y;
-	GpStatus ret;
-
-	/* We use graphics->copy_of_ctm matrix for path creation. We should have it set already. */
-	gdip_cairo_move_to (graphics, points [0].X, points [0].Y, TRUE, TRUE);
-
-	for (i = 1; i < count; i++) {
-		gdip_cairo_line_to (graphics, points [i].X, points [i].Y, TRUE, TRUE);
-		prev_x = points [i - 1].X;
-		prev_y = points [i - 1].Y;
-		last_x = points [i].X;
-		last_y = points [i].Y;
-	}
-
-	ret = stroke_graphics_with_pen (graphics, pen);
-
-	if (count > 1) {
-		gdip_pen_draw_custom_start_cap (graphics, pen, points [0].X, points [0].Y, points [1].X, points [1].Y);
-		gdip_pen_draw_custom_end_cap (graphics, pen, last_x, last_y, prev_x, prev_y);
-	}
-
-	return ret;
-}
-
-GpStatus 
-cairo_DrawLinesI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count)
 {
 	int i;
 	float last_x, last_y, prev_x, prev_y;
@@ -787,13 +650,6 @@ cairo_DrawPolygon (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points,
 }
 
 GpStatus
-cairo_DrawPolygonI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count)
-{
-	make_polygon_from_integers (graphics, points, count, TRUE);
-	return stroke_graphics_with_pen (graphics, pen);
-}
-
-GpStatus
 cairo_FillPolygon (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *points, int count, FillMode fillMode)
 {
 	make_polygon (graphics, points, count, FALSE);
@@ -801,36 +657,9 @@ cairo_FillPolygon (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *poi
 	return fill_graphics_with_brush (graphics, brush, FALSE);
 }
 
-GpStatus
-cairo_FillPolygonI (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPoint *points, int count, FillMode fillMode)
-{
-	make_polygon_from_integers (graphics, points, count, FALSE);
-	cairo_set_fill_rule (graphics->ct, gdip_convert_fill_mode (fillMode));
-	return fill_graphics_with_brush (graphics, brush, FALSE);
-}
-
 /*
  * Rectangle(s)
  */
-
-GpStatus
-cairo_DrawRectangle (GpGraphics *graphics, GpPen *pen, float x, float y, float width, float height)
-{
-	/* wide pen position can be different between cairo and gdi+ */
-	if (gdip_cairo_pen_width_needs_adjustment (pen)) {
-		x -= 1.0f;
-		y -= 1.0f;
-	}
-	gdip_cairo_rectangle (graphics, x, y, width, height, TRUE);
-	return stroke_graphics_with_pen (graphics, pen);
-}
-
-GpStatus 
-cairo_FillRectangle (GpGraphics *graphics, GpBrush *brush, float x, float y, float width, float height)
-{
-	gdip_cairo_rectangle (graphics, x, y, width, height, FALSE);
-	return fill_graphics_with_brush (graphics, brush, FALSE);
-}
 
 GpStatus
 cairo_DrawRectangles (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRectF *rects, int count)
@@ -865,66 +694,8 @@ cairo_DrawRectangles (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRectF *rects
 	return stroke_graphics_with_pen (graphics, pen);
 }
 
-GpStatus
-cairo_DrawRectanglesI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRect *rects, int count)
-{
-	BOOL draw = FALSE;
-	BOOL adjust = gdip_cairo_pen_width_needs_adjustment (pen);
-	int i;
-
-	for (i = 0; i < count; i++) {
-		int x = rects [i].X;
-		int y = rects [i].Y;
-		int w = rects [i].Width;
-		int h = rects [i].Height;
-
-		/* don't draw/fill rectangles with negative width/height (bug #77129) */
-		if ((w < 0) || (h < 0))
-			continue;
-
-		/* wide pen position can be different between cairo and gdi+ */
-		if (adjust) {
-			x -= 1;
-			y -= 1;
-		}
-
-		gdip_cairo_rectangle (graphics, x, y, w, h, TRUE);
-		draw = TRUE;
-	}
-
-	if (!draw)
-		return Ok;
-
-	return stroke_graphics_with_pen (graphics, pen);
-}
-
 GpStatus 
 cairo_FillRectangles (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpRectF *rects, int count)
-{
-	BOOL draw = FALSE;
-	int i;
-
-	/* We use graphics->copy_of_ctm matrix for path creation. We
-	 * should have it set already.
-	 */
-	for (i = 0; i < count; i++) {
-		/* don't draw/fill rectangles with negative width/height (bug #77129) */
-		if ((rects [i].Width < 0) || (rects [i].Height < 0))
-			continue;
-
-		gdip_cairo_rectangle (graphics, rects [i].X, rects [i].Y, rects [i].Width, rects [i].Height, FALSE);
-		draw = TRUE;
-	}
-
-	/* shortcut if no rectangles were drawn into the graphics */
-	if (!draw)
-		return Ok;
-
-	return fill_graphics_with_brush (graphics, brush, FALSE);
-}
-
-GpStatus 
-cairo_FillRectanglesI (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpRect *rects, int count)
 {
 	BOOL draw = FALSE;
 	int i;
@@ -984,7 +755,7 @@ cairo_FillRegion (GpGraphics *graphics, GpBrush *brush, GpRegion *region)
 			status = GdipGetImageGraphicsContext ((GpImage*)bitmap, &bitgraph);
 			if (status == Ok) {
 				/* fill the "full" rectangle using the specified brush */
-				cairo_FillRectangle (bitgraph, brush, 0, 0, region->bitmap->Width, region->bitmap->Height);
+				GdipFillRectangle (bitgraph, brush, 0, 0, region->bitmap->Width, region->bitmap->Height);
 
 				/* adjust bitmap alpha (i.e. shape the brushed-rectangle like the region) */
 				gdip_region_bitmap_apply_alpha (bitmap, region->bitmap);

--- a/src/graphics-metafile-private.h
+++ b/src/graphics-metafile-private.h
@@ -28,65 +28,35 @@
 
 GpStatus metafile_DrawArc (GpGraphics *graphics, GpPen *pen, float x, float y, float width, float height, float startAngle, 
 	float sweepAngle) GDIP_INTERNAL;
-GpStatus metafile_DrawArcI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height, float startAngle, 
-	float sweepAngle) GDIP_INTERNAL;
 
-GpStatus metafile_DrawBezier (GpGraphics *graphics, GpPen *pen, float x1, float y1, float x2, float y2, float x3, float y3, 
-	float x4, float y4) GDIP_INTERNAL;
-GpStatus metafile_DrawBezierI (GpGraphics *graphics, GpPen *pen, int x1, int y1, int x2, int y2, int x3, int y3, 
-	int x4, int y4) GDIP_INTERNAL;
 GpStatus metafile_DrawBeziers (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count) GDIP_INTERNAL;
-GpStatus metafile_DrawBeziersI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count) GDIP_INTERNAL;
 
 GpStatus metafile_DrawClosedCurve2 (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count, 
 	float tension) GDIP_INTERNAL;
-GpStatus metafile_DrawClosedCurve2I (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count, 
-	float tension) GDIP_INTERNAL;
 GpStatus metafile_FillClosedCurve2 (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *points, int count, 
-	float tension) GDIP_INTERNAL;
-GpStatus metafile_FillClosedCurve2I (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPoint *points, int count, 
 	float tension) GDIP_INTERNAL;
 GpStatus metafile_DrawCurve3 (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPointF *points, int count, int offset, 
 	int numOfSegments, float tension) GDIP_INTERNAL;
-GpStatus metafile_DrawCurve3I (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPoint *points, int count, int offset,
-	int numOfSegments, float tension) GDIP_INTERNAL;
 
 GpStatus metafile_DrawEllipse (GpGraphics *graphics, GpPen *pen, float x, float y, float width, float height) GDIP_INTERNAL;
-GpStatus metafile_DrawEllipseI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height) GDIP_INTERNAL;
 GpStatus metafile_FillEllipse (GpGraphics *graphics, GpBrush *brush, float x, float y, float width, float height) GDIP_INTERNAL;
-GpStatus metafile_FillEllipseI (GpGraphics *graphics, GpBrush *brush, int x, int y, int width, int height) GDIP_INTERNAL;
 
-GpStatus metafile_DrawLine (GpGraphics *graphics, GpPen *pen, float x1, float y1, float x2, float y2) GDIP_INTERNAL;
-GpStatus metafile_DrawLineI (GpGraphics *graphics, GpPen *pen, int x1, int y1, int x2, int y2) GDIP_INTERNAL;
 GpStatus metafile_DrawLines (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count) GDIP_INTERNAL;
-GpStatus metafile_DrawLinesI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count) GDIP_INTERNAL;
 
-GpStatus metafile_DrawRectangle (GpGraphics *graphics, GpPen *pen, float x, float y, float width, float height) GDIP_INTERNAL;
-GpStatus metafile_DrawRectangleI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height) GDIP_INTERNAL;
 GpStatus metafile_FillRectangle (GpGraphics *graphics, GpBrush *brush, float x, float y, float width, float height) GDIP_INTERNAL;
-GpStatus metafile_FillRectangleI (GpGraphics *graphics, GpBrush *brush, int x, int y, int width, int height) GDIP_INTERNAL;
 GpStatus metafile_DrawRectangles (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRectF *rects, int count) GDIP_INTERNAL;
-GpStatus metafile_DrawRectanglesI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRect *rects, int count) GDIP_INTERNAL;
 GpStatus metafile_FillRectangles (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpRectF *rects, int count) GDIP_INTERNAL;
-GpStatus metafile_FillRectanglesI (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpRect *rects, int count) GDIP_INTERNAL;
 
 GpStatus metafile_DrawPath (GpGraphics *graphics, GpPen *pen, GpPath *path) GDIP_INTERNAL;
 GpStatus metafile_FillPath (GpGraphics *graphics, GpBrush *brush, GpPath *path) GDIP_INTERNAL;
 
 GpStatus metafile_DrawPie (GpGraphics *graphics, GpPen *pen, float x, float y, float width, float height, 
 	float startAngle, float sweepAngle) GDIP_INTERNAL;
-GpStatus metafile_DrawPieI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height, 
-	float startAngle, float sweepAngle) GDIP_INTERNAL;
 GpStatus metafile_FillPie (GpGraphics *graphics, GpBrush *brush, float x, float y, float width, float height, 
-	float startAngle, float sweepAngle) GDIP_INTERNAL;
-GpStatus metafile_FillPieI (GpGraphics *graphics, GpBrush *brush, int x, int y, int width, int height, 
 	float startAngle, float sweepAngle) GDIP_INTERNAL;
 
 GpStatus metafile_DrawPolygon (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count) GDIP_INTERNAL;
-GpStatus metafile_DrawPolygonI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count) GDIP_INTERNAL;
 GpStatus metafile_FillPolygon (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *points, int count, 
-	FillMode fillMode) GDIP_INTERNAL;
-GpStatus metafile_FillPolygonI (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPoint *points, int count, 
 	FillMode fillMode) GDIP_INTERNAL;
 
 GpStatus metafile_FillRegion (GpGraphics *graphics, GpBrush *brush, GpRegion *region) GDIP_INTERNAL;

--- a/src/graphics-metafile.c
+++ b/src/graphics-metafile.c
@@ -57,24 +57,6 @@ GpRectArrayFitInInt16 (GDIPCONST GpRect *rects, int count)
 	return TRUE;
 }
 
-static GpRectF *
-convert_rects (GDIPCONST GpRect *rects, int count)
-{
-	int i;
-	GpRectF *result = (GpRectF *) GdipAlloc (sizeof (GpRectF) * count);
-	if (!result)
-		return NULL;
-
-	for (i = 0; i < count; i++) {
-			result [i].X = rects [i].X;
-			result [i].Y = rects [i].Y;
-			result [i].Width = rects [i].Width;
-			result [i].Height = rects [i].Height;
-	}
-
-	return result;
-}
-
 /* DrawArcs - http://www.aces.uiuc.edu/~jhtodd/Metafile/MetafileRecords/DrawArc.html */
 
 GpStatus
@@ -85,42 +67,10 @@ metafile_DrawArc (GpGraphics *graphics, GpPen *pen, float x, float y, float widt
 	return Ok;
 }
 
-GpStatus
-metafile_DrawArcI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height, float startAngle, float sweepAngle)
-{
-	/* every rectangle must fit into a INT16 or we must use the float version */
-	if (!RectFitInInt16 (x, y, width, height))
-		return metafile_DrawArc (graphics, pen, x, y, width, height, startAngle, sweepAngle);
-	/* TODO */
-	return Ok;
-}
-
 /* DrawBeziers - http://www.aces.uiuc.edu/~jhtodd/Metafile/MetafileRecords/DrawBeziers.html */
 
 GpStatus 
-metafile_DrawBezier (GpGraphics *graphics, GpPen *pen, float x1, float y1, float x2, float y2, float x3, float y3, 
-	float x4, float y4)
-{
-	/* TODO */
-	return Ok;
-}
-
-GpStatus
-metafile_DrawBezierI (GpGraphics *graphics, GpPen *pen, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4)
-{
-	/* TODO */
-	return Ok;
-}
-
-GpStatus 
 metafile_DrawBeziers (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count)
-{
-	/* TODO */
-	return Ok;
-}
-
-GpStatus
-metafile_DrawBeziersI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count)
 {
 	/* TODO */
 	return Ok;
@@ -137,26 +87,12 @@ metafile_DrawClosedCurve2 (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF 
 	return Ok;
 }
 
-GpStatus
-metafile_DrawClosedCurve2I (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count, float tension)
-{
-	/* TODO */
-	return Ok;
-}
-
 /*
  * FillClosedCurve - http://www.aces.uiuc.edu/~jhtodd/Metafile/MetafileRecords/FillClosedCurve.html
  */
 
 GpStatus
 metafile_FillClosedCurve2 (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *points, int count, float tension)
-{
-	/* TODO */
-	return Ok;
-}
-
-GpStatus
-metafile_FillClosedCurve2I (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPoint *points, int count, float tension)
 {
 	/* TODO */
 	return Ok;
@@ -174,14 +110,6 @@ metafile_DrawCurve3 (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPointF *point
 	return Ok;
 }
 
-GpStatus
-metafile_DrawCurve3I (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPoint *points, int count, int offset, int numOfSegments,
-	float tension)
-{
-	/* TODO */
-	return Ok;
-}
-
 /*
  * DrawEllipse - http://www.aces.uiuc.edu/~jhtodd/Metafile/MetafileRecords/DrawEllipse.html
  */
@@ -189,16 +117,6 @@ metafile_DrawCurve3I (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPoint *point
 GpStatus 
 metafile_DrawEllipse (GpGraphics *graphics, GpPen *pen, float x, float y, float width, float height)
 {	
-	/* TODO */
-	return Ok;
-}
-
-GpStatus
-metafile_DrawEllipseI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height)
-{
-	/* every rectangle must fit into a INT16 or we must use the float version */
-	if (!RectFitInInt16 (x, y, width, height))
-		return metafile_DrawEllipse (graphics, pen, x, y, width, height);
 	/* TODO */
 	return Ok;
 }
@@ -214,43 +132,12 @@ metafile_FillEllipse (GpGraphics *graphics, GpBrush *brush, float x, float y, fl
 	return Ok;
 }
 
-GpStatus
-metafile_FillEllipseI (GpGraphics *graphics, GpBrush *brush, int x, int y, int width, int height)
-{
-	/* every rectangle must fit into a INT16 or we must use the float version */
-	if (!RectFitInInt16 (x, y, width, height))
-		return metafile_FillEllipse (graphics, brush, x, y, width, height);
-	/* TODO */
-	return Ok;
-}
-
 /*
  * DrawLines - http://www.aces.uiuc.edu/~jhtodd/Metafile/MetafileRecords/DrawLines.html
  */
 
-GpStatus
-metafile_DrawLine (GpGraphics *graphics, GpPen *pen, float x1, float y1, float x2, float y2)
-{
-	/* TODO */
-	return Ok;
-}
-
-GpStatus
-metafile_DrawLineI (GpGraphics *graphics, GpPen *pen, int x1, int y1, int x2, int y2)
-{
-	/* TODO */
-	return Ok;
-}
-
 GpStatus 
 metafile_DrawLines (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count)
-{
-	/* TODO */
-	return Ok;
-}
-
-GpStatus
-metafile_DrawLinesI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count)
 {
 	/* TODO */
 	return Ok;
@@ -289,16 +176,6 @@ metafile_DrawPie (GpGraphics *graphics, GpPen *pen, float x, float y, float widt
 	return Ok;
 }
 
-GpStatus
-metafile_DrawPieI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height, float startAngle, float sweepAngle)
-{
-	/* every rectangle must fit into a INT16 or we must use the float version */
-	if (!RectFitInInt16 (x, y, width, height))
-		return metafile_DrawPie (graphics, pen, x, y, width, height, startAngle, sweepAngle);
-	/* TODO */
-	return Ok;
-}
-
 /*
  * FillPie - http://www.aces.uiuc.edu/~jhtodd/Metafile/MetafileRecords/FillPie.html
  */
@@ -311,30 +188,12 @@ metafile_FillPie (GpGraphics *graphics, GpBrush *brush, float x, float y, float 
 	return Ok;
 }
 
-GpStatus
-metafile_FillPieI (GpGraphics *graphics, GpBrush *brush, int x, int y, int width, int height, 
-	float startAngle, float sweepAngle)
-{
-	/* every rectangle must fit into a INT16 or we must use the float version */
-	if (!RectFitInInt16 (x, y, width, height))
-		return metafile_FillPie (graphics, brush, x, y, width, height, startAngle, sweepAngle);
-	/* TODO */
-	return Ok;
-}
-
 /*
  * DrawPolygon - ?
  */
 
 GpStatus
 metafile_DrawPolygon (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, int count)
-{
-	/* TODO */
-	return Ok;
-}
-
-GpStatus
-metafile_DrawPolygonI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, int count)
 {
 	/* TODO */
 	return Ok;
@@ -351,55 +210,13 @@ metafile_FillPolygon (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *
 	return Ok;
 }
 
-GpStatus
-metafile_FillPolygonI (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPoint *points, int count, FillMode fillMode)
-{
-	/* TODO */
-	return Ok;
-}
-
 /*
  * DrawRects - http://www.aces.uiuc.edu/~jhtodd/Metafile/MetafileRecords/DrawRects.html
  */
 
 GpStatus
-metafile_DrawRectangle (GpGraphics *graphics, GpPen *pen, float x, float y, float width, float height)
-{
-	/* TODO */
-	return Ok;
-}
-
-GpStatus
-metafile_DrawRectangleI (GpGraphics *graphics, GpPen *pen, int x, int y, int width, int height)
-{
-	/* every rectangle must fit into a INT16 or we must use the float version */
-	if (!RectFitInInt16 (x, y, width, height))
-		return metafile_DrawRectangleI (graphics, pen, x, y, width, height);
-	/* TODO */
-	return Ok;
-}
-
-GpStatus
 metafile_DrawRectangles (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRectF *rects, int count)
 {
-	/* TODO */
-	return Ok;
-}
-
-GpStatus
-metafile_DrawRectanglesI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRect *rects, int count)
-{
-	/* every rectangle must fit into a INT16 or we must use the float version */
-	if (!GpRectArrayFitInInt16 (rects, count)) {
-		GpStatus status;
-		GpRectF *rf = convert_rects (rects, count);
-		if (!rf)
-			return OutOfMemory;
-
-		status = metafile_DrawRectangles (graphics, pen, rf, count);
-		GdipFree (rf);
-		return status;
-	}
 	/* TODO */
 	return Ok;
 }
@@ -416,37 +233,8 @@ metafile_FillRectangle (GpGraphics *graphics, GpBrush *brush, float x, float y, 
 }
 
 GpStatus 
-metafile_FillRectangleI (GpGraphics *graphics, GpBrush *brush, int x, int y, int width, int height)
-{
-	/* every rectangle must fit into a INT16 or we must use the float version */
-	if (!RectFitInInt16 (x, y, width, height))
-		return metafile_FillRectangle (graphics, brush, x, y, width, height);
-	/* TODO */
-	return Ok;
-}
-
-GpStatus 
 metafile_FillRectangles (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpRectF *rects, int count)
 {
-	/* TODO */
-	return Ok;
-}
-
-GpStatus 
-metafile_FillRectanglesI (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpRect *rects, int count)
-{
-	/* every rectangle must fit into a INT16 or we must use the float version */
-	if (!GpRectArrayFitInInt16 (rects, count)) {
-		GpStatus status;
-		GpRectF *rf = convert_rects (rects, count);
-		if (!rf)
-			return OutOfMemory;
-
-		status = metafile_FillRectangles (graphics, brush, rf, count);
-		GdipFree (rf);
-		return status;
-	}
-
 	/* TODO */
 	return Ok;
 }

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -877,13 +877,20 @@ GdipDrawBeziers (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, I
 GpStatus WINGDIPAPI
 GdipDrawBeziersI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, INT count)
 {
+	GpStatus status;
 	GpPointF *pointsF;
 	
 	if (!points || count < 0)
 		return InvalidParameter;
 
 	pointsF = convert_points (points, count);
-	return GdipDrawBeziers (graphics, pen, pointsF, count);
+	if (!pointsF)
+		return OutOfMemory;
+
+	status = GdipDrawBeziers (graphics, pen, pointsF, count);
+
+	GdipFree (pointsF);
+	return status;
 }
 
 GpStatus WINGDIPAPI
@@ -943,12 +950,20 @@ GdipDrawLines (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, INT
 GpStatus WINGDIPAPI
 GdipDrawLinesI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, INT count)
 {
+	GpStatus status;
 	GpPointF *pointsF;
+
 	if (!points || count < 0)
 		return OutOfMemory;
 
 	pointsF = convert_points (points, count);
-	return GdipDrawLines (graphics, pen, pointsF, count);
+	if (!pointsF)
+		return OutOfMemory;
+
+	status = GdipDrawLines (graphics, pen, pointsF, count);
+
+	GdipFree (pointsF);
+	return status;
 }
 
 GpStatus WINGDIPAPI
@@ -1012,13 +1027,20 @@ GdipDrawPolygon (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *points, I
 GpStatus WINGDIPAPI
 GdipDrawPolygonI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, INT count)
 {
+	GpStatus status;
 	GpPointF *pointsF;
 
 	if (!points || count < 0)
 		return OutOfMemory;
 
 	pointsF = convert_points (points, count);
-	return GdipDrawPolygon (graphics, pen, pointsF, count);
+	if (!pointsF)
+		return OutOfMemory;
+
+	status = GdipDrawPolygon (graphics, pen, pointsF, count);
+
+	GdipFree (pointsF);
+	return status;
 }
 
 GpStatus WINGDIPAPI
@@ -1053,13 +1075,20 @@ GdipDrawRectangles (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRectF *rects, 
 GpStatus WINGDIPAPI
 GdipDrawRectanglesI (GpGraphics *graphics, GpPen *pen, GDIPCONST GpRect *rects, INT count)
 {
+	GpStatus status;
 	GpRectF *rectsF;
 
 	if (!rects || count < 0)
 		return InvalidParameter;
 	
 	rectsF = convert_rects (rects, count);
-	return GdipDrawRectangles (graphics, pen, rectsF, count);
+	if (!rectsF)
+		return OutOfMemory;
+
+	status = GdipDrawRectangles (graphics, pen, rectsF, count);
+
+	GdipFree (rectsF);
+	return status;
 }
 
 GpStatus WINGDIPAPI
@@ -1097,13 +1126,20 @@ GdipDrawClosedCurve2 (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPointF *poin
 GpStatus WINGDIPAPI
 GdipDrawClosedCurve2I (GpGraphics *graphics, GpPen *pen, GDIPCONST GpPoint *points, INT count, REAL tension)
 {
+	GpStatus status;
 	GpPointF *pointsF;
 
 	if (!points || count < 0)
 		return OutOfMemory;
 
 	pointsF = convert_points (points, count);
-	return GdipDrawClosedCurve2 (graphics, pen, pointsF, count, tension);
+	if (!pointsF)
+		return OutOfMemory;
+
+	status = GdipDrawClosedCurve2 (graphics, pen, pointsF, count, tension);
+
+	GdipFree (pointsF);
+	return status;
 }
 
 GpStatus WINGDIPAPI
@@ -1132,14 +1168,22 @@ GdipDrawCurve2 (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPointF *points, IN
 GpStatus WINGDIPAPI
 GdipDrawCurve2I (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPoint *points, INT count, REAL tension)
 {
+	GpStatus status;
 	GpPointF *pointsF;
+
 	if (count < 0)
 		return OutOfMemory;
 	if (!points)
 		return InvalidParameter;
 
 	pointsF = convert_points (points, count);
-	return GdipDrawCurve2 (graphics, pen, pointsF, count, tension);
+	if (!pointsF)
+		return OutOfMemory;
+
+	status = GdipDrawCurve2 (graphics, pen, pointsF, count, tension);
+
+	GdipFree (pointsF);
+	return status;
 }
 
 GpStatus WINGDIPAPI
@@ -1172,13 +1216,20 @@ GdipDrawCurve3 (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPointF *points, IN
 GpStatus WINGDIPAPI
 GdipDrawCurve3I (GpGraphics *graphics, GpPen* pen, GDIPCONST GpPoint *points, INT count, INT offset, INT numOfSegments, REAL tension)
 {
+	GpStatus status;
 	GpPointF *pointsF;
 
 	if (!points || count < 0)
 		return OutOfMemory;
 
 	pointsF = convert_points (points, count);
-	return GdipDrawCurve3 (graphics, pen, pointsF, count, offset, numOfSegments, tension);
+	if (!pointsF)
+		return OutOfMemory;
+
+	status = GdipDrawCurve3 (graphics, pen, pointsF, count, offset, numOfSegments, tension);
+
+	GdipFree (pointsF);
+	return status;
 }
 
 /*
@@ -1238,12 +1289,20 @@ GdipFillRectangles (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpRectF *rec
 GpStatus WINGDIPAPI
 GdipFillRectanglesI (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpRect *rects, INT count)
 {
+	GpStatus status;
 	GpRectF *rectsF;
+
 	if (!rects || count < 0)
 		return OutOfMemory;
 
 	rectsF = convert_rects (rects, count);
-	return GdipFillRectangles (graphics, brush, rectsF, count);
+	if (!rectsF)
+		return OutOfMemory;
+
+	status = GdipFillRectangles (graphics, brush, rectsF, count);
+
+	GdipFree (rectsF);
+	return status;
 }
 
 GpStatus WINGDIPAPI
@@ -1308,13 +1367,20 @@ GdipFillPolygon (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *point
 GpStatus WINGDIPAPI
 GdipFillPolygonI (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPoint *points, INT count, FillMode fillMode)
 {
+	GpStatus status;
 	GpPointF *pointsF;
 
 	if (!points || count < 0)
 		return OutOfMemory;	
 
 	pointsF = convert_points (points, count);
-	return GdipFillPolygon (graphics, brush, pointsF, count, fillMode);
+	if (!pointsF)
+		return OutOfMemory;
+
+	status = GdipFillPolygon (graphics, brush, pointsF, count, fillMode);
+
+	GdipFree (pointsF);
+	return status;
 }
 
 GpStatus WINGDIPAPI
@@ -1364,13 +1430,20 @@ GdipFillClosedCurve2 (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *
 GpStatus WINGDIPAPI
 GdipFillClosedCurve2I (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPoint *points, INT count, REAL tension)
 {
+	GpStatus status;
 	GpPointF *pointsF;
 
 	if (!points || count < 0)
 		return OutOfMemory;
 
 	pointsF = convert_points (points, count);
-	return GdipFillClosedCurve2 (graphics, brush, pointsF, count, tension);
+	if (!pointsF)
+		return OutOfMemory;
+
+	status = GdipFillClosedCurve2 (graphics, brush, pointsF, count, tension);
+
+	GdipFree (pointsF);
+	return status;
 }
 
 GpStatus WINGDIPAPI


### PR DESCRIPTION
- We can implement `Gdip{Draw/Fill}*I` functions in terms of `Gdip{Draw/Fill}`
- We can implement some single functions in terms of multiple functions (e.g.`Gdip{Draw/Fill}Rectangle` in terms of `Gdip{Draw/Fille}Rectangles`

This will also make it a lot easier to record data when metafile recording is implemented, as EMF+ records are only for the float/array versions of GDI+ draw/fill functions