### PR TITLE
Cleanup PathGradientBrush code and fix some compat bugs

### DIFF
--- a/src/general-private.h
+++ b/src/general-private.h
@@ -116,6 +116,8 @@ GpPointF *gdip_open_curve_tangents (int terms,  const GpPointF *points, int coun
 /* Conversion functions. */
 void gdip_RectF_from_Rect (const GpRect* rect, GpRectF* rectf) GDIP_INTERNAL;
 void gdip_Rect_from_RectF (const GpRectF* rectf, GpRect* rect) GDIP_INTERNAL;
+void gdip_PointF_from_Point (const GpPoint* point, GpPointF* pointf) GDIP_INTERNAL;
+void gdip_Point_from_PointF (const GpPointF* pointf, GpPoint* point) GDIP_INTERNAL;
 
 /* memory */
 void* gdip_realloc (void *org, int size) GDIP_INTERNAL;

--- a/src/general.c
+++ b/src/general.c
@@ -603,3 +603,15 @@ void gdip_Rect_from_RectF (const GpRectF* rectf, GpRect* rect)
 	rect->Width = iround (rectf->Width);
 	rect->Height = iround (rectf->Height);
 }
+
+void gdip_PointF_from_Point (const GpPoint* point, GpPointF* pointf)
+{
+	pointf->X = point->X;
+	pointf->Y = point->Y;
+}
+
+void gdip_Point_from_PointF (const GpPointF* pointf, GpPoint* point)
+{
+	point->X = iround (pointf->X);
+	point->Y = iround (pointf->Y);
+}

--- a/src/lineargradientbrush.c
+++ b/src/lineargradientbrush.c
@@ -99,7 +99,7 @@ gdip_linear_gradient_new (void)
 		GdipFree (result);
 	}
 
-	return result;
+	return NULL;
 }
 
 GpStatus
@@ -548,7 +548,6 @@ GdipCreateLineBrush (GDIPCONST GpPointF *point1, GDIPCONST GpPointF *point2, ARG
 	gdip_linear_gradient_setup_initial_matrix (linear);
 
 	*lineGradient = linear;
-
 	return Ok;
 }
 
@@ -643,7 +642,6 @@ GdipCreateLineBrushFromRectWithAngle (GDIPCONST GpRectF *rect, ARGB color1, ARGB
 	gdip_linear_gradient_setup_initial_matrix (linear);
 
 	*lineGradient = linear;
-
 	return Ok;
 }
 
@@ -654,7 +652,6 @@ GdipGetLineBlendCount (GpLineGradient *brush, int *count)
 		return InvalidParameter;
 
 	*count = brush->blend->count;
-
 	return Ok;
 }
 
@@ -707,7 +704,6 @@ GdipSetLineBlend (GpLineGradient *brush, GDIPCONST float *blend, GDIPCONST float
 	}
 
 	brush->base.changed = TRUE;
-
 	return Ok;
 }
 
@@ -927,7 +923,7 @@ GdipSetLineWrapMode (GpLineGradient *brush, GpWrapMode wrapMode)
 	if (!brush || (wrapMode == WrapModeClamp))
 		return InvalidParameter;
 
-	if (wrapMode < WrapModeTile || wrapMode > WrapModeClamp)
+	if (wrapMode > WrapModeClamp)
 		return Ok;
 
 	brush->wrapMode = wrapMode;

--- a/src/pathgradientbrush.c
+++ b/src/pathgradientbrush.c
@@ -664,8 +664,7 @@ GdipGetPathGradientCenterPointI (GpPathGradient *brush, GpPoint *point)
 	if (!brush || !point)
 		return InvalidParameter;
 
-	point->X = iround(brush->center.X);
-	point->Y = iround(brush->center.Y);
+	gdip_Point_from_PointF (&brush->center, point);
 	return Ok;
 }
 
@@ -684,13 +683,13 @@ GdipSetPathGradientCenterPoint (GpPathGradient *brush, GDIPCONST GpPointF *point
 GpStatus WINGDIPAPI
 GdipSetPathGradientCenterPointI (GpPathGradient *brush, GDIPCONST GpPoint *point)
 {
+	PointF pointF;
+
 	if (!brush || !point)
 		return InvalidParameter;
 
-	brush->center.X = (REAL)point->X;
-	brush->center.Y = (REAL)point->Y;
-	brush->base.changed = TRUE;
-	return Ok;
+	gdip_PointF_from_Point (point, &pointF);
+	return GdipSetPathGradientCenterPoint (brush, &pointF);
 }
 
 GpStatus WINGDIPAPI
@@ -760,7 +759,6 @@ GdipGetPathGradientBlendCount (GpPathGradient *brush, INT *count)
 		return InvalidParameter;
 	
 	*count = brush->blend->count;
-	
 	return Ok;
 }
 
@@ -1218,7 +1216,7 @@ GdipSetPathGradientWrapMode (GpPathGradient *brush, GpWrapMode wrapMode)
 	if (!brush)
 		return InvalidParameter;
 
-	if (wrapMode < WrapModeTile || wrapMode > WrapModeClamp)
+	if (wrapMode > WrapModeClamp)
 		return Ok;
 
 	brush->wrapMode = wrapMode;

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -30,6 +30,8 @@
 #define ATTRIBUTE_USED
 #endif
 
+#define ARRAY_SIZE(x) sizeof (x) / sizeof (*x)
+
 ATTRIBUTE_USED static BOOL floatsEqual(float v1, float v2)
 {
     if (isnan (v1))

--- a/tests/testlineargradientbrush.c
+++ b/tests/testlineargradientbrush.c
@@ -66,22 +66,86 @@ static void test_createLineBrush ()
 {
     GpStatus status;
     GpLineGradient *brush;
-    GpPointF point1 = { 1, 5 };
-    GpPointF point2 = { 2, 3 };
+    GpPointF point1 = {1, 5};
+    GpPointF point2 = {2, 3};
+    GpPointF topLeft = {1, 2};
+    GpPointF topCenter = {3, 2};
+    GpPointF topRight = {5, 2};
+    GpPointF middleLeft = {1, 4};
+    GpPointF middleCenter = {3, 4};
+    GpPointF middleRight = {5, 4};
+    GpPointF bottomLeft = {1, 6};
+    GpPointF bottomCenter = {3, 6};
+    GpPointF bottomRight = {5, 6};
 
+    // WrapModeTile.
     status = GdipCreateLineBrush (&point1, &point2, 10, 11, WrapModeTile, &brush);
     assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTile, 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
     GdipDeleteBrush ((GpBrush *) brush);
 
-    status = GdipCreateLineBrush (&point2, &point1, 10, 11, (WrapMode)(WrapModeTile - 1), &brush);
+    // WrapModeTileFlipX.
+    status = GdipCreateLineBrush (&point1, &point2, 10, 11, WrapModeTileFlipX, &brush);
     assertEqualInt (status, Ok);
-    verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeTile - 1), -1, 2, -0.8f, -0.4f, 6.2f, 2.6f);
+    verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipX, 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
     GdipDeleteBrush ((GpBrush *) brush);
 
+    // WrapModeTileFlipY.
+    status = GdipCreateLineBrush (&point1, &point2, 10, 11, WrapModeTileFlipY, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipY, 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
+    GdipDeleteBrush ((GpBrush *) brush);
+
+    // WrapModeTileFlipXY
+    status = GdipCreateLineBrush (&point1, &point2, 10, 11, WrapModeTileFlipXY, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipXY, 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
+    GdipDeleteBrush ((GpBrush *) brush);
+
+    // Invalid WrapMode.
     status = GdipCreateLineBrush (&point1, &point2, 10, 11, (WrapMode)(WrapModeClamp + 1), &brush);
     assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
+
+    // point1.X > point2.X, point1.Y == point2.Y
+    status = GdipCreateLineBrush (&middleCenter, &middleLeft, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 1, 3, 2, 2, 10, 11, WrapModeTile, -1, 0, 0, -1, 4, 8);
+
+    // point1.X > point2.X, point1.Y > point2.Y
+    status = GdipCreateLineBrush (&middleCenter, &topLeft, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 1, 2, 2, 2, 10, 11, WrapModeTile, -1, -1, 1, -1, 1, 8);
+
+    // point1.X == point2.X, point1.Y > point2.Y
+    status = GdipCreateLineBrush (&middleCenter, &topCenter, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 2, 2, 2, 2, 10, 11, WrapModeTile, 0, -1, 1, 0, 0, 6);
+
+    // point1.X < point2.X, point1.Y > point2.Y
+    status = GdipCreateLineBrush (&middleCenter, &topRight, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 3, 2, 2, 2, 10, 11, WrapModeTile, 1, -1, 1, 1, -3, 4);
+
+    // point1.X < point2.X, point1.Y == point2.Y
+    status = GdipCreateLineBrush (&middleCenter, &middleRight, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 3, 3, 2, 2, 10, 11, WrapModeTile, 1, 0, 0, 1, 0, 0);
+
+    // point1.X < point2.X, point1.Y < point2.Y
+    status = GdipCreateLineBrush (&middleCenter, &bottomRight, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 3, 4, 2, 2, 10, 11, WrapModeTile, 1, 1, -1, 1, 5, -4);
+
+    // point1.X == point2.X, point1.Y < point2.Y
+    status = GdipCreateLineBrush (&middleCenter, &bottomCenter, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 2, 4, 2, 2, 10, 11, WrapModeTile, -0, 1, -1, -0, 8, 2);
+
+    // point1.X > point2.X, point1.Y < point2.Y
+    status = GdipCreateLineBrush (&middleCenter, &bottomLeft, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 1, 4, 2, 2, 10, 11, WrapModeTile, -1, 1, -1, -1, 9, 8);
 
     // Negative tests.
     status = GdipCreateLineBrush (NULL, &point2, 10, 11, WrapModeTile, &brush);
@@ -103,22 +167,86 @@ static void test_createLineBrushI ()
 {
     GpStatus status;
     GpLineGradient *brush;
-    GpPoint point1 = { 1, 5 };
-    GpPoint point2 = { 2, 3 };
+    GpPoint point1 = {1, 5};
+    GpPoint point2 = {2, 3};
+    GpPoint topLeft = {1, 2};
+    GpPoint topCenter = {3, 2};
+    GpPoint topRight = {5, 2};
+    GpPoint middleLeft = {1, 4};
+    GpPoint middleCenter = {3, 4};
+    GpPoint middleRight = {5, 4};
+    GpPoint bottomLeft = {1, 6};
+    GpPoint bottomCenter = {3, 6};
+    GpPoint bottomRight = {5, 6};
 
+    // WrapModeTile.
     status = GdipCreateLineBrushI (&point1, &point2, 10, 11, WrapModeTile, &brush);
     assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTile, 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
     GdipDeleteBrush ((GpBrush *) brush);
 
-    status = GdipCreateLineBrushI (&point2, &point1, 10, 11, (WrapMode)(WrapModeTile - 1), &brush);
+    // WrapModeTileFlipX.
+    status = GdipCreateLineBrushI (&point1, &point2, 10, 11, WrapModeTileFlipX, &brush);
     assertEqualInt (status, Ok);
-    verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeTile - 1), -1, 2, -0.8f, -0.4f, 6.2f, 2.6f);
+    verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipX, 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
     GdipDeleteBrush ((GpBrush *) brush);
 
+    // WrapModeTileFlipY.
+    status = GdipCreateLineBrushI (&point1, &point2, 10, 11, WrapModeTileFlipY, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipY, 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
+    GdipDeleteBrush ((GpBrush *) brush);
+
+    // WrapModeTileFlipXY
+    status = GdipCreateLineBrushI (&point1, &point2, 10, 11, WrapModeTileFlipXY, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipXY, 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
+    GdipDeleteBrush ((GpBrush *) brush);
+
+    // Invalid WrapMode.
     status = GdipCreateLineBrushI (&point1, &point2, 10, 11, (WrapMode)(WrapModeClamp + 1), &brush);
     assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
+
+    // point1.X > point2.X, point1.Y == point2.Y
+    status = GdipCreateLineBrushI (&middleCenter, &middleLeft, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 1, 3, 2, 2, 10, 11, WrapModeTile, -1, 0, 0, -1, 4, 8);
+
+    // point1.X > point2.X, point1.Y > point2.Y
+    status = GdipCreateLineBrushI (&middleCenter, &topLeft, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 1, 2, 2, 2, 10, 11, WrapModeTile, -1, -1, 1, -1, 1, 8);
+
+    // point1.X == point2.X, point1.Y > point2.Y
+    status = GdipCreateLineBrushI (&middleCenter, &topCenter, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 2, 2, 2, 2, 10, 11, WrapModeTile, 0, -1, 1, 0, 0, 6);
+
+    // point1.X < point2.X, point1.Y > point2.Y
+    status = GdipCreateLineBrushI (&middleCenter, &topRight, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 3, 2, 2, 2, 10, 11, WrapModeTile, 1, -1, 1, 1, -3, 4);
+
+    // point1.X < point2.X, point1.Y == point2.Y
+    status = GdipCreateLineBrushI (&middleCenter, &middleRight, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 3, 3, 2, 2, 10, 11, WrapModeTile, 1, 0, 0, 1, 0, 0);
+
+    // point1.X < point2.X, point1.Y < point2.Y
+    status = GdipCreateLineBrushI (&middleCenter, &bottomRight, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 3, 4, 2, 2, 10, 11, WrapModeTile, 1, 1, -1, 1, 5, -4);
+
+    // point1.X == point2.X, point1.Y < point2.Y
+    status = GdipCreateLineBrushI (&middleCenter, &bottomCenter, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 2, 4, 2, 2, 10, 11, WrapModeTile, -0, 1, -1, -0, 8, 2);
+
+    // point1.X > point2.X, point1.Y < point2.Y
+    status = GdipCreateLineBrushI (&middleCenter, &bottomLeft, 10, 11, WrapModeTile, &brush);
+    assertEqualInt (status, Ok);
+    verifyLineGradientBrush (brush, 1, 4, 2, 2, 10, 11, WrapModeTile, -1, 1, -1, -1, 9, 8);
 
     // Negative tests.
     status = GdipCreateLineBrushI (NULL, &point2, 10, 11, WrapModeTile, &brush);
@@ -983,25 +1111,42 @@ static void test_setLineWrapMode ()
 
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTileFlipY, &brush);
 
+    // WrapModeTile.
+    status = GdipSetLineWrapMode (brush, WrapModeTile);
+    assertEqualInt (status, Ok);
+
+    GdipGetLineWrapMode (brush, &wrapMode);
+    assertEqualInt (wrapMode, WrapModeTile);
+
+    // WrapModeTileFlipX.
+    status = GdipSetLineWrapMode (brush, WrapModeTileFlipX);
+    assertEqualInt (status, Ok);
+
+    GdipGetLineWrapMode (brush, &wrapMode);
+    assertEqualInt (wrapMode, WrapModeTileFlipX);
+
+    // WrapModeTileFlipY.
     status = GdipSetLineWrapMode (brush, WrapModeTileFlipY);
     assertEqualInt (status, Ok);
 
     GdipGetLineWrapMode (brush, &wrapMode);
     assertEqualInt (wrapMode, WrapModeTileFlipY);
 
-    status = GdipSetLineWrapMode (brush, (WrapMode)(WrapModeTile - 1));
+    // WrapModeTileFlipXY.
+    status = GdipSetLineWrapMode (brush, WrapModeTileFlipXY);
     assertEqualInt (status, Ok);
 
     GdipGetLineWrapMode (brush, &wrapMode);
-    assertEqualInt (wrapMode, WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeTileFlipXY);
 
+    // Invalid WrapMode - nop.
     status = GdipSetLineWrapMode (brush, (WrapMode)(WrapModeClamp + 1));
     assertEqualInt (status, Ok);
 
-    // Negative tests.
     GdipGetLineWrapMode (brush, &wrapMode);
-    assertEqualInt (wrapMode, WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeTileFlipXY);
 
+    // Negative tests.
     status = GdipSetLineWrapMode (NULL, WrapModeTile);
     assertEqualInt (status, InvalidParameter);
 
@@ -1057,10 +1202,12 @@ static void test_setLineTransform ()
     GpLineGradient *brush;
     GpRectF rect = { 1, 3, 1, 2 };
     GpMatrix *matrix;
+    GpMatrix *nonInvertibleMatrix;
     GpMatrix *transform;
 
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTileFlipY, &brush);
     GdipCreateMatrix2 (1, 2, 3, 4, 5, 6, &matrix);
+    GdipCreateMatrix2 (123, 24, 82, 16, 47, 30, &nonInvertibleMatrix);
     GdipCreateMatrix (&transform);
 
     status = GdipSetLineTransform (brush, matrix);
@@ -1082,8 +1229,12 @@ static void test_setLineTransform ()
     status = GdipSetLineTransform (brush, NULL);
     assertEqualInt (status, InvalidParameter);
 
+    status = GdipSetLineTransform (brush, nonInvertibleMatrix);
+    assertEqualInt (status, InvalidParameter);
+
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (matrix);
+    GdipDeleteMatrix (nonInvertibleMatrix);
     GdipDeleteMatrix (transform);
 }
 

--- a/tests/testlineargradientbrush.c
+++ b/tests/testlineargradientbrush.c
@@ -83,6 +83,7 @@ static void test_createLineBrush ()
     assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
 
+    // Negative tests.
     status = GdipCreateLineBrush (NULL, &point2, 10, 11, WrapModeTile, &brush);
     assertEqualInt (status, InvalidParameter);
 
@@ -119,6 +120,7 @@ static void test_createLineBrushI ()
     assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, (WrapMode)(WrapModeClamp + 1), 1, -2, 0.8f, 0.4f, -3.2f, 5.4f);
 
+    // Negative tests.
     status = GdipCreateLineBrushI (NULL, &point2, 10, 11, WrapModeTile, &brush);
     assertEqualInt (status, InvalidParameter);
 
@@ -160,6 +162,7 @@ static void test_createLineBrushFromRect ()
     assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipX, 0, 2, -0.5, 0, 3.5, 1);
 
+    // Negative tests.
     status = GdipCreateLineBrushFromRect (NULL, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
     assertEqualInt (status, InvalidParameter);
 
@@ -287,6 +290,7 @@ static void test_createLineBrushFromRectWithAngle ()
     assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipX, 0, 2, -0.5, 0, 3.5, 1);
 
+    // Negative tests.
     status = GdipCreateLineBrushFromRectWithAngle (NULL, 10, 11, 90, TRUE, WrapModeTile, &brush);
     assertEqualInt (status, InvalidParameter);
 
@@ -343,6 +347,7 @@ static void test_createLineBrushFromRectWithAngleI ()
     assertEqualInt (status, Ok);
     verifyLineGradientBrush (brush, 1, 3, 1, 2, 10, 11, WrapModeTileFlipX, 0, 2, -0.5, 0, 3.5, 1);
 
+    // Negative tests.
     status = GdipCreateLineBrushFromRectWithAngleI (NULL, 10, 11, 90, TRUE, WrapModeTile, &brush);
     assertEqualInt (status, InvalidParameter);
 
@@ -379,6 +384,7 @@ static void test_setLineColors ()
     assertEqualInt (colors[0], 1);
     assertEqualInt (colors[1], 2);
 
+    // Negative tests.
     status = GdipSetLineColors (NULL, 1, 2);
     assertEqualInt (status, InvalidParameter);
 
@@ -394,6 +400,7 @@ static void test_getLineColors ()
 
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
+    // Negative tests.
     status = GdipGetLineColors (NULL, colors);
     assertEqualInt (status, InvalidParameter);
 
@@ -412,6 +419,7 @@ static void test_getLineRect ()
 
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
+    // Negative tests.
     status = GdipGetLineRect (NULL, &lineRect);
     assertEqualInt (status, InvalidParameter);
 
@@ -433,10 +441,10 @@ static void test_getLineRectI ()
 
     status = GdipGetLineRectI (brush, &lineRect);
     assertEqualInt (status, Ok);
-    assertEqualFloat (lineRect.X, 1);
-    assertEqualFloat (lineRect.Y, 3);
-    assertEqualFloat (lineRect.Width, 1);
-    assertEqualFloat (lineRect.Height, 2);
+    assertEqualInt (lineRect.X, 1);
+    assertEqualInt (lineRect.Y, 3);
+    assertEqualInt (lineRect.Width, 1);
+    assertEqualInt (lineRect.Height, 2);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
@@ -446,10 +454,10 @@ static void test_getLineRectI ()
 
     status = GdipGetLineRectI (brush, &lineRect);
     assertEqualInt (status, Ok);
-    assertEqualFloat (lineRect.X, 2);
-    assertEqualFloat (lineRect.Y, 4);
-    assertEqualFloat (lineRect.Width, 2);
-    assertEqualFloat (lineRect.Height, 3);
+    assertEqualInt (lineRect.X, 2);
+    assertEqualInt (lineRect.Y, 4);
+    assertEqualInt (lineRect.Width, 2);
+    assertEqualInt (lineRect.Height, 3);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
@@ -459,10 +467,10 @@ static void test_getLineRectI ()
 
     status = GdipGetLineRectI (brush, &lineRect);
     assertEqualInt (status, Ok);
-    assertEqualFloat (lineRect.X, 2);
-    assertEqualFloat (lineRect.Y, 4);
-    assertEqualFloat (lineRect.Width, 2);
-    assertEqualFloat (lineRect.Height, 3);
+    assertEqualInt (lineRect.X, 2);
+    assertEqualInt (lineRect.Y, 4);
+    assertEqualInt (lineRect.Width, 2);
+    assertEqualInt (lineRect.Height, 3);
 
     GdipDeleteBrush ((GpBrush *) brush);
 
@@ -472,10 +480,10 @@ static void test_getLineRectI ()
 
     status = GdipGetLineRectI (brush, &lineRect);
     assertEqualInt (status, Ok);
-    assertEqualFloat (lineRect.X, 1);
-    assertEqualFloat (lineRect.Y, 3);
-    assertEqualFloat (lineRect.Width, 1);
-    assertEqualFloat (lineRect.Height, 2);
+    assertEqualInt (lineRect.X, 1);
+    assertEqualInt (lineRect.Y, 3);
+    assertEqualInt (lineRect.Width, 1);
+    assertEqualInt (lineRect.Height, 2);
 
     // Negative tests.
     status = GdipGetLineRectI (NULL, &lineRect);
@@ -502,6 +510,7 @@ static void test_setLineGammaCorrection ()
     GdipGetLineGammaCorrection (brush, &useGammaCorrection);
     assert (useGammaCorrection == TRUE);
 
+    // Negative tests.
     status = GdipSetLineGammaCorrection (NULL, TRUE);
     assertEqualInt (status, InvalidParameter);
 
@@ -521,6 +530,7 @@ static void test_getLineGammaCorrection ()
     assertEqualInt (status, Ok);
     assert (useGammaCorrection == FALSE);
 
+    // Negative tests.
     status = GdipGetLineGammaCorrection (NULL, &useGammaCorrection);
     assertEqualInt (status, InvalidParameter);
 
@@ -543,6 +553,7 @@ static void test_getLineBlendCount ()
     assertEqualInt (status, Ok);
     assertEqualInt (blendCount, 1);
 
+    // Negative tests.
     status = GdipGetLineBlendCount (NULL, &blendCount);
     assertEqualInt (status, InvalidParameter);
 
@@ -552,39 +563,52 @@ static void test_getLineBlendCount ()
     GdipDeleteBrush ((GpBrush *) brush);
 }
 
+static void fill_array (REAL *array, INT count, REAL value)
+{
+    for (int i = 0; i < count; i++)
+        array[i] = value;
+}
+
 static void test_getLineBlend ()
 {
     GpStatus status;
     GpLineGradient *brush;
+    REAL blend[3];
+    REAL positions[3];
     GpRectF rect = { 1, 3, 1, 2 };
-    REAL blend[2];
-    REAL positions[2];
-    REAL largeBlend[3] = { 1, 2, 3 };
-    REAL largePositions[3] = { 0, 0.5, 1 };
+    REAL threeBlends[3] = {1, 2, 3};
+    REAL threePositions[3] = {0, 0.5, 1};
 
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
+    // Default blend - equal count.
+    fill_array (blend, ARRAY_SIZE (blend), 123);
+    fill_array (positions, ARRAY_SIZE (positions), 123);
     status = GdipGetLineBlend (brush, blend, positions, 1);
     assertEqualInt (status, Ok);
     assertEqualFloat (blend[0], 1);
-    // It appears that Windows 10+ versions of GDI+ don't copy anything to positions.
-    // This is a GDI+ bug we don't want to replicate.
-#if !defined(USE_WINDOWS_GDIPLUS)
-    assertEqualFloat (positions[0], 0);
-#endif
+    assertEqualFloat (blend[1], 123);
+    assertEqualFloat (blend[2], 123);
+    // Positions are meaningless for blends with a count of 1 so this parameter is ignored.
+    assertEqualFloat (positions[0], 123);
+    assertEqualFloat (positions[1], 123);
+    assertEqualFloat (positions[2], 123);
 
+    // Default blend - larger count.
+    fill_array (blend, ARRAY_SIZE (blend), 123);
+    fill_array (positions, ARRAY_SIZE (positions), 123);
     status = GdipGetLineBlend (brush, blend, positions, 2);
     assertEqualInt (status, Ok);
-    assertEqualFloat (blend[0], 1.0);
-    // It appears that Windows 10+ versions of GDI+ don't copy anything to positions.
-    // This is a GDI+ bug we don't want to replicate.
-    #if !defined(USE_WINDOWS_GDIPLUS)
-    assertEqualFloat (positions[0], 0);
-#endif
+    assertEqualFloat (blend[0], 1);
+    assertEqualFloat (blend[1], 123);
+    assertEqualFloat (blend[2], 123);
+    // Positions are meaningless for blends with a count of 1 so this parameter is ignored.
+    assertEqualFloat (positions[0], 123);
+    assertEqualFloat (positions[1], 123);
+    assertEqualFloat (positions[2], 123);
 
-    status = GdipSetLineBlend (brush, largeBlend, largePositions, 3);
-    assertEqualInt (status, Ok);
-
+    // Negative tests.
+    GdipSetLineBlend (brush, threeBlends, threePositions, 3);
     status = GdipGetLineBlend (brush, blend, positions, 1);
     assertEqualInt (status, InsufficientBuffer);
 
@@ -612,72 +636,74 @@ static void test_setLineBlend ()
     GpLineGradient *brush;
     GpRectF rect = { 1, 3, 1, 2 };
 
-    REAL blend1[1] = { 3 };
-    REAL positions1[1] = { -12 };
-    REAL destBlend1[1];
-    REAL destPositions1[1];
-
-    REAL blend2[2] = { -1, 0 };
-    REAL positions2[2] = { 0, 1.0f };
-    REAL destBlend2[2];
-    REAL destPositions2[2];
-
-    REAL blend3[3] = { 1, 2, 3 };
-    REAL positions3[3] = { 0, 0.5f, 1.0f };
-    REAL destBlend3[3];
-    REAL destPositions3[3];
-
-    REAL invalidPositions1[2] = { 0.5, 1 };
-    REAL invalidPositions2[2] = { 0, 0.5 };
-
-    ARGB linePresetBlend[3] = { 1, 2, 3 };
-    REAL linePresetPositions[3] = { 0, 0.5f, 1.0f };
+    REAL blend[3]= {1, 2, 3};
+    REAL positions[3] = {0, 0.5f, 1.0f};
+    REAL twoBlends[2] = {1, 2};
+    REAL twoPositions[2] = {0, 1};
+    REAL threeBlends[3] = {1, 2, 3};
+    REAL threePositions[3] = {0, 0.5, 1};
+    REAL oneBlend[1] = {10};
+    REAL onePosition[1] = {-12};
+    ARGB pathPresetBlend[3] = {1, 2, 3};
+    REAL pathPresetPositions[3] = {0, 0.5f, 1.0f};
     INT presetBlendCount;
+
+    REAL invalidPositions1[2] = {0.5, 1};
+    REAL invalidPositions2[2] = {0, 0.5};
 
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
-    // Count of 1.
-    status = GdipSetLineBlend (brush, blend1, positions1, 1);
+    
+    // Two blends - equal count.
+    status = GdipSetLineBlend (brush, twoBlends, twoPositions, 2);
     assertEqualInt (status, Ok);
 
-    status = GdipGetLineBlend (brush, destBlend1, destPositions1, 1);
+    fill_array (blend, ARRAY_SIZE (blend), 123);
+    fill_array (positions, ARRAY_SIZE (positions), 123);
+    status = GdipGetLineBlend (brush, blend, positions, 2);
     assertEqualInt (status, Ok);
-    assertEqualFloat (destBlend1[0], 3);
-    // It appears GDI+ ignores the position value if there is a single element.
-    // This is a GDI+ bug we don't want to replicate.
-#if !defined(USE_WINDOWS_GDIPLUS)
-    assertEqualFloat (destPositions1[0], -12);
-#endif
+    assertEqualFloat (blend[0], 1);
+    assertEqualFloat (blend[1], 2);
+    assertEqualFloat (blend[2], 123);
+    assertEqualFloat (positions[0], 0);
+    assertEqualFloat (positions[1], 1);
+    assertEqualFloat (positions[2], 123);
 
-    // Count of 2.
-    status = GdipSetLineBlend (brush, blend2, positions2, 2);
-    assertEqualInt (status, Ok);
-
-    status = GdipGetLineBlend (brush, destBlend2, destPositions2, 2);
-    assertEqualInt (status, Ok);
-    assertEqualFloat (destBlend2[0], -1);
-    assertEqualFloat (destBlend2[1], 0);
-    assertEqualFloat (destPositions2[0], 0);
-    assertEqualFloat (destPositions2[1], 1);
-
-    // Count of 3.
-    status = GdipSetLineBlend (brush, blend3, positions3, 3);
+    // Three blends - equal count.
+    status = GdipSetLineBlend (brush, threeBlends, threePositions, 3);
     assertEqualInt (status, Ok);
 
-    status = GdipGetLineBlend (brush, destBlend3, destPositions3, 3);
+    fill_array (blend, ARRAY_SIZE (blend), 123);
+    fill_array (positions, ARRAY_SIZE (positions), 123);
+    status = GdipGetLineBlend (brush, blend, positions, 3);
     assertEqualInt (status, Ok);
-    assertEqualFloat (destBlend3[0], 1);
-    assertEqualFloat (destBlend3[1], 2);
-    assertEqualFloat (destBlend3[2], 3);
-    assertEqualFloat (destPositions3[0], 0);
-    assertEqualFloat (destPositions3[1], 0.5);
-    assertEqualFloat (destPositions3[2], 1);
+    assertEqualFloat (blend[0], 1);
+    assertEqualFloat (blend[1], 2);
+    assertEqualFloat (blend[2], 3);
+    assertEqualFloat (positions[0], 0);
+    assertEqualFloat (positions[1], 0.5);
+    assertEqualFloat (positions[2], 1);
+
+    // One blend - equal count.
+    status = GdipSetLineBlend (brush, oneBlend, onePosition, 1);
+    assertEqualInt (status, Ok);
+
+    fill_array (blend, ARRAY_SIZE (blend), 123);
+    fill_array (positions, ARRAY_SIZE (positions), 123);
+    status = GdipGetLineBlend (brush, blend, positions, 1);
+    assertEqualInt (status, Ok);
+    assertEqualFloat (blend[0], 10);
+    assertEqualFloat (blend[1], 123);
+    assertEqualFloat (blend[2], 123);
+    assertEqualFloat (positions[0], 123);
+    assertEqualFloat (positions[1], 123);
+    assertEqualFloat (positions[2], 123);
 
     // Should clear the existing blend.
-    status = GdipSetLinePresetBlend (brush, linePresetBlend, linePresetPositions, 3);
+    status = GdipSetLinePresetBlend (brush, pathPresetBlend, pathPresetPositions, 3);
     assertEqualInt (status, Ok);
 
-    status = GdipSetLineBlend (brush, destBlend2, destPositions2, 2);
+    status = GdipSetLineBlend (brush, threeBlends, threePositions, 3);
     assertEqualInt (status, Ok);
 
     status = GdipGetLinePresetBlendCount (brush, &presetBlendCount);
@@ -685,25 +711,25 @@ static void test_setLineBlend ()
     assertEqualInt (presetBlendCount, 0);
 
     // Negative tests.
-    status = GdipSetLineBlend (NULL, blend3, positions3, 3);
+    status = GdipSetLineBlend (NULL, threeBlends, threePositions, 3);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetLineBlend (brush, NULL, positions3, 3);
+    status = GdipSetLineBlend (brush, NULL, threePositions, 3);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetLineBlend (brush, blend3, NULL, 3);
+    status = GdipSetLineBlend (brush, threeBlends, NULL, 2);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetLineBlend (brush, blend2, invalidPositions1, 2);
+    status = GdipSetLineBlend (brush, twoBlends, invalidPositions1, 2);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetLineBlend (brush, blend2, invalidPositions2, 2);
+    status = GdipSetLineBlend (brush, twoBlends, invalidPositions2, 2);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetLineBlend (brush, blend3, positions3, 0);
+    status = GdipSetLineBlend (brush, threeBlends, threePositions, 0);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetLineBlend (brush, blend3, positions3, -1);
+    status = GdipSetLineBlend (brush, threeBlends, threePositions, -1);
     assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
@@ -741,6 +767,7 @@ static void test_getLinePresetBlend ()
 
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTile, &brush);
 
+    // Negative tests.
     status = GdipGetLinePresetBlend (brush, blend, positions, 2);
     assertEqualInt (status, GenericError);
 
@@ -760,6 +787,15 @@ static void test_getLinePresetBlend ()
     assertEqualInt (status, InvalidParameter);
 
     status = GdipGetLinePresetBlend (brush, blend, positions, -1);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipGetLinePresetBlend (NULL, blend, positions, -1);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipGetLinePresetBlend (brush, NULL, positions, -1);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipGetLinePresetBlend (brush, blend, NULL, -1);
     assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
@@ -883,6 +919,7 @@ static void test_setLineSigmaBlend ()
     status = GdipSetLineSigmaBlend (brush, 1, 0);
     assertEqualInt (status, Ok);
 
+    // Negative tests.
     status = GdipSetLineSigmaBlend (NULL, 0.5f, 0.5f);
     assertEqualInt (status, InvalidParameter);
 
@@ -918,6 +955,7 @@ static void test_setLineLinearBlend ()
     status = GdipSetLineLinearBlend (brush, 1, 0);
     assertEqualInt (status, Ok);
 
+    // Negative tests.
     status = GdipSetLineLinearBlend (NULL, 0.5f, 0.5f);
     assertEqualInt (status, InvalidParameter);
 
@@ -960,6 +998,7 @@ static void test_setLineWrapMode ()
     status = GdipSetLineWrapMode (brush, (WrapMode)(WrapModeClamp + 1));
     assertEqualInt (status, Ok);
 
+    // Negative tests.
     GdipGetLineWrapMode (brush, &wrapMode);
     assertEqualInt (wrapMode, WrapModeTileFlipY);
 
@@ -981,6 +1020,7 @@ static void test_getLineWrapMode ()
 
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTileFlipY, &brush);
 
+    // Negative tests.
     status = GdipGetLineWrapMode (NULL, &wrapMode);
     assertEqualInt (status, InvalidParameter);
 
@@ -1000,6 +1040,7 @@ static void test_getLineTransform ()
     GdipCreateLineBrushFromRect (&rect, 10, 11, LinearGradientModeHorizontal, WrapModeTileFlipY, &brush);
     GdipCreateMatrix (&transform);
 
+    // Negative tests.
     status = GdipGetLineTransform (NULL, transform);
     assertEqualInt (status, InvalidParameter);
 
@@ -1066,6 +1107,7 @@ static void test_resetLineTransform ()
     GdipGetLineTransform (brush, transform);
     verifyMatrix (transform, 1, 0, 0, 1, 0, 0);
 
+    // Negative tests.
     status = GdipResetLineTransform (NULL);
     assertEqualInt (status, InvalidParameter);
 

--- a/tests/testpathgradientbrush.c
+++ b/tests/testpathgradientbrush.c
@@ -1313,23 +1313,47 @@ static void test_setPathGradientWrapMode ()
 
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
+    // WrapModeTile.
+    status = GdipSetPathGradientWrapMode (brush, WrapModeTile);
+    assertEqualInt (status, Ok);
+
+    GdipGetPathGradientWrapMode (brush, &wrapMode);
+    assertEqualInt (wrapMode, WrapModeTile);
+
+    // WrapModeTileFlipX.
+    status = GdipSetPathGradientWrapMode (brush, WrapModeTileFlipX);
+    assertEqualInt (status, Ok);
+
+    GdipGetPathGradientWrapMode (brush, &wrapMode);
+    assertEqualInt (wrapMode, WrapModeTileFlipX);
+
+    // WrapModeTileFlipX.
     status = GdipSetPathGradientWrapMode (brush, WrapModeTileFlipY);
     assertEqualInt (status, Ok);
 
     GdipGetPathGradientWrapMode (brush, &wrapMode);
     assertEqualInt (wrapMode, WrapModeTileFlipY);
 
-    status = GdipSetPathGradientWrapMode (brush, (WrapMode)(WrapModeTile - 1));
+    // WrapModeTileFlipXY.
+    status = GdipSetPathGradientWrapMode (brush, WrapModeTileFlipXY);
     assertEqualInt (status, Ok);
 
     GdipGetPathGradientWrapMode (brush, &wrapMode);
-    assertEqualInt (wrapMode, WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeTileFlipXY);
 
+    // WrapModeClamp.
+    status = GdipSetPathGradientWrapMode (brush, WrapModeClamp);
+    assertEqualInt (status, Ok);
+
+    GdipGetPathGradientWrapMode (brush, &wrapMode);
+    assertEqualInt (wrapMode, WrapModeClamp);
+
+    // Invalid WrapMode - nop.
     status = GdipSetPathGradientWrapMode (brush, (WrapMode)(WrapModeClamp + 1));
     assertEqualInt (status, Ok);
 
     GdipGetPathGradientWrapMode (brush, &wrapMode);
-    assertEqualInt (wrapMode, WrapModeTileFlipY);
+    assertEqualInt (wrapMode, WrapModeClamp);
 
     // Negative tests.
     status = GdipSetPathGradientWrapMode (NULL, WrapModeTile);
@@ -1363,10 +1387,12 @@ static void test_setPathGradientTransform ()
     GpStatus status;
     GpPathGradient *brush;
     GpMatrix *matrix;
+    GpMatrix *nonInvertibleMatrix;
     GpMatrix *transform;
 
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
     GdipCreateMatrix2 (1, 2, 3, 4, 5, 6, &matrix);
+    GdipCreateMatrix2 (123, 24, 82, 16, 47, 30, &nonInvertibleMatrix);
     GdipCreateMatrix (&transform);
 
     status = GdipSetPathGradientTransform (brush, matrix);
@@ -1386,6 +1412,9 @@ static void test_setPathGradientTransform ()
     assertEqualInt (status, InvalidParameter);
 
     status = GdipSetPathGradientTransform (brush, NULL);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipSetPathGradientTransform (brush, nonInvertibleMatrix);
     assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);

--- a/tests/testpathgradientbrush.c
+++ b/tests/testpathgradientbrush.c
@@ -78,40 +78,87 @@ static void test_createPathGradient ()
 {
     GpStatus status;
     GpPathGradient *brush;
-    GpPointF points2[2] =
+    GpPointF points[2] =
     {
 		{1, 2},
 		{-10, 11}
     };
+    GpPointF points3[3] =
+    {
+		{3, 13},
+		{1, 2},
+		{5, 6}
+    };
 
-    status = GdipCreatePathGradient (points2, 2, WrapModeClamp, &brush);
+    // WrapModeClamp.
+    status = GdipCreatePathGradient (points, 2, WrapModeClamp, &brush);
     assertEqualInt (status, Ok);
     verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xff000000, -4.5, 6.5, WrapModeClamp);
-    GdipDeleteBrush ((GpBrush *) brush);
 
-    status = GdipCreatePathGradient (threePoints, 3, WrapModeTile, &brush);
+    // WrapModeTileFlipXY.
+    status = GdipCreatePathGradient (points, 2, WrapModeTileFlipX, &brush);
+    assertEqualInt (status, Ok);
+    verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xff000000, -4.5, 6.5, WrapModeTileFlipX);
+
+    // WrapModeTileFlipY.
+    status = GdipCreatePathGradient (points, 2, WrapModeTileFlipY, &brush);
+    assertEqualInt (status, Ok);
+    verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xff000000, -4.5, 6.5, WrapModeTileFlipY);
+
+    // WrapModeTileFlipX.
+    status = GdipCreatePathGradient (points, 2, WrapModeTileFlipX, &brush);
+    assertEqualInt (status, Ok);
+    verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xff000000, -4.5, 6.5, WrapModeTileFlipX);
+
+    // WrapModeTile.
+    status = GdipCreatePathGradient (points3, 3, WrapModeTile, &brush);
     assertEqualInt (status, Ok);
     verifyPathGradientBrush (brush, 1, 2, 4, 11, 0xff000000, 3, 7, WrapModeTile);
 
+    // Negative tests.
     status = GdipCreatePathGradient (NULL, 2, WrapModeClamp, &brush);
     assertEqualInt (status, OutOfMemory);
 
-    status = GdipCreatePathGradient (points2, 1, WrapModeClamp, &brush);
+    status = GdipCreatePathGradient (NULL, 1, WrapModeClamp, &brush);
     assertEqualInt (status, OutOfMemory);
 
-    status = GdipCreatePathGradient (points2, 0, WrapModeClamp, &brush);
+    status = GdipCreatePathGradient (NULL, 0, WrapModeClamp, &brush);
     assertEqualInt (status, OutOfMemory);
 
-    status = GdipCreatePathGradient (points2, -1, WrapModeClamp, &brush);
+    status = GdipCreatePathGradient (NULL, -1, WrapModeClamp, &brush);
     assertEqualInt (status, OutOfMemory);
 
-    status = GdipCreatePathGradient (points2, 2, (WrapMode)(WrapModeTile - 1), &brush);
+    status = GdipCreatePathGradient (NULL, 2, WrapModeClamp, NULL);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradient (points, 1, WrapModeClamp, &brush);
     assertEqualInt (status, OutOfMemory);
 
-    status = GdipCreatePathGradient (points2, 2, (WrapMode)(WrapModeClamp + 1), &brush);
+    status = GdipCreatePathGradient (points, 0, WrapModeClamp, &brush);
     assertEqualInt (status, OutOfMemory);
 
-    status = GdipCreatePathGradient (points2, 2, WrapModeClamp, NULL);
+    status = GdipCreatePathGradient (points, -1, WrapModeClamp, &brush);
+    assertEqualInt (status, OutOfMemory);
+
+    status = GdipCreatePathGradient (points, 2, (WrapMode)(WrapModeTile - 1), &brush);
+    assertEqualInt (status, OutOfMemory);
+
+    status = GdipCreatePathGradient (points, 2, (WrapMode)(WrapModeClamp + 1), &brush);
+    assertEqualInt (status, OutOfMemory);
+
+    status = GdipCreatePathGradient (points, 2, WrapModeClamp, NULL);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradient (points, 1, WrapModeClamp, NULL);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradient (points, 0, WrapModeClamp, NULL);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradient (points, -1, WrapModeClamp, NULL);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradient (points, 2, (WrapMode)(WrapModeClamp + 1), NULL);
     assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
@@ -133,15 +180,45 @@ static void test_createPathGradientI ()
 		{5, 6}
     };
 
+    // WrapModeClamp.
     status = GdipCreatePathGradientI (points, 2, WrapModeClamp, &brush);
     assertEqualInt (status, Ok);
-    verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xff000000, -4.5, 6.5, WrapModeClamp);
+    verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xFF000000, -4.5, 6.5, WrapModeClamp);
 
+    // WrapModeTileFlipXY.
+    status = GdipCreatePathGradientI (points, 2, WrapModeTileFlipX, &brush);
+    assertEqualInt (status, Ok);
+    verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xFF000000, -4.5, 6.5, WrapModeTileFlipX);
+
+    // WrapModeTileFlipY.
+    status = GdipCreatePathGradientI (points, 2, WrapModeTileFlipY, &brush);
+    assertEqualInt (status, Ok);
+    verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xFF000000, -4.5, 6.5, WrapModeTileFlipY);
+
+    // WrapModeTileFlipX.
+    status = GdipCreatePathGradientI (points, 2, WrapModeTileFlipX, &brush);
+    assertEqualInt (status, Ok);
+    verifyPathGradientBrush (brush, -10, 2, 11, 9, 0xFF000000, -4.5, 6.5, WrapModeTileFlipX);
+
+    // WrapModeTile.
     status = GdipCreatePathGradientI (points3, 3, WrapModeTile, &brush);
     assertEqualInt (status, Ok);
-    verifyPathGradientBrush (brush, 1, 2, 4, 11, 0xff000000, 3, 7, WrapModeTile);
+    verifyPathGradientBrush (brush, 1, 2, 4, 11, 0xFF000000, 3, 7, WrapModeTile);
 
+    // Negative tests.
     status = GdipCreatePathGradientI (NULL, 2, WrapModeClamp, &brush);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradientI (NULL, 1, WrapModeClamp, &brush);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradientI (NULL, 0, WrapModeClamp, &brush);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradientI (NULL, -1, WrapModeClamp, &brush);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradientI (NULL, 2, WrapModeClamp, NULL);
     assertEqualInt (status, InvalidParameter);
 
     status = GdipCreatePathGradientI (points, 1, WrapModeClamp, &brush);
@@ -162,6 +239,18 @@ static void test_createPathGradientI ()
     status = GdipCreatePathGradientI (points, 2, WrapModeClamp, NULL);
     assertEqualInt (status, InvalidParameter);
 
+    status = GdipCreatePathGradientI (points, 1, WrapModeClamp, NULL);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradientI (points, 0, WrapModeClamp, NULL);
+    assertEqualInt (status, InvalidParameter);
+
+    status = GdipCreatePathGradientI (points, -1, WrapModeClamp, NULL);
+    assertEqualInt (status, OutOfMemory);
+
+    status = GdipCreatePathGradientI (points, 2, (WrapMode)(WrapModeClamp + 1), NULL);
+    assertEqualInt (status, InvalidParameter);
+
     GdipDeleteBrush ((GpBrush *) brush);
 }
 
@@ -169,38 +258,43 @@ static void test_createPathGradientFromPath ()
 {
     GpStatus status;
     GpPathGradient *brush;
-    BYTE types[3] = {1, 2, 3};
-    GpPath *path;
+    GpPath *linePath;
     GpPath *emptyPath;
+    BYTE types[3] = {1, 2, 3};
+    GpPath *invalidPath;
 
-    status = GdipCreatePath2 (threePoints, types, 3, FillModeAlternate, &path);
+    GdipCreatePath (FillModeWinding, &linePath);
+    GdipAddPathRectangle (linePath, 10, 20, 30, 40);
+    GdipCreatePath (FillModeWinding, &emptyPath);    
+    GdipCreatePath2 (threePoints, types, 3, FillModeAlternate, &invalidPath);
+
+    status = GdipCreatePathGradientFromPath (linePath, &brush);
     assertEqualInt (status, Ok);
+    verifyPathGradientBrush (brush, 10, 20, 30, 40, 0xFFFFFFFF, 25, 40, WrapModeClamp);
 
-    status = GdipCreatePath (FillModeWinding, &emptyPath);
-    assertEqualInt (status, Ok);
-
-    status = GdipCreatePathGradientFromPath (path, &brush);
-    // FIXME: this fails in GDI+.
-#if !defined(USE_WINDOWS_GDIPLUS)
-    assertEqualInt (status, Ok);
-    verifyPathGradientBrush (brush, 1, 2, 4, 11, 0xffffffff, 3, 7, WrapModeClamp);
-#endif
-
+    // Negative tests.
     status = GdipCreatePathGradientFromPath (NULL, &brush);
     assertEqualInt (status, OutOfMemory);
 
     status = GdipCreatePathGradientFromPath (emptyPath, &brush);
     assertEqualInt (status, OutOfMemory);
 
+    // FIXME: GDI+ performs some validation on the path.
+#if defined(USE_WINDOWS_GDIPLUS)
+    status = GdipCreatePathGradientFromPath (invalidPath, &brush);
+    assertEqualInt (status, OutOfMemory);
+#endif
+
     status = GdipCreatePathGradientFromPath (NULL, NULL);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipCreatePathGradientFromPath (path, NULL);
+    status = GdipCreatePathGradientFromPath (linePath, NULL);
     assertEqualInt (status, InvalidParameter);
 
-    GdipDeleteBrush ((GpBrush *)brush);
-    GdipDeletePath (path);
+    GdipDeleteBrush ((GpBrush *) brush);
+    GdipDeletePath (linePath);
     GdipDeletePath (emptyPath);
+    GdipDeletePath (invalidPath);
 }
 
 static void test_getPathGradientCenterColor ()
@@ -211,6 +305,7 @@ static void test_getPathGradientCenterColor ()
 
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
+    // Negative tests.
     status = GdipGetPathGradientCenterColor (NULL, &centerColor);
     assertEqualInt (status, InvalidParameter);
 
@@ -234,6 +329,7 @@ static void test_setPathGradientCenterColor ()
     GdipGetPathGradientCenterColor (brush, &centerColor);
     assertEqualInt (centerColor, 2);
 
+    // Negative tests.
     status = GdipSetPathGradientCenterColor (NULL, 1);
     assertEqualInt (status, InvalidParameter);
 
@@ -251,7 +347,7 @@ static void test_getPathGradientSurroundColorCount ()
 
     status = GdipGetPathGradientSurroundColorCount (brush, &count);
     assertEqualInt (status, Ok);
-    assertEqualInt (count,  3);
+    assertEqualInt (count, 3);
     GdipDeleteBrush ((GpBrush *) brush);
 
     // Two points.
@@ -259,7 +355,7 @@ static void test_getPathGradientSurroundColorCount ()
 
     status = GdipGetPathGradientSurroundColorCount (brush, &count);
     assertEqualInt (status, Ok);
-    assertEqualInt (count,  2);
+    assertEqualInt (count, 2);
 
     // Negative tests
     status = GdipGetPathGradientSurroundColorCount (NULL, &count);
@@ -283,10 +379,10 @@ static void test_getPathGradientSurroundColorsWithCount ()
 
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
     assertEqualInt (status, Ok);
-    assertEqualInt (count,  1);
-    assertEqualInt (colors[0], 0xffffffff);
-    assertEqualInt (colors[1], 0xffffffff);
-    assertEqualInt (colors[2], 0xffffffff);
+    assertEqualInt (count, 1);
+    assertEqualInt (colors[0], 0xFFFFFFFF);
+    assertEqualInt (colors[1], 0xFFFFFFFF);
+    assertEqualInt (colors[2], 0xFFFFFFFF);
 
     // Negative tests
     status = GdipGetPathGradientSurroundColorsWithCount (NULL, colors, &count);
@@ -335,11 +431,15 @@ static void test_setPathGradientSurroundColorsWithCount ()
     // Three surround colors.
     status = GdipSetPathGradientSurroundColorsWithCount (brush, threeSurroundColors, &count);
     assertEqualInt (status, Ok);
-    assertEqualInt (count,  3);
+    assertEqualInt (count, 3);
+
+    count = 0xFF;
+    status = GdipGetPathGradientSurroundColorCount (brush, &count);
+    assertEqualInt (count, 3);
 
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
     assertEqualInt (status, Ok);
-    assertEqualInt (count,  3);
+    assertEqualInt (count, 3);
     assertEqualInt (colors[0], 1);
     assertEqualInt (colors[1], 2);
     assertEqualInt (colors[2], 3);
@@ -348,12 +448,16 @@ static void test_setPathGradientSurroundColorsWithCount ()
     count = 2;
     status = GdipSetPathGradientSurroundColorsWithCount (brush, threeEmptyColors, &count);
     assertEqualInt (status, Ok);
-    assertEqualInt (count,  2);
+    assertEqualInt (count, 2);
+
+    count = 0xFF;
+    status = GdipGetPathGradientSurroundColorCount (brush, &count);
+    assertEqualInt (count, 3);
 
     count = 3;
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
     assertEqualInt (status, Ok);
-    assertEqualInt (count,  1);
+    assertEqualInt (count, 1);
     assertEqualInt (colors[0], 0);
     assertEqualInt (colors[1], 0);
     assertEqualInt (colors[2], 0);
@@ -362,12 +466,16 @@ static void test_setPathGradientSurroundColorsWithCount ()
     count = 2;
     status = GdipSetPathGradientSurroundColorsWithCount (brush, twoSameColors, &count);
     assertEqualInt (status, Ok);
-    assertEqualInt (count,  2);
+    assertEqualInt (count, 2);
+
+    count = 0xFF;
+    status = GdipGetPathGradientSurroundColorCount (brush, &count);
+    assertEqualInt (count, 3);
 
     count = 3;
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
     assertEqualInt (status, Ok);
-    assertEqualInt (count,  1);
+    assertEqualInt (count, 1);
     assertEqualInt (colors[0], 1);
     assertEqualInt (colors[1], 1);
     assertEqualInt (colors[2], 1);
@@ -378,6 +486,10 @@ static void test_setPathGradientSurroundColorsWithCount ()
     count = 1;
     status = GdipSetPathGradientSurroundColorsWithCount (brush, threeSurroundColors, &count);
     assertEqualInt (status, Ok);
+
+    count = 0xFF;
+    status = GdipGetPathGradientSurroundColorCount (brush, &count);
+    assertEqualInt (count, 3);
 
     count = 3;
     status = GdipGetPathGradientSurroundColorsWithCount (brush, colors, &count);
@@ -758,6 +870,7 @@ static void test_getPathGradientBlendCount ()
     status = GdipGetPathGradientBlendCount (brush, &blendCount);
     assertEqualInt (blendCount, 1);
 
+    // Negative tests.
     status = GdipGetPathGradientBlendCount (NULL, &blendCount);
     assertEqualInt (status, InvalidParameter);
 
@@ -767,38 +880,51 @@ static void test_getPathGradientBlendCount ()
     GdipDeleteBrush ((GpBrush *) brush);
 }
 
+static void fill_array (REAL *array, INT count, REAL value)
+{
+    for (int i = 0; i < count; i++)
+        array[i] = value;
+}
+
 static void test_getPathGradientBlend ()
 {
     GpStatus status;
     GpPathGradient *brush;
-    REAL blend[1];
-    REAL positions[1];
-    REAL largeBlend[3] = {1, 2, 3};
-    REAL largePositions[3] = {0, 0.5, 1};
+    REAL blend[3];
+    REAL positions[3];
+    REAL threeBlends[3] = {1, 2, 3};
+    REAL threePositions[3] = {0, 0.5, 1};
 
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
+    // Default blend - equal count.
+    fill_array (blend, ARRAY_SIZE (blend), 123);
+    fill_array (positions, ARRAY_SIZE (positions), 123);
     status = GdipGetPathGradientBlend (brush, blend, positions, 1);
     assertEqualInt (status, Ok);
     assertEqualFloat (blend[0], 1);
-    // It appears that Windows 10+ versions of GDI+ don't copy anything to positions.
-    // This is a GDI+ bug that we don't want to replicate.
-#if !defined(USE_WINDOWS_GDIPLUS)
-    assertEqualFloat (positions[0], 0);
-#endif
+    assertEqualFloat (blend[1], 123);
+    assertEqualFloat (blend[2], 123);
+    // Positions are meaningless for blends with a count of 1 so this parameter is ignored.
+    assertEqualFloat (positions[0], 123);
+    assertEqualFloat (positions[1], 123);
+    assertEqualFloat (positions[2], 123);
 
+    // Default blend - larger count.
+    fill_array (blend, ARRAY_SIZE (blend), 123);
+    fill_array (positions, ARRAY_SIZE (positions), 123);
     status = GdipGetPathGradientBlend (brush, blend, positions, 2);
     assertEqualInt (status, Ok);
     assertEqualFloat (blend[0], 1);
-    // It appears that Windows 10+ versions of GDI+ don't copy anything to positions.
-    // This is a GDI+ bug that we don't want to replicate.
-#if !defined(USE_WINDOWS_GDIPLUS)
-    assertEqualFloat (positions[0], 0);
-#endif
+    assertEqualFloat (blend[1], 123);
+    assertEqualFloat (blend[2], 123);
+    // Positions are meaningless for blends with a count of 1 so this parameter is ignored.
+    assertEqualFloat (positions[0], 123);
+    assertEqualFloat (positions[1], 123);
+    assertEqualFloat (positions[2], 123);
 
-    status = GdipSetPathGradientBlend (brush, largeBlend, largePositions, 3);
-    assertEqualInt (status, Ok);
-
+    // Negative tests.
+    GdipSetPathGradientBlend (brush, threeBlends, threePositions, 3);
     status = GdipGetPathGradientBlend (brush, blend, positions, 1);
     assertEqualInt (status, InsufficientBuffer);
 
@@ -825,72 +951,73 @@ static void test_setPathGradientBlend ()
     GpStatus status;
     GpPathGradient *brush;
 
-    REAL blend1[1] = {3};
-    REAL positions1[1] = {-12};
-    REAL destBlend1[1];
-    REAL destPositions1[1];
-
-    REAL blend2[2] = {-1, 0};
-    REAL positions2[2] = {0, 1.0f};
-    REAL destBlend2[2];
-    REAL destPositions2[2];
-
-    REAL blend3[3] = {1, 2, 3};
-    REAL positions3[3] = {0, 0.5f, 1.0f};
-    REAL destBlend3[3];
-    REAL destPositions3[3];
-
-    REAL invalidPositions1[2] = {0.5, 1};
-    REAL invalidPositions2[2] = {0, 0.5};
-
+    REAL blend[3]= {1, 2, 3};
+    REAL positions[3] = {0, 0.5f, 1.0f};
+    REAL twoBlends[2] = {1, 2};
+    REAL twoPositions[2] = {0, 1};
+    REAL threeBlends[3] = {1, 2, 3};
+    REAL threePositions[3] = {0, 0.5, 1};
+    REAL oneBlend[1] = {10};
+    REAL onePosition[1] = {-12};
     ARGB pathPresetBlend[3] = {1, 2, 3};
     REAL pathPresetPositions[3] = {0, 0.5f, 1.0f};
     INT presetBlendCount;
 
+    REAL invalidPositions1[2] = {0.5, 1};
+    REAL invalidPositions2[2] = {0, 0.5};
+
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
-    // Count of 1.
-    status = GdipSetPathGradientBlend (brush, blend1, positions1, 1);
+    // Two blends - equal count.
+    status = GdipSetPathGradientBlend (brush, twoBlends, twoPositions, 2);
     assertEqualInt (status, Ok);
 
-    status = GdipGetPathGradientBlend (brush, destBlend1, destPositions1, 1);
+    fill_array (blend, ARRAY_SIZE (blend), 123);
+    fill_array (positions, ARRAY_SIZE (positions), 123);
+    status = GdipGetPathGradientBlend (brush, blend, positions, 2);
     assertEqualInt (status, Ok);
-    assertEqualFloat (destBlend1[0], 3);
-    // It appears GDI+ ignores the position value if there is a single element.
-    // This is a GDI+ bug we don't want to replicate.
-#if !defined(USE_WINDOWS_GDIPLUS)
-    assertEqualFloat (destPositions1[0], -12);
-#endif
+    assertEqualFloat (blend[0], 1);
+    assertEqualFloat (blend[1], 2);
+    assertEqualFloat (blend[2], 123);
+    assertEqualFloat (positions[0], 0);
+    assertEqualFloat (positions[1], 1);
+    assertEqualFloat (positions[2], 123);
 
-    // Count of 2.
-    status = GdipSetPathGradientBlend (brush, blend2, positions2, 2);
-    assertEqualInt (status, Ok);
-
-    status = GdipGetPathGradientBlend (brush, destBlend2, destPositions2, 2);
-    assertEqualInt (status, Ok);
-    assertEqualFloat (destBlend2[0], -1);
-    assertEqualFloat (destBlend2[1], 0);
-    assertEqualFloat (destPositions2[0], 0);
-    assertEqualFloat (destPositions2[1], 1);
-
-    // Count of 3.
-    status = GdipSetPathGradientBlend (brush, blend3, positions3, 3);
+    // Three blends - equal count.
+    status = GdipSetPathGradientBlend (brush, threeBlends, threePositions, 3);
     assertEqualInt (status, Ok);
 
-    status = GdipGetPathGradientBlend (brush, destBlend3, destPositions3, 3);
+    fill_array (blend, ARRAY_SIZE (blend), 123);
+    fill_array (positions, ARRAY_SIZE (positions), 123);
+    status = GdipGetPathGradientBlend (brush, blend, positions, 3);
     assertEqualInt (status, Ok);
-    assertEqualFloat (destBlend3[0], 1);
-    assertEqualFloat (destBlend3[1], 2);
-    assertEqualFloat (destBlend3[2], 3);
-    assertEqualFloat (destPositions3[0], 0);
-    assertEqualFloat (destPositions3[1], 0.5);
-    assertEqualFloat (destPositions3[2], 1);
+    assertEqualFloat (blend[0], 1);
+    assertEqualFloat (blend[1], 2);
+    assertEqualFloat (blend[2], 3);
+    assertEqualFloat (positions[0], 0);
+    assertEqualFloat (positions[1], 0.5);
+    assertEqualFloat (positions[2], 1);
+
+    // One blend - equal count.
+    status = GdipSetPathGradientBlend (brush, oneBlend, onePosition, 1);
+    assertEqualInt (status, Ok);
+
+    fill_array (blend, ARRAY_SIZE (blend), 123);
+    fill_array (positions, ARRAY_SIZE (positions), 123);
+    status = GdipGetPathGradientBlend (brush, blend, positions, 1);
+    assertEqualInt (status, Ok);
+    assertEqualFloat (blend[0], 10);
+    assertEqualFloat (blend[1], 123);
+    assertEqualFloat (blend[2], 123);
+    assertEqualFloat (positions[0], 123);
+    assertEqualFloat (positions[1], 123);
+    assertEqualFloat (positions[2], 123);
 
     // Should clear the existing blend.
     status = GdipSetPathGradientPresetBlend (brush, pathPresetBlend, pathPresetPositions, 3);
     assertEqualInt (status, Ok);
 
-    status = GdipSetPathGradientBlend (brush, destBlend2, destPositions2, 2);
+    status = GdipSetPathGradientBlend (brush, threeBlends, threePositions, 3);
     assertEqualInt (status, Ok);
 
     status = GdipGetPathGradientPresetBlendCount (brush, &presetBlendCount);
@@ -898,25 +1025,25 @@ static void test_setPathGradientBlend ()
     assertEqualInt (presetBlendCount, 0);
 
     // Negative tests.
-    status = GdipSetPathGradientBlend (NULL, blend3, positions3, 3);
+    status = GdipSetPathGradientBlend (NULL, threeBlends, threePositions, 3);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetPathGradientBlend (brush, NULL, positions3, 3);
+    status = GdipSetPathGradientBlend (brush, NULL, threePositions, 3);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetPathGradientBlend (brush, blend3, NULL, 3);
+    status = GdipSetPathGradientBlend (brush, threeBlends, NULL, 2);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetPathGradientBlend (brush, blend2, invalidPositions1, 2);
+    status = GdipSetPathGradientBlend (brush, twoBlends, invalidPositions1, 2);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetPathGradientBlend (brush, blend2, invalidPositions2, 2);
+    status = GdipSetPathGradientBlend (brush, twoBlends, invalidPositions2, 2);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetPathGradientBlend (brush, blend3, positions3, 0);
+    status = GdipSetPathGradientBlend (brush, threeBlends, threePositions, 0);
     assertEqualInt (status, InvalidParameter);
 
-    status = GdipSetPathGradientBlend (brush, blend3, positions3, -1);
+    status = GdipSetPathGradientBlend (brush, threeBlends, threePositions, -1);
     assertEqualInt (status, InvalidParameter);
 
     GdipDeleteBrush ((GpBrush *) brush);
@@ -934,6 +1061,7 @@ static void test_getPathGradientPresetBlendCount ()
     assertEqualInt (status, Ok);
     assertEqualInt (blendCount, 0);
 
+    // Negative tests.
     status = GdipGetPathGradientPresetBlendCount (NULL, &blendCount);
     assertEqualInt (status, InvalidParameter);
 
@@ -952,6 +1080,7 @@ static void test_getPathGradientPresetBlend ()
 
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
+    // Negative tests.
     status = GdipGetPathGradientPresetBlend (brush, blend, positions, 2);
     assertEqualInt (status, GenericError);
 
@@ -1000,8 +1129,10 @@ static void test_setPathGradientPresetBlend ()
     ARGB destBlend3[3];
     REAL destPositions3[3];
 
+#if !defined(USE_WINDOWS_GDIPLUS)
     REAL destBlendReal[2];
     REAL destPositionsReal[2];
+#endif
 
     REAL invalidPositions1[2] = {0.5, 1};
     REAL invalidPositions2[2] = {0, 0.5};
@@ -1102,6 +1233,7 @@ static void test_setPathGradientSigmaBlend ()
     status = GdipSetPathGradientSigmaBlend (brush, 1, 0);
     assertEqualInt (status, Ok);
 
+    // Negative tests.
     status = GdipSetPathGradientSigmaBlend (NULL, 0.5f, 0.5f);
     assertEqualInt (status, InvalidParameter);
 
@@ -1136,6 +1268,7 @@ static void test_setPathGradientLinearBlend ()
     status = GdipSetPathGradientLinearBlend (brush, 1, 0);
     assertEqualInt (status, Ok);
 
+    // Negative tests.
     status = GdipSetPathGradientLinearBlend (NULL, 0.5f, 0.5f);
     assertEqualInt (status, InvalidParameter);
 
@@ -1162,6 +1295,7 @@ static void test_getPathGradientWrapMode ()
 
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
 
+    // Negative tests.
     status = GdipGetPathGradientWrapMode (NULL, &wrapMode);
     assertEqualInt (status, InvalidParameter);
 
@@ -1197,6 +1331,7 @@ static void test_setPathGradientWrapMode ()
     GdipGetPathGradientWrapMode (brush, &wrapMode);
     assertEqualInt (wrapMode, WrapModeTileFlipY);
 
+    // Negative tests.
     status = GdipSetPathGradientWrapMode (NULL, WrapModeTile);
     assertEqualInt (status, InvalidParameter);
 
@@ -1212,6 +1347,7 @@ static void test_getPathGradientTransform ()
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
     GdipCreateMatrix (&transform);
 
+    // Negative tests.
     status = GdipGetPathGradientTransform (NULL, transform);
     assertEqualInt (status, InvalidParameter);
 
@@ -1276,6 +1412,7 @@ static void test_resetPathGradientTransform ()
     GdipGetPathGradientTransform (brush, transform);
     verifyMatrix (transform, 1, 0, 0, 1, 0, 0);
 
+    // Negative tests.
     status = GdipResetPathGradientTransform (NULL);
     assertEqualInt (status, InvalidParameter);
 
@@ -1501,6 +1638,7 @@ static void test_getPathGradientFocusScales ()
     assertEqualFloat (xScale, 0);
     assertEqualFloat (yScale, 0);
 
+    // Negative tests.
     status = GdipGetPathGradientFocusScales (NULL, &xScale, &yScale);
     assertEqualInt (status, InvalidParameter);
 
@@ -1546,6 +1684,7 @@ static void test_setPathGradientFocusScales ()
     assertEqualFloat (xScale, 0);
     assertEqualFloat (yScale, 0);
 
+    // Negative tests.
     status = GdipSetPathGradientFocusScales (NULL, 0, 0);
     assertEqualInt (status, InvalidParameter);
 


### PR DESCRIPTION
- Handle memory allocation failures better
- Implement GdipCreatePathGradientI in terms of GdipCreatePathGradient
- Add more tests
- Fix ordering of parameter validation to match GDI+
- Fix writing to positions when the blend count is 1, to match GDI+