### PR TITLE
GraphicsPath fixes

### DIFF
--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -1247,6 +1247,12 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 	
 	if (string_format != format)
 		GdipDeleteStringFormat (string_format);
+
+	// If our Cairo context had a current point before laying out the path, Pango will have moved us back there.
+	// We don't want that when we process the path below, so clear it if set.
+	if (cairo_has_current_point(cr))
+		cairo_new_sub_path(cr);
+
 	}
 #else
 	{

--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -1241,7 +1241,7 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 	}
 
 	layout = gdip_pango_setup_layout (cr, string, length, font, layoutRect, &box, &box_offset, string_format, NULL);
-	cairo_move_to (cr, layoutRect->X + box_offset.X, layoutRect->Y + box_offset.X);
+	cairo_move_to (cr, layoutRect->X + box_offset.X, layoutRect->Y + box_offset.Y);
 	pango_cairo_layout_path (cr, layout);
 	g_object_unref (layout);
 	

--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -1192,7 +1192,7 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 	if (emSize == 0)
 		return GenericError;
 
-	cs = cairo_recording_surface_create (CAIRO_FORMAT_ARGB32, NULL);
+	cs = cairo_recording_surface_create (CAIRO_CONTENT_COLOR_ALPHA, NULL);
 	if (cairo_surface_status (cs) != CAIRO_STATUS_SUCCESS) {
 		cairo_surface_destroy (cs);
 		return OutOfMemory;

--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -107,8 +107,11 @@ append (GpPath *path, float x, float y, PathPointType type, BOOL compress)
 		if ((lastPoint.X == x) && (lastPoint.Y == y)) {
 			/* types need not be identical but must handle closed subpaths */
 			PathPointType last_type = path->types[path->count - 1];
-			if ((last_type & PathPointTypeCloseSubpath) != PathPointTypeCloseSubpath)
+			if ((last_type & PathPointTypeCloseSubpath) != PathPointTypeCloseSubpath) {
+				if ((type & PathPointTypeCloseSubpath) == PathPointTypeCloseSubpath) 
+					path->types[path->count - 1] |= PathPointTypeCloseSubpath;
 				return;
+			}
 		}
 	}
 
@@ -1189,7 +1192,7 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 	if (emSize == 0)
 		return GenericError;
 
-	cs = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, 1, 1);
+	cs = cairo_recording_surface_create (CAIRO_FORMAT_ARGB32, NULL);
 	if (cairo_surface_status (cs) != CAIRO_STATUS_SUCCESS) {
 		cairo_surface_destroy (cs);
 		return OutOfMemory;
@@ -1286,9 +1289,10 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 		if (gdip_path_ensure_size (path, path->count + count)) {
 			for (i=0; i < cp->num_data; i += cp->data[i].header.length) {
 				PathPointType type = PathPointTypeStart;
+				int dataLength = cp->data[i].header.length;
 				cairo_path_data_t *data = &cp->data[i];
 
-				if ((i < cp->num_data - 1) && (data->header.type == CAIRO_PATH_CLOSE_PATH))
+				if ((i < cp->num_data - dataLength) && (cp->data[i + dataLength].header.type == CAIRO_PATH_CLOSE_PATH))
 					type |= PathPointTypeCloseSubpath;
 
 				switch (data->header.type) {

--- a/tests/testgraphicspath.c
+++ b/tests/testgraphicspath.c
@@ -93,20 +93,13 @@ static void test_createPath ()
 
 static void test_addPathString ()
 {
-  GpImage *image;
-  GpGraphics *graphics;
   GpStatus status;
   GpPath *path;
   const WCHAR string[] = {'H', 'e', 'l', 'l', 'o', '\0'};
-  const WCHAR longString[] = {'H', 'e', 'l', 'l', 'o', ' ', 't', 'h', 'e', 'r', 'e', ',', ' ', 't', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g', '.', '\0'};
   const WCHAR emptyString[] = {'\0'};
-  const int fontSize = 20;
   GpFontFamily *family;
-  GpFont *font;
   GpStringFormat *format;
   RectF layoutRect = {10, 20, 236, 226};
-  RectF longLayoutRect = {30, 40, 700, 100};
-  RectF rect1, rect2;
 
   GdipGetGenericFontFamilySerif (&family);
   GdipCreateStringFormat (0, 0, &format);
@@ -272,6 +265,14 @@ static void test_addPathString ()
   GdipDeletePath (path);
   
 #if defined USE_PANGO_RENDERING || defined(USE_WINDOWS_GDIPLUS)
+  const WCHAR longString[] = {'H', 'e', 'l', 'l', 'o', ' ', 't', 'h', 'e', 'r', 'e', ',', ' ', 't', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'l', 'o', 'n', 'g', ' ', 's', 't', 'r', 'i', 'n', 'g', '.', '\0'};
+  const int fontSize = 20;
+  GpImage *image;
+  GpGraphics *graphics;
+  GpFont *font;
+  RectF longLayoutRect = {30, 40, 700, 100};
+  RectF rect1, rect2;
+
   // Set up Graphics stuff to use MeasureString (copied from testtext.c)
   status = GdipCreateFont (family, fontSize, FontStyleRegular, UnitPixel, &font);
   assertEqualInt (status, Ok);

--- a/tests/testgraphicspath.c
+++ b/tests/testgraphicspath.c
@@ -271,6 +271,7 @@ static void test_addPathString ()
 
   GdipDeletePath (path);
   
+#if defined USE_PANGO_RENDERING || defined(USE_WINDOWS_GDIPLUS)
   // Set up Graphics stuff to use MeasureString (copied from testtext.c)
   status = GdipCreateFont (family, fontSize, FontStyleRegular, UnitPixel, &font);
   assertEqualInt (status, Ok);
@@ -299,6 +300,7 @@ static void test_addPathString ()
   GdipDeleteGraphics (graphics);
   GdipDeleteFont (font);
   GdipDisposeImage (image);  
+#endif
   
   GdipDeleteFontFamily (family);
   GdipDeleteStringFormat (format);

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -118,6 +118,21 @@ ATTRIBUTE_USED static void assertEqualFloatImpl (REAL actual, REAL expected, con
 
 #define assertEqualFloat(actual, expected) assertEqualFloatImpl (actual, expected, NULL, __FILE__, __func__, __LINE__)
 
+ATTRIBUTE_USED static void assertSimilarFloatImpl (REAL actual, REAL expected, REAL tolerance, const char *message, const char *file, const char *function, int line)
+{
+    if (abs(actual - expected) > abs(tolerance)) {
+        if (message)
+            fprintf (stderr, "%s\n", message);
+
+        printFailure (file, function, line);
+        fprintf (stderr, "Expected %f +/- %f\n", expected, tolerance);
+        fprintf (stderr, "Actual:   %f\n", actual);
+        abort ();
+    }
+}
+
+#define assertSimilarFloat(actual, expected, tolerance) assertSimilarFloatImpl (actual, expected, tolerance, NULL, __FILE__, __func__, __LINE__)
+
 ATTRIBUTE_USED static BOOL stringsEqual (const WCHAR *actual, const char *expected)
 {
 	int i = 0;

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -120,7 +120,7 @@ ATTRIBUTE_USED static void assertEqualFloatImpl (REAL actual, REAL expected, con
 
 ATTRIBUTE_USED static void assertSimilarFloatImpl (REAL actual, REAL expected, REAL tolerance, const char *message, const char *file, const char *function, int line)
 {
-    if (abs(actual - expected) > abs(tolerance)) {
+    if (fabs(actual - expected) > fabs(tolerance)) {
         if (message)
             fprintf (stderr, "%s\n", message);
 


### PR DESCRIPTION
- When using the Pango text backend, pass an actual GpGraphics object.
- For GdipAddPathString, use an infinite Cairo Recording surface. I was having problems with longer strings clipping on the old 1x1 image surface.
- In GdipAddPathString, fix checking whether the next path point is a CAIRO_PATH_CLOSE_PATH.
- Also change append to correctly handle the second of two identically-positioned points closing the path.