### PR TITLE
Region fixes

### DIFF
--- a/src/region.c
+++ b/src/region.c
@@ -247,18 +247,21 @@ gdip_is_InfiniteRegion (const GpRegion *region)
 }
 
 static BOOL
-gdip_intersects (const GpRectF *rect1, const GpRectF *rect2, BOOL includeTouching)
+gdip_intersects (const GpRectF *rect1, const GpRectF *rect2)
 {
-	if (includeTouching)
-		return (rect1->X <= rect2->X + rect2->Width &&
-			rect1->X + rect1->Width >= rect2->X &&
-			rect1->Y <= rect2->Y + rect2->Height &&
-			rect1->Y + rect1->Height >= rect2->Y);
-
 	return (rect1->X < rect2->X + rect2->Width &&
 		rect1->X + rect1->Width > rect2->X &&
 		rect1->Y < rect2->Y + rect2->Height &&
 		rect1->Y + rect1->Height > rect2->Y);
+}
+
+static BOOL
+gdip_intersects_or_touches (GpRectF *rect1, GpRectF *rect2)
+{
+	return (rect1->X <= rect2->X + rect2->Width &&
+		rect1->X + rect1->Width >= rect2->X &&
+		rect1->Y <= rect2->Y + rect2->Height &&
+		rect1->Y + rect1->Height >= rect2->Y);
 }
 
 /* Is source contained in target ? */
@@ -782,7 +785,7 @@ gdip_combine_exclude (GpRegion *region, GpRectF *rtrg, int cntt)
 		/* Current rect with lowest y and X against the target ones */
 		for (i = 0, recttrg = alltrgrects; i < alltrgcnt; i++, recttrg++) {
 
-			if (gdip_intersects (&current, recttrg, FALSE) == FALSE
+			if (gdip_intersects (&current, recttrg) == FALSE
 				|| gdip_equals (&current, recttrg) == TRUE ||
 				recttrg->Height < 0 || recttrg->Width < 0) {
 				continue;
@@ -991,7 +994,7 @@ gdip_combine_union (GpRegion *region, GpRectF *rtrg, int cnttrg)
 				continue;
 			}
 
-			if (gdip_intersects (&current, recttrg, TRUE) == FALSE
+			if (gdip_intersects_or_touches (&current, recttrg) == FALSE
 				|| gdip_equals (&current, recttrg) == TRUE ||
 				recttrg->Height < 0 || recttrg->Width < 0) {
 				continue;

--- a/src/region.c
+++ b/src/region.c
@@ -470,22 +470,20 @@ gdip_getlowestrect (GpRectF *rects, int cnt, GpRectF* src, GpRectF* rslt)
 	return TRUE;
 }
 
-/* Finds a rect that has the lowest x and y after the src rect provided */
+/* Finds the non-empty rect that has the lowest x and y after the current index */
 static BOOL
-gdip_getlowestrect_sorted (GpRectF *rects, int cnt, int* index, GpRectF* src, GpRectF* rslt)
+gdip_getlowestrect_sorted (GpRectF *rects, int cnt, int* index, GpRectF* rslt)
 {
 	GpRectF *current;
 	BOOL found = FALSE;
 
+	(*index)++;
 	for (current = rects + *index; *index < cnt; (*index)++, current++) {
 		if (current->Width <= 0 || current->Height <= 0)
 			continue;
 
-		if (current->Y > src->Y ||
-			(current->Y == src->Y && current->X > src->X)) {
-			found = TRUE;
-			break;
-		}
+		found = TRUE;
+		break;
 	}
 
 	if (found == FALSE) {
@@ -1092,7 +1090,7 @@ gdip_combine_union (GpRegion *region, GpRectF *rtrg, int cnttrg)
 {
 	GpRectF *allrects = NULL, *rects = NULL;
 	GpRectF *recttrg, *rect, *rectop;
-	int allcnt = 0, allcap, cnt = 0, cap = 0, currentIndex = 0, i, n;
+	int allcnt = 0, allcap, cnt = 0, cap = 0, currentIndex = -1, i, n;
 	GpRectF current, rslt, newrect;
 	BOOL storecomplete, contained, needsort;
 	GpStatus status;
@@ -1124,12 +1122,7 @@ gdip_combine_union (GpRegion *region, GpRectF *rtrg, int cnttrg)
 
 	gdip_sort_rect_array(allrects, allcnt);
 
-	/* Init current with the first element in the array */
-	current.X = REGION_INFINITE_POSITION;
-	current.Y = REGION_INFINITE_POSITION;
-	current.Width = 0; current.Height = 0;
-
-	while (gdip_getlowestrect_sorted (allrects, allcnt, &currentIndex, &current, &rslt)) {
+	while (gdip_getlowestrect_sorted (allrects, allcnt, &currentIndex, &rslt)) {
 
 		current.X = rslt.X; current.Y = rslt.Y;
 		current.Width = rslt.Width; current.Height = rslt.Height;

--- a/src/region.c
+++ b/src/region.c
@@ -775,7 +775,7 @@ GdipCreateRegionRgnData (GDIPCONST BYTE *regionData, INT size, GpRegion **region
 		result->type = RegionTypeInfinite;
 
 		GpRectF rect = {REGION_INFINITE_POSITION, REGION_INFINITE_POSITION, REGION_INFINITE_LENGTH, REGION_INFINITE_LENGTH};
-		gdip_add_rect_to_array (&result->rects, &result->cnt, &rect);
+		gdip_add_rect_to_array (&result->rects, &result->cnt, NULL, &rect);
 		
 		break;
 	}
@@ -1391,7 +1391,7 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 
 	if (combineMode == CombineModeReplace) {
 		GdipSetEmpty (region);
-		return gdip_add_rect_to_array (&region->rects, &region->cnt, (GpRectF *)rect);
+		return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, (GpRectF *)rect);
 	}
 
 	BOOL infinite = gdip_is_InfiniteRegion (region);
@@ -1429,7 +1429,7 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 			GdipSetEmpty (region);
 			GpRectF normalized;
 			gdip_normalize_rectangle (rect, &normalized);
-			return gdip_add_rect_to_array (&region->rects, &region->cnt, &normalized);
+			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, &normalized);
 		}
 		case CombineModeUnion:
 			/* The union of the infinite region and X is the infinite region */
@@ -1454,7 +1454,7 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 			/* The XOR of the empty region and X is X */
 			/* Everything is outside the empty region */
 			GdipSetEmpty (region);
-			return gdip_add_rect_to_array (&region->rects, &region->cnt, (GpRectF *)rect);
+			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, (GpRectF *)rect);
 		default:
 			break;
 		}

--- a/src/region.c
+++ b/src/region.c
@@ -1162,22 +1162,23 @@ gdip_combine_union (GpRegion *region, GpRectF *rtrg, int cnttrg)
 
 			/* Our rect intersects in the lower part with another rect */
 			newrect.Y = current.Y;
+			newrect.X = current.X;
 			if (current.Y == recttrg->Y) {
-				newrect.X = MIN (current.X, recttrg->X);
 				newrect.Width = MAX (current.X + current.Width, recttrg->X + recttrg->Width) - newrect.X;
 				newrect.Height = MIN (current.Height, recttrg->Height);
 			}
 			else {
-				newrect.X = current.X;
 				newrect.Width = current.Width;
 				newrect.Height = recttrg->Y - current.Y;
 			}
 
 			/* If it's contained inside, get the > height */
-			if (recttrg->X == current.X && recttrg->Width == current.Width) {
-				newrect.Height = MAX (current.Height, recttrg->Y + recttrg->Height - current.Y);
+			if (recttrg->X == current.X && (recttrg->Width == current.Width ||
+				(recttrg->Y == current.Y && recttrg->Width > current.Width))) {
+
+				newrect.Height = recttrg->Y + recttrg->Height - current.Y;
 			} else if (recttrg->X >= current.X && recttrg->X + recttrg->Width <= current.X + current.Width) {
-				newrect.Height = MAX (current.Height, newrect.Height);
+				newrect.Height = current.Height;
 			}
 
 			gdip_add_rect_to_array_notcontained (&rects, &cnt, &cap, &newrect);

--- a/src/region.c
+++ b/src/region.c
@@ -247,11 +247,13 @@ gdip_is_InfiniteRegion (const GpRegion *region)
 }
 
 static BOOL
-gdip_intersects (const GpRectF *rect1, const GpRectF *rect2)
+gdip_intersects (const GpRectF *rect1, const GpRectF *rect2, BOOL includeTouching)
 {
-	if (rect1->X + rect1->Width == rect2->X) {
-		return TRUE;
-	}
+	if (includeTouching)
+		return (rect1->X <= rect2->X + rect2->Width &&
+			rect1->X + rect1->Width >= rect2->X &&
+			rect1->Y <= rect2->Y + rect2->Height &&
+			rect1->Y + rect1->Height >= rect2->Y);
 
 	return (rect1->X < rect2->X + rect2->Width &&
 		rect1->X + rect1->Width > rect2->X &&
@@ -780,7 +782,7 @@ gdip_combine_exclude (GpRegion *region, GpRectF *rtrg, int cntt)
 		/* Current rect with lowest y and X against the target ones */
 		for (i = 0, recttrg = alltrgrects; i < alltrgcnt; i++, recttrg++) {
 
-			if (gdip_intersects (&current, recttrg) == FALSE
+			if (gdip_intersects (&current, recttrg, FALSE) == FALSE
 				|| gdip_equals (&current, recttrg) == TRUE ||
 				recttrg->Height < 0 || recttrg->Width < 0) {
 				continue;
@@ -989,7 +991,7 @@ gdip_combine_union (GpRegion *region, GpRectF *rtrg, int cnttrg)
 				continue;
 			}
 
-			if (gdip_intersects (&current, recttrg) == FALSE
+			if (gdip_intersects (&current, recttrg, TRUE) == FALSE
 				|| gdip_equals (&current, recttrg) == TRUE ||
 				recttrg->Height < 0 || recttrg->Width < 0) {
 				continue;

--- a/src/region.c
+++ b/src/region.c
@@ -1209,8 +1209,7 @@ gdip_combine_union (GpRegion *region, GpRectF *rtrg, int cnttrg)
 				}
 
 				if (contained == FALSE) {
-					status = gdip_add_rect_to_array (&allrects, &allcnt, &allcap,  &rslt);
-					needsort = TRUE;
+					status = gdip_add_rect_to_array_sorted (&allrects, &allcnt, &allcap,  &rslt);
 					if (status != Ok) {
 						GdipFree (allrects);
 						return status;

--- a/src/region.c
+++ b/src/region.c
@@ -1178,10 +1178,13 @@ gdip_combine_union (GpRegion *region, GpRectF *rtrg, int cnttrg)
 				newrect.X = current.X;
 				newrect.Width = current.Width;
 				newrect.Height = recttrg->Y - current.Y;
+			}
 
-				/* If it's contained inside, get the > height */
-				if (recttrg->X >= current.X && recttrg->X + recttrg->Width <= current.X + current.Width)
-					newrect.Height = MAX (current.Height, recttrg->Height);
+			/* If it's contained inside, get the > height */
+			if (recttrg->X == current.X && recttrg->Width == current.Width) {
+				newrect.Height = MAX (current.Height, recttrg->Y + recttrg->Height - current.Y);
+			} else if (recttrg->X >= current.X && recttrg->X + recttrg->Width <= current.X + current.Width) {
+				newrect.Height = MAX (current.Height, newrect.Height);
 			}
 
 			gdip_add_rect_to_array_notcontained (&rects, &cnt, &cap, &newrect);

--- a/tests/testregion.c
+++ b/tests/testregion.c
@@ -4219,6 +4219,10 @@ static void test_combineUnion ()
 	RectF intersectRightTallerRect = {20, 20, 30, 60};
 	RectF intersectRightShorterRect = {20, 20, 30, 20};
 	RectF tallerRect = {10, 20, 30, 70};
+	RectF tallerNarrowRect = {10, 20, 10, 70};
+	RectF widerRect = {10, 20, 60, 40};
+	RectF widerShorterRect = {10, 20, 60, 20};
+	RectF largerRect = {10, 20, 60, 70};
 	RectF crossingRect = {0, 30, 50, 20};
 	RectF emptyRect = {0, 0, 0, 0};
 	RectF infiniteRect = {-4194304, -4194304, 8388608, 8388608};
@@ -4569,6 +4573,28 @@ static void test_combineUnion ()
 	// Rect + Taller = Calculation.
 	RectF tallerScan = tallerRect;
 	verifyCombineRectWithRect (&rect, &tallerRect, CombineModeUnion, 10, 20, 30, 70, FALSE, FALSE, &tallerScan, sizeof (tallerScan));
+
+	// Rect + Taller Narrow = Calculation.
+	RectF tallerNarrowScans[] = {
+		{10, 20, 30, 40},
+		{10, 60, 10, 30},
+	};
+	verifyCombineRectWithRect (&rect, &tallerNarrowRect, CombineModeUnion, 10, 20, 30, 70, FALSE, FALSE, tallerNarrowScans, sizeof (tallerNarrowScans));
+
+	// Rect + Wider = Calculation.
+	RectF widerScan = widerRect;
+	verifyCombineRectWithRect (&rect, &widerRect, CombineModeUnion, 10, 20, 60, 40, FALSE, FALSE, &widerScan, sizeof (widerScan));
+
+	// Rect + Wider Shorter = Calculation.
+	RectF widerShorterScans[] = {
+		{10, 20, 60, 20},
+		{10, 40, 30, 20},
+	};
+	verifyCombineRectWithRect (&rect, &widerShorterRect, CombineModeUnion, 10, 20, 60, 40, FALSE, FALSE, widerShorterScans, sizeof (widerShorterScans));
+
+	// Rect + Larger = Calculation.
+	RectF largerScan = largerRect;
+	verifyCombineRectWithRect (&rect, &largerRect, CombineModeUnion, 10, 20, 60, 70, FALSE, FALSE, &largerScan, sizeof (largerScan));
 
 	// Rect + Overlap Taller Narrow = Calculation.
 	RectF crossingScans[] = {

--- a/tests/testregion.c
+++ b/tests/testregion.c
@@ -4682,10 +4682,10 @@ static void test_combineUnion ()
 
 	// No Intersect Top Rect + No Intersect Bottom Right = Both.
 	RectF noIntersectTopAndBottomRight[] = {
-		noIntersectTopRect,
-		noIntersectBottomRightRect
+		touchingTopRect,
+		touchingBottomRightRect
 	};
-	verifyCombineRectWithRect (&noIntersectTopRect, &noIntersectBottomRightRect, CombineModeUnion, 10, -20, 60, 120, FALSE, FALSE, noIntersectTopAndBottomRight, sizeof (noIntersectTopAndBottomRight));
+	verifyCombineRectWithRect (&touchingTopRect, &touchingBottomRightRect, CombineModeUnion, 10, -20, 60, 120, FALSE, FALSE, noIntersectTopAndBottomRight, sizeof (noIntersectTopAndBottomRight));
 
 
 	// Rect + Infinite Path = Infinite.

--- a/tests/testregion.c
+++ b/tests/testregion.c
@@ -3291,6 +3291,18 @@ static void verifyCombineRegionWithPathImpl (GpRegion *region, GpPath *path, Com
 	GdipDeleteRegion (region); \
 } \
 
+#define verifyCombineRects(rects, rectsCount, mode, x, y, width, height, isEmpty, isInfinite, scans, scansCount) \
+{ \
+	GpRegion *region; \
+	GdipCreateRegionRect (rects, &region); \
+	int _c = rectsCount / sizeof (GpRectF); \
+ \
+	for (int _i = 1; _i < _c - 1; _i++) \
+		GdipCombineRegionRect (region, &rects[_i], mode); \
+	verifyCombineRegionWithRect (region, &rects[_c - 1], mode, x, y, width, height, isEmpty, isInfinite, scans, scansCount); \
+	GdipDeleteRegion (region); \
+} \
+
 #define verifyCombineRectWithPath(rect, path, mode, x, y, width, height, isEmpty, isInfinite, scans, scansCount) \
 { \
 	GpRegion *region; \
@@ -4199,6 +4211,15 @@ static void test_combineUnion ()
 	RectF noIntersectTopRightRect = {41, -21, 30, 40};
 	RectF noIntersectBottomRightRect = {41, 61, 30, 40};
 	RectF noIntersectBottomLeftRect = {-21, 61, 30, 40};
+	RectF intersectLeftNarrowRect = {-30, 30, 60, 10};
+	RectF intersectTopNarrowRect = {20, -20, 10, 60};
+	RectF intersectRightNarrowRect = {20, 30, 60, 10};
+	RectF intersectBottomNarrowRect = {20, 40, 10, 60};
+	RectF touchesTopIntersectBottomNarrowRect = {20, 20, 10, 60};
+	RectF intersectRightTallerRect = {20, 20, 30, 60};
+	RectF intersectRightShorterRect = {20, 20, 30, 20};
+	RectF tallerRect = {10, 20, 30, 70};
+	RectF crossingRect = {0, 30, 50, 20};
 	RectF emptyRect = {0, 0, 0, 0};
 	RectF infiniteRect = {-4194304, -4194304, 8388608, 8388608};
 	RectF negativeRect = {20, 30, -10, -10};
@@ -4374,13 +4395,8 @@ static void test_combineUnion ()
 	verifyCombineRectWithRect (&rect, &intersectLeftRect, CombineModeUnion, 0, 20, 40, 40, FALSE, FALSE, &intersectLeftScan, sizeof (intersectLeftScan));
 
 	// Rect + Intersect Top = Calculation.
-	// FIXME: should be combined into a single rect: https://github.com/mono/libgdiplus/issues/340
 	RectF intersectTopScan = {10, 10, 30, 50};
-#if defined(USE_WINDOWS_GDIPLUS)
 	RectF intersectTopScansRect[] = {intersectTopScan};
-#else
-	RectF intersectTopScansRect[] = {{10, 10, 30, 40}, {10, 50, 30, 10}};
-#endif
 	verifyCombineRectWithRect (&rect, &intersectTopRect, CombineModeUnion, 10, 10, 30, 50, FALSE, FALSE, intersectTopScansRect, sizeof (intersectTopScansRect));
 	
 	// Rect + Intersect Right = Calculation.
@@ -4388,13 +4404,8 @@ static void test_combineUnion ()
 	verifyCombineRectWithRect (&rect, &intersectRightRect, CombineModeUnion, 10, 20, 40, 40, FALSE, FALSE, &intersectRightScan, sizeof (intersectRightScan));
 
 	// Rect + Intersect Bottom = Calculation.
-	// FIXME: should be combined into a single rect: https://github.com/mono/libgdiplus/issues/340
 	RectF intersectBottomScan = {10, 20, 30, 50};
-#if defined(USE_WINDOWS_GDIPLUS)
 	RectF intersectBottomScansRect[] = {intersectBottomScan};
-#else
-	RectF intersectBottomScansRect[] = {{10, 20, 30, 40}, {10, 60, 30, 10}};
-#endif
 	verifyCombineRectWithRect (&rect, &intersectBottomRect, CombineModeUnion, 10, 20, 30, 50, FALSE, FALSE, intersectBottomScansRect, sizeof (intersectBottomScansRect));
 
 	// Rect + Intersect Top Left = Calculation.
@@ -4434,13 +4445,8 @@ static void test_combineUnion ()
 	verifyCombineRectWithRect (&rect, &touchingLeftRect, CombineModeUnion, -20, 20, 60, 40, FALSE, FALSE, &touchingLeftScan, sizeof (touchingLeftScan));
 
 	// Rect + Touching Top = Calculation.
-	// FIXME: should be combined into a single rect: https://github.com/mono/libgdiplus/issues/340
 	RectF touchingTopScan = {10, -20, 30, 80};
-#if defined(USE_WINDOWS_GDIPLUS)
 	RectF touchingTopScansRect[] = {touchingTopScan};
-#else
-	RectF touchingTopScansRect[] = {{10, -20, 30, 40}, {10, 20, 30, 40}};
-#endif
 	verifyCombineRectWithRect (&rect, &touchingTopRect, CombineModeUnion, 10, -20, 30, 80, FALSE, FALSE, touchingTopScansRect, sizeof (touchingTopScansRect));
 
 	// Rect + Touching Right = Calculation.
@@ -4448,13 +4454,8 @@ static void test_combineUnion ()
 	verifyCombineRectWithRect (&rect, &touchingRightRect, CombineModeUnion, 10, 20, 60, 40, FALSE, FALSE, &touchingRightScan, sizeof (touchingRightScan));
 
 	// Rect + Touching Bottom = Calculation.
-	// FIXME: should be combined into a single rect: https://github.com/mono/libgdiplus/issues/340
 	RectF touchingBottomScan = {10, 20, 30, 80};
-#if defined(USE_WINDOWS_GDIPLUS)
 	RectF touchingBottomScansRect[] = {touchingBottomScan};
-#else
-	RectF touchingBottomScansRect[] = {{10, 20, 30, 40}, {10, 60, 30, 40}};
-#endif
 	verifyCombineRectWithRect (&rect, &touchingBottomRect, CombineModeUnion, 10, 20, 30, 80, FALSE, FALSE, touchingBottomScansRect, sizeof (touchingBottomScansRect));
 
 	// Rect + Touching Top Left = Both.
@@ -4512,6 +4513,118 @@ static void test_combineUnion ()
 		noIntersectBottomRect
 	};
 	verifyCombineRectWithRect (&rect, &noIntersectBottomRect, CombineModeUnion, 10, 20, 30, 81, FALSE, FALSE, noIntersectBottomScans, sizeof (noIntersectBottomScans));
+	
+	// Rect + Intersect Left Narrow = Calculation.
+	RectF intersectLeftNarrowScans[] = {
+		{10, 20, 30, 10},
+		{-30, 30, 70, 10},
+		{10, 40, 30, 20},
+	};
+	verifyCombineRectWithRect (&rect, &intersectLeftNarrowRect, CombineModeUnion, -30, 20, 70, 40, FALSE, FALSE, intersectLeftNarrowScans, sizeof (intersectLeftNarrowScans));
+
+	// RectF intersectTopNarrowRect = {20, -20, 10, 60};
+	// Rect + Intersect Top Narrow = Calculation.
+	RectF intersectTopNarrowScans[] = {
+		{20, -20, 10, 40},
+		{10, 20, 30, 40},
+	};
+	verifyCombineRectWithRect (&rect, &intersectTopNarrowRect, CombineModeUnion, 10, -20, 30, 80, FALSE, FALSE, intersectTopNarrowScans, sizeof (intersectTopNarrowScans));
+
+	// Rect + Intersect Right Narrow = Calculation.
+	RectF intersectRightNarrowScans[] = {
+		{10, 20, 30, 10},
+		{10, 30, 70, 10},
+		{10, 40, 30, 20},
+	};
+	verifyCombineRectWithRect (&rect, &intersectRightNarrowRect, CombineModeUnion, 10, 20, 70, 40, FALSE, FALSE, intersectRightNarrowScans, sizeof (intersectRightNarrowScans));
+
+	// Rect + Intersect Bottom Narrow = Calculation.
+	RectF intersectBottomNarrowScans[] = {
+		{10, 20, 30, 40},
+		{20, 60, 10, 40}
+	};
+	verifyCombineRectWithRect (&rect, &intersectBottomNarrowRect, CombineModeUnion, 10, 20, 30, 80, FALSE, FALSE, intersectBottomNarrowScans, sizeof (intersectBottomNarrowScans));
+
+	// Rect + Touches Top Intersect Bottom Narrow = Calculation.
+	RectF touchesTopIntersectBottomNarrowScans[] = {
+		{10, 20, 30, 40},
+		{20, 60, 10, 20}
+	};
+	verifyCombineRectWithRect (&rect, &touchesTopIntersectBottomNarrowRect, CombineModeUnion, 10, 20, 30, 60, FALSE, FALSE, touchesTopIntersectBottomNarrowScans, sizeof (touchesTopIntersectBottomNarrowScans));
+
+	// Rect + Intersect Right Taller = Calculation.
+	RectF intersectRightTallerScans[] = {
+		{10, 20, 40, 40},
+		{20, 60, 30, 20},
+	};
+	verifyCombineRectWithRect (&rect, &intersectRightTallerRect, CombineModeUnion, 10, 20, 40, 60, FALSE, FALSE, intersectRightTallerScans, sizeof (intersectRightTallerScans));
+
+	// Rect + Intersect Right Shorter = Calculation.
+	RectF intersectRightShorterScans[] = {
+		{10, 20, 40, 20},
+		{10, 40, 30, 20},
+	};
+	verifyCombineRectWithRect (&rect, &intersectRightShorterRect, CombineModeUnion, 10, 20, 40, 40, FALSE, FALSE, intersectRightShorterScans, sizeof (intersectRightShorterScans));
+
+	// Rect + Taller = Calculation.
+	RectF tallerScan = tallerRect;
+	verifyCombineRectWithRect (&rect, &tallerRect, CombineModeUnion, 10, 20, 30, 70, FALSE, FALSE, &tallerScan, sizeof (tallerScan));
+
+	// Rect + Overlap Taller Narrow = Calculation.
+	RectF crossingScans[] = {
+		{10, 20, 30, 10},
+		{0, 30, 50, 20},
+		{10, 50, 30, 10},
+	};
+	verifyCombineRectWithRect (&rect, &crossingRect, CombineModeUnion, 0, 20, 50, 40, FALSE, FALSE, crossingScans, sizeof (crossingScans));
+
+	// Ported from mono/external/corefx/src/System.Drawing.Common/tests/RegionTests.cs:1813
+	RectF intersectThreeRects[] = {
+		{20, 180, 40, 50},
+		{50, 190, 40, 50},
+		{70, 210, 30, 50}
+	};
+	RectF intersectThreeRectsScans[] = {
+		{20, 180, 40, 10},
+		{20, 190, 70, 20},
+		{20, 210, 80, 20},
+		{50, 230, 50, 10},
+		{70, 240, 30, 20}
+	};
+	verifyCombineRects (intersectThreeRects, sizeof (intersectThreeRects), CombineModeUnion, 20, 180, 80, 80, FALSE, FALSE, intersectThreeRectsScans, sizeof (intersectThreeRectsScans));
+
+	// Ported from mono/external/corefx/src/System.Drawing.Common/tests/RegionTests.cs:1831
+	RectF intersectFourRects[] = {
+		{20, 330, 40, 50},
+		{50, 340, 40, 50},
+		{70, 360, 30, 50},
+		{80, 400, 30, 10}
+	};
+	RectF intersectFourRectsScans[] = {
+		{20, 330, 40, 10},
+		{20, 340, 70, 20},
+		{20, 360, 80, 20},
+		{50, 380, 50, 10},
+		{70, 390, 30, 10},
+		{70, 400, 40, 10}
+	};
+	verifyCombineRects (intersectFourRects, sizeof (intersectFourRects), CombineModeUnion, 20, 330, 90, 80, FALSE, FALSE, intersectFourRectsScans, sizeof (intersectFourRectsScans));
+
+	// Ported from mono/external/corefx/src/System.Drawing.Common/tests/RegionTests.cs:1918
+	// Has two regions separated by 0 pixels.
+	RectF fourPartialIntersectRects[] = {
+		{30, 30, 80, 80},
+		{45, 45, 200, 200},
+		{160, 260, 10, 10},
+		{170, 260, 10, 10}
+	};
+	RectF fourPartialIntersectRectsScans[] = {
+		{30, 30, 80, 15},
+		{30, 45, 215, 65},
+		{45, 110, 200, 135},
+		{160, 260, 20, 10}
+	};
+	verifyCombineRects (fourPartialIntersectRects, sizeof (fourPartialIntersectRects), CombineModeUnion, 30, 30, 215, 240, FALSE, FALSE, fourPartialIntersectRectsScans, sizeof (fourPartialIntersectRectsScans));
 
 	// Rect + No Intersect Top Left = Both.
 	RectF noIntersectTopLeftScans[] = {

--- a/tests/testregion.c
+++ b/tests/testregion.c
@@ -4541,6 +4541,14 @@ static void test_combineUnion ()
 	};
 	verifyCombineRectWithRect (&rect, &noIntersectBottomLeftRect, CombineModeUnion, -21, 20, 61, 81, FALSE, FALSE, noIntersectBottomLeftScans, sizeof (noIntersectBottomLeftScans));
 
+	// No Intersect Top Rect + No Intersect Bottom Right = Both.
+	RectF noIntersectTopAndBottomRight[] = {
+		noIntersectTopRect,
+		noIntersectBottomRightRect
+	};
+	verifyCombineRectWithRect (&noIntersectTopRect, &noIntersectBottomRightRect, CombineModeUnion, 10, -20, 60, 120, FALSE, FALSE, noIntersectTopAndBottomRight, sizeof (noIntersectTopAndBottomRight));
+
+
 	// Rect + Infinite Path = Infinite.
 	// FIXME: this should be infinite: https://github.com/mono/libgdiplus/issues/339
 #if defined(USE_WINDOWS_GDIPLUS)


### PR DESCRIPTION
Region Union was sometimes doing strange things. The problem seems to be that gdip_intersects was returning true in some situations for rectangles that do not necessarily intersect (right of first == X of next, irrespective of Y / Height). I have added a test-case for this.

I initially made gdip_intersects return true for any rectangles that touch, as this would seem to be the desired behaviour for unions. However, that caused test failures for XOR which traces back to exclude, so I tried changing back to only returning true when actually overlapping. That in turn caused test failures for union, so I added a parameter to choose which behaviour was desired.