### PR TITLE
Initial AIX support for libgdiplus

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,17 @@ case "$host" in
 		CFLAGS="-pthreads $CFLAGS"
 		;;
 
+	*-*-aix*|*-*-os400)
+		AC_DEFINE_UNQUOTED(AIX,1,[AIX or PASE])
+		# Specify a 64-bit build via GCC, as Mono is always 64-bit on AIX/PASE
+		CFLAGS="-D_THREAD_SAFE -maix64 $CFLAGS"
+		LDFLAGS="-maix64 $LDFLAGS"
+		# Like mono, don't use `OBJECT_MODE=64`, but specify 64-bit mode IBM binutils
+		# explictly instead.
+		AR="/usr/bin/ar -X64"
+		NM="/usr/bin/nm -X64"
+		;;
+
 	*-*-darwin*)
 		AC_DEFINE_UNQUOTED(OSX,1,[OS X])
 		CFLAGS="-no-cpp-precomp $CFLAGS"
@@ -190,6 +201,13 @@ case "$host" in
 		case $host_os in
 		  solaris*)
 			# On solaris 10 x86, gcc prints a warning saying 'visibility attribute not supported on this configuration; ignored', but linking fails.
+			have_visibility_hidden=no
+		esac
+		;;
+	powerpc-*-*)
+		case $host_os in
+		  aix*|os400*)
+			# XCOFF doesn't have this, but somehow it appears anyways
 			have_visibility_hidden=no
 		esac
 		;;


### PR DESCRIPTION
Tested with a mix of AIX Toolbox and Perzl packages. Builds a 64
bit libgdiplus to go with mono.

X11, giflib (but not ungiflib), libexif, libpng, giflib, and libtiff
are all used.

Due to deficiencies in the AIX Toolbox version of Cairo, where it
specifies system X11 in the package, but IBM's system X11 lacks
a package, you must specify Cairo flags manually to the configure
script like so. This isn't done by the script as you may be using
a Cairo linked against a newer X.org instead.

```shell
CAIRO_CFLAGS=-I/opt/freeware/include/cairo
CAIRO_LIBS="-L/opt/freeware/lib -lcairo"
CPPFLAGS=-I/opt/freeware/include/cairo
```

This is untested on PASE.