### PR TITLE
Transform fixes

### DIFF
--- a/src/graphics-private.h
+++ b/src/graphics-private.h
@@ -131,6 +131,7 @@ typedef struct _Graphics {
 	GpRegion*		clip;
 	GpMatrix*		clip_matrix;
 	GpRect			bounds;
+	GpRect			orig_bounds;
 	GpUnit			page_unit;
 	float			scale;
 	InterpolationMode	interpolation;

--- a/src/image.c
+++ b/src/image.c
@@ -329,6 +329,8 @@ GdipGetImageGraphicsContext (GpImage *image, GpGraphics **graphics)
 	gfx->dpi_y = image->active_bitmap->dpi_vert <= 0 ? gdip_get_display_dpi () : image->active_bitmap->dpi_vert;
 	gfx->bounds.Width = image->active_bitmap->width;
 	gfx->bounds.Height = image->active_bitmap->height;
+	gfx->orig_bounds.Width = image->active_bitmap->width;
+	gfx->orig_bounds.Height = image->active_bitmap->height;
 	cairo_surface_destroy (surface);
 
 	gfx->image = image;

--- a/tests/testgraphics.c
+++ b/tests/testgraphics.c
@@ -2078,6 +2078,70 @@ static void test_premultiplication ()
 	GdipDisposeImage ((GpImage *) bitmap);
 }
 
+static void test_world_transform_in_container ()
+{
+	GpStatus status;
+	GpImage *image;
+	GpGraphics *graphics;
+	GraphicsContainer state;
+	GpMatrix *matrix;
+	GpMatrix *setMatrix;
+
+	graphics = getImageGraphics (&image);
+
+	status = GdipCreateMatrix2 (0, 0, 0, 0, 0, 0, &matrix);
+	assertEqualInt (status, Ok);
+
+	status = GdipCreateMatrix2 (2, 0, 0, 2, 10, 20, &setMatrix);
+	assertEqualInt (status, Ok);
+
+	status = GdipSetWorldTransform (graphics, setMatrix);
+	assertEqualInt (status, Ok);
+
+	status = GdipGetWorldTransform (graphics, matrix);
+	assertEqualInt (status, Ok);
+	BOOL result;
+	GdipIsMatrixEqual (matrix, setMatrix, &result);
+	assertEqualInt (result, 1);
+
+	status = GdipBeginContainer2 (graphics, &state);
+	assertEqualInt (status, Ok);
+
+	status = GdipGetWorldTransform (graphics, matrix);
+	assertEqualInt (status, Ok);
+	GdipIsMatrixIdentity (matrix, &result);
+	assertEqualInt (result, 1);
+
+	status = GdipSetWorldTransform (graphics, setMatrix);
+	assertEqualInt (status, Ok);
+
+	status = GdipGetWorldTransform (graphics, matrix);
+	assertEqualInt (status, Ok);
+	GdipIsMatrixEqual (matrix, setMatrix, &result);
+	assertEqualInt (result, 1);
+
+	status = GdipResetWorldTransform (graphics);
+	assertEqualInt (status, Ok);
+
+	status = GdipGetWorldTransform (graphics, matrix);
+	assertEqualInt (status, Ok);
+	GdipIsMatrixIdentity (matrix, &result);
+	assertEqualInt (result, 1);
+
+	status = GdipEndContainer (graphics, state);
+	assertEqualInt (status, Ok);
+
+	status = GdipGetWorldTransform (graphics, matrix);
+	assertEqualInt (status, Ok);
+	GdipIsMatrixEqual (matrix, setMatrix, &result);
+	assertEqualInt (result, 1);
+
+	GdipDeleteMatrix (matrix);
+	GdipDeleteMatrix (setMatrix);
+	GdipDisposeImage (image);
+	GdipDeleteGraphics (graphics);
+}
+
 int
 main (int argc, char**argv)
 {
@@ -2121,6 +2185,7 @@ main (int argc, char**argv)
 	test_translateClipI ();
 	test_region_mask ();
 	test_premultiplication ();
+	test_world_transform_in_container ();
 
 	SHUTDOWN;
 	return 0;


### PR DESCRIPTION
Fix setting the world transform when in a container. It needs to take the parent transform into account.

Also store and use the original GpGraphics bounds, to fix the action of `apply_world_to_bounds` (was applying the complete transform to partially-transformed coordinates.