### PR TITLE
Fix incorrect cast in apply_world_to_bounds

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -580,19 +580,16 @@ GdipSaveGraphics (GpGraphics *graphics, unsigned int *state)
 	return Ok;
 }
 
-static GpStatus
+static void
 apply_world_to_bounds (GpGraphics *graphics)
 {
-	GpStatus status;
 	GpPointF pts[2];
 
 	pts[0].X = graphics->orig_bounds.X;
 	pts[0].Y = graphics->orig_bounds.Y;
 	pts[1].X = graphics->orig_bounds.X + graphics->orig_bounds.Width;
 	pts[1].Y = graphics->orig_bounds.Y + graphics->orig_bounds.Height;
-	status = GdipTransformMatrixPoints (graphics->clip_matrix, (GpPointF*)&pts, 2);
-	if (status != Ok)
-		return status;
+	GdipTransformMatrixPoints (graphics->clip_matrix, pts, 2);
 
 	if (pts[0].X > pts[1].X) {
 		graphics->bounds.X = pts[1].X;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -605,7 +605,6 @@ apply_world_to_bounds (GpGraphics *graphics)
 		graphics->bounds.Y = pts[0].Y;
 		graphics->bounds.Height = iround (pts[1].Y - pts[0].Y);
 	}
-	return Ok;
 }
 
 GpStatus WINGDIPAPI


### PR DESCRIPTION
Taking the address of an array then converting it to a pointer is incorrect.
- not sure why this code actually works though, maybe because PointF the same size as a pointer?

And remove unecessary checks for status
- there's no way GdipTransformMatrixPoints can fail here and no one even checks the return value anyway

