### PR TITLE
Revert " Fix combine for negative rects/paths and IsEmpty"

### DIFF
--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -1021,7 +1021,7 @@ GdipAddPathRectangle (GpPath *path, float x, float y, float width, float height)
 	if (!path)
 		return InvalidParameter;
 
-	if ((width <= 0.0) || (height <= 0.0))
+	if ((width == 0.0) || (height == 0.0))
 		return Ok;
 
 	if (!gdip_path_ensure_size (path, path->count + 4))

--- a/src/region.c
+++ b/src/region.c
@@ -320,8 +320,6 @@ gdip_is_region_empty (const GpRegion *region, BOOL allowNegative)
 			if (!gdip_path_closed (region->tree->path))
 				return TRUE;
 		}
-		if (region->bitmap && (region->bitmap->Width == 0 || region->bitmap->Height == 0))
-			return TRUE;
 
 		return FALSE;
 	default:
@@ -1362,12 +1360,9 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 		return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, (GpRectF *)rect);
 	}
 
-	GpRectF normalized;
-	gdip_normalize_rectangle (rect, &normalized);
-
 	BOOL infinite = gdip_is_InfiniteRegion (region);
 	BOOL empty = gdip_is_region_empty (region, /* allowNegative */ TRUE);
-	BOOL rectEmpty = gdip_is_rect_empty (&normalized, /* allowNegative */ FALSE);
+	BOOL rectEmpty = gdip_is_rect_empty (rect, /* allowNegative */ FALSE);
 
 	if (rectEmpty) {
 		switch (combineMode) {
@@ -1398,6 +1393,8 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 		case CombineModeIntersect: {
 			/* The intersection of the infinite region with X is X */
 			GdipSetEmpty (region);
+			GpRectF normalized;
+			gdip_normalize_rectangle (rect, &normalized);
 			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, &normalized);
 		}
 		case CombineModeUnion:
@@ -1423,7 +1420,7 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 			/* The XOR of the empty region and X is X */
 			/* Everything is outside the empty region */
 			GdipSetEmpty (region);
-			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, &normalized);
+			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, (GpRectF *)rect);
 		default:
 			break;
 		}
@@ -1435,35 +1432,30 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 		region->type = RegionTypeRect;
 		switch (combineMode) {
 		case CombineModeExclude:
-			return gdip_combine_exclude (region, &normalized, 1);
+			return gdip_combine_exclude (region, (GpRectF *) rect, 1);
 		case CombineModeComplement:
-			return gdip_combine_complement (region, &normalized, 1);
+			return gdip_combine_complement (region, (GpRectF *) rect, 1);
 		case CombineModeIntersect:
-			return gdip_combine_intersect (region, &normalized, 1);
+			return gdip_combine_intersect (region, (GpRectF *) rect, 1);
 		case CombineModeUnion:
-			return gdip_combine_union (region, &normalized, 1);
+			return gdip_combine_union (region, (GpRectF *) rect, 1);
 		case CombineModeXor:
-			return gdip_combine_xor (region, &normalized, 1);
+			return gdip_combine_xor (region, (GpRectF *) rect, 1);
 		case CombineModeReplace: /* Used by Graphics clipping */
-			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, &normalized);
+			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, (GpRectF *)rect);
 		default:
 			return NotImplemented;
 		}
 	}
 	case RegionTypePath: {
 		/* Convert GpRectF to GpPath and use GdipCombineRegionPath */
-		GpPath *path;
+		GpPath *path = NULL;
 		GpStatus status = GdipCreatePath (FillModeAlternate, &path);
-		if (status != Ok)
-			return status;
-
-		status = GdipAddPathRectangle (path, normalized.X, normalized.Y, normalized.Width, normalized.Height);
-		if (status != Ok) {
-			GdipDeletePath (path);
-			return status;
+		if (status == Ok) {
+			GdipAddPathRectangle (path, rect->X, rect->Y, rect->Width, rect->Height);
+			status = GdipCombineRegionPath (region, path, combineMode);
 		}
 
-		status = GdipCombineRegionPath (region, path, combineMode);
 		GdipDeletePath (path);
 		return status;
 	}

--- a/tests/testregion.c
+++ b/tests/testregion.c
@@ -114,14 +114,6 @@ static void verifyRegionDataImpl (GpRegion *region, BYTE *expected, INT expected
 #define verifyRegionData(region, expectedData) \
 	verifyRegionDataImpl (region, expectedData, sizeof (expectedData), __FILE__, __func__, __LINE__)
 
-static GpPath *createPathFromRect(RectF *rect)
-{
-	GpPath *path;
-	GdipCreatePath (FillModeAlternate, &path);
-	GdipAddPathRectangle (path, rect->X, rect->Y, rect->Width, rect->Height);
-	return path;
-}
-
 static BYTE infiniteRegionData[] = {
 	/* --RegionHeader-- */
 	/* Size */          0x0C, 0x00, 0x00, 0x00,
@@ -4119,6 +4111,14 @@ static void verifyCombineRegionWithPathImpl (GpRegion *region, GpPath *path, Com
 	GdipDeleteRegion (region); \
 } \
 
+static GpPath *createPathFromRect(RectF *rect)
+{
+	GpPath *path;
+	GdipCreatePath (FillModeAlternate, &path);
+	GdipAddPathRectangle (path, rect->X, rect->Y, rect->Width, rect->Height);
+	return path;
+}
+
 static void test_combineReplace ()
 {
 	GpRegion *infiniteRegion;
@@ -4516,7 +4516,6 @@ static void test_combineIntersect ()
 
 	// Rect + No Intersect Bottom Left = Empty.
 	verifyCombineRectWithRect (&rect, &noIntersectBottomLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
-
 	// Rect + Infinite Path = Path.
 	// FIXME: this fails with OutOfMemory: https://github.com/mono/libgdiplus/issues/338
 #if defined(USE_WINDOWS_GDIPLUS)
@@ -4527,7 +4526,10 @@ static void test_combineIntersect ()
 	verifyCombineRectWithPath (&rect, emptyPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Negative Path = Empty.
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+#if defined(USE_WINDOWS_GDIPLUS)
 	verifyCombineRectWithPath (&rect, negativePath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+#endif
 
 	// Rect + Equal Path = Equal Path.
 	verifyCombineRectWithPath (&rect, path, CombineModeIntersect, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
@@ -4563,52 +4565,68 @@ static void test_combineIntersect ()
 	verifyCombineRectWithPath (&rect, intersectBottomLeftPath, CombineModeIntersect, 10, 30, 20, 30, FALSE, FALSE, &intersectBottomLeftScan, sizeof (intersectBottomLeftScan));
 
 	// Rect + Touching Left = Empty.
-	verifyCombineRectWithPath (&rect, touchingLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, touchingLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Touching Top = Empty.
-	verifyCombineRectWithPath (&rect, touchingTopPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, touchingTopPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Touching Right = Empty.
-	verifyCombineRectWithPath (&rect, touchingRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, touchingRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Touching Bottom = Empty.
-	verifyCombineRectWithPath (&rect, touchingBottomPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, touchingBottomPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Touching Top Left = Empty.
-	verifyCombineRectWithPath (&rect, touchingTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, touchingTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Touching Top Right = Empty.
-	verifyCombineRectWithPath (&rect, touchingTopRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, touchingTopRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Touching Bottom Right = Empty.
-	verifyCombineRectWithPath (&rect, touchingBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, touchingBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Touching Bottom Left = Empty.
-	verifyCombineRectWithPath (&rect, touchingBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, touchingBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Left = Empty.
-	verifyCombineRectWithPath (&rect, noIntersectLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, noIntersectLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Top = Empty.
-	verifyCombineRectWithPath (&rect, noIntersectTopPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, noIntersectTopPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Right = Empty.
-	verifyCombineRectWithPath (&rect, noIntersectRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, noIntersectRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Bottom = Empty.
-	verifyCombineRectWithPath (&rect, noIntersectBottomPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, noIntersectBottomPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Top Left = Empty.
-	verifyCombineRectWithPath (&rect, noIntersectTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, noIntersectTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Top Right = Empty.
-	verifyCombineRectWithPath (&rect, noIntersectTopRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, noIntersectTopRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Bottom Right = Empty.
-	verifyCombineRectWithPath (&rect, noIntersectBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, noIntersectBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Bottom Left = Empty.
-	verifyCombineRectWithPath (&rect, noIntersectBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, noIntersectBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 	
 	// Infinite Path + Infinite = Infinite.
 	verifyCombinePathWithRegion (infinitePath, infiniteRegion, CombineModeIntersect, -4194304, -4194304, 8388608, 8388608, FALSE, TRUE, infiniteScans, sizeof (infiniteScans));
@@ -4731,52 +4749,68 @@ static void test_combineIntersect ()
 	verifyCombinePathWithRect (path, &intersectBottomLeftRect, CombineModeIntersect, 10, 30, 20, 30, FALSE, FALSE, &intersectBottomLeftScan, sizeof (intersectBottomLeftScan));
 
 	// Path + Touching Left = Empty.
-	verifyCombinePathWithRect (path, &touchingLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &touchingLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Top = Empty.
-	verifyCombinePathWithRect (path, &touchingTopRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &touchingTopRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Right = Empty.
-	verifyCombinePathWithRect (path, &touchingRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &touchingRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom = Empty.
-	verifyCombinePathWithRect (path, &touchingBottomRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &touchingBottomRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Top Left = Empty.
-	verifyCombinePathWithRect (path, &touchingTopLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &touchingTopLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Top Right = Empty.
-	verifyCombinePathWithRect (path, &touchingTopRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &touchingTopRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom Right = Empty.
-	verifyCombinePathWithRect (path, &touchingBottomRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &touchingBottomRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom Left = Empty.
-	verifyCombinePathWithRect (path, &touchingBottomLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &touchingBottomLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Left = Empty.
-	verifyCombinePathWithRect (path, &noIntersectLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &noIntersectLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top = Empty.
-	verifyCombinePathWithRect (path, &noIntersectTopRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &noIntersectTopRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Right = Empty.
-	verifyCombinePathWithRect (path, &noIntersectRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &noIntersectRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom = Empty.
-	verifyCombinePathWithRect (path, &noIntersectBottomRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &noIntersectBottomRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top Left = Empty.
-	verifyCombinePathWithRect (path, &noIntersectTopLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &noIntersectTopLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top Right = Empty.
-	verifyCombinePathWithRect (path, &noIntersectTopRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &noIntersectTopRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom Right = Empty.
-	verifyCombinePathWithRect (path, &noIntersectBottomRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &noIntersectBottomRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom Left = Empty.
-	verifyCombinePathWithRect (path, &noIntersectBottomLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &noIntersectBottomLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Equal Path = Equal Path.
 	verifyCombinePathWithPath (path, path, CombineModeIntersect, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
@@ -4810,54 +4844,69 @@ static void test_combineIntersect ()
 
 	// Path + Intersect Bottom Left = Calculation.
 	verifyCombinePathWithPath (path, intersectBottomLeftPath, CombineModeIntersect, 10, 30, 20, 30, FALSE, FALSE, &intersectBottomLeftScan, sizeof (intersectBottomLeftScan));
-	
-	// Path + Touching Left = Empty.
-	verifyCombinePathWithPath (path, touchingLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+		// Path + Touching Left = Empty.
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, touchingLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Top = Empty.
-	verifyCombinePathWithPath (path, touchingTopPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, touchingTopPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Right = Empty.
-	verifyCombinePathWithPath (path, touchingRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, touchingRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom = Empty.
-	verifyCombinePathWithPath (path, touchingBottomPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, touchingBottomPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Top Left = Empty.
-	verifyCombinePathWithPath (path, touchingTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, touchingTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Top Right = Empty.
-	verifyCombinePathWithPath (path, touchingTopRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, touchingTopRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom Right = Empty.
-	verifyCombinePathWithPath (path, touchingBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, touchingBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom Left = Empty.
-	verifyCombinePathWithPath (path, touchingBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, touchingBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Left = Empty.
-	verifyCombinePathWithPath (path, noIntersectLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, noIntersectLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top = Empty.
-	verifyCombinePathWithPath (path, noIntersectTopPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, noIntersectTopPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Right = Empty.
-	verifyCombinePathWithPath (path, noIntersectRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, noIntersectRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom = Empty.
-	verifyCombinePathWithPath (path, noIntersectBottomPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, noIntersectBottomPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top Left = Empty.
-	verifyCombinePathWithPath (path, noIntersectTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, noIntersectTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top Right = Empty.
-	verifyCombinePathWithPath (path, noIntersectTopRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, noIntersectTopRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom Right = Empty.
-	verifyCombinePathWithPath (path, noIntersectBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, noIntersectBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom Left = Empty.
-	verifyCombinePathWithPath (path, noIntersectBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, noIntersectBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	GdipDeleteRegion (infiniteRegion);
 	GdipDeleteRegion (emptyRegion);
@@ -6346,7 +6395,8 @@ static void test_combineXor ()
 	verifyCombineRectWithPath (&rect, emptyPath, CombineModeXor, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
 
 	// Rect + Equal Path = Empty.
-	verifyCombineRectWithPath (&rect, path, CombineModeXor, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, path, CombineModeXor, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/347.
 #if defined(USE_WINDOWS_GDIPLUS)
@@ -6623,10 +6673,14 @@ static void test_combineXor ()
 	verifyCombinePathWithPath (path, emptyPath, CombineModeXor, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
 
 	// Path + Negative Path = Path.
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+#if defined(USE_WINDOWS_GDIPLUS)
 	verifyCombinePathWithPath (path, negativePath, CombineModeXor, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
+#endif
 
 	// Path + Equal Path = Empty.
-	verifyCombinePathWithPath (path, path, CombineModeXor, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, path, CombineModeXor, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/347.
 #if defined(USE_WINDOWS_GDIPLUS)
@@ -7170,10 +7224,12 @@ static void test_combineExclude ()
 	}
 
 	// Rect + Equal Path = Empty.
-	verifyCombineRectWithPath (&rect, path, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, path, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Super Path = Empty.
-	verifyCombineRectWithPath (&rect, superPath, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, superPath, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Sub Path = Rect and Not Sub Path.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/354
@@ -7347,10 +7403,12 @@ static void test_combineExclude ()
 	}
 
 	// Path + Equal Rect = Empty.
-	verifyCombinePathWithRect (path, &rect, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &rect, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Super Rect = Empty.
-	verifyCombinePathWithRect (path, &superRect, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &superRect, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Sub Rect = Path and Not Sub Rect.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/354
@@ -7440,13 +7498,18 @@ static void test_combineExclude ()
 	verifyCombinePathWithPath (path, emptyPath, CombineModeExclude, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
 
 	// Path + Negative Path = Path.
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+#if defined(USE_WINDOWS_GDIPLUS)
 	verifyCombinePathWithPath (path, negativePath, CombineModeExclude, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
+#endif
 
 	// Path + Equal Path = Empty.
-	verifyCombinePathWithPath (path, path, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, path, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Super Path = Empty.
-	verifyCombinePathWithPath (path, superPath, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, superPath, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Sub Path = Path and Not Sub Path.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/354
@@ -7875,7 +7938,7 @@ static void test_combineComplement ()
 	// Rect + No Intersect Bottom Left = No Intersect Bottom Left.
 	verifyCombineRectWithRect (&rect, &noIntersectBottomLeftRect, CombineModeComplement, -21, 61, 30, 40, FALSE, FALSE, &noIntersectBottomLeftRect, sizeof (noIntersectBottomLeftRect));
 
-  	// Rect + Infinite Path = Infinite.
+  // Rect + Infinite Path = Infinite.
 	// FIXME: this fails with OutOfMemory: https://github.com/mono/libgdiplus/issues/338
 #if defined(USE_WINDOWS_GDIPLUS)
 	verifyCombineRectWithPath (&rect, infinitePath, CombineModeComplement, -4194304, -4194304, 8388608, 8388608, FALSE, FALSE, rectWithInfiniteScans, sizeof (rectWithInfiniteScans));
@@ -7885,10 +7948,10 @@ static void test_combineComplement ()
 	verifyCombineRectWithPath (&rect, emptyPath, CombineModeComplement, 0, 0,0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Negative Path = Empty.
-	verifyCombineRectWithPath (&rect, negativePath, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, negativePath, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Equal Path = Empty.
-	verifyCombineRectWithPath (&rect, path, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, path, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Super Path = Not Rect and Super Path.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/358
@@ -7897,7 +7960,8 @@ static void test_combineComplement ()
 #endif
 
 	// Rect + Sub Path = Empty
-	verifyCombineRectWithPath (&rect, subPath, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombineRectWithPath (&rect, subPath, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Rect + Intersect Left = Not Rect and Intersect Left.
 	verifyCombineRectWithPath (&rect, intersectLeftPath, CombineModeComplement, 0, 20, 10, 40, FALSE, FALSE, &intersectLeftScan, sizeof (intersectLeftScan));
@@ -8041,10 +8105,14 @@ static void test_combineComplement ()
 	verifyCombinePathWithRect (path, &emptyRect, CombineModeComplement, 0, 0,0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Negative Rect = Empty.
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+#if defined(USE_WINDOWS_GDIPLUS)
 	verifyCombinePathWithRect (path, &negativeRect, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+#endif
 
 	// Path + Equal Rect = Empty.
-	verifyCombinePathWithRect (path, &rect, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &rect, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Super Rect = Not Rect and Super Rect.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/358
@@ -8053,7 +8121,8 @@ static void test_combineComplement ()
 #endif
 
 	// Path + Sub Rect = Empty.
-	verifyCombinePathWithRect (path, &subRect, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithRect (path, &subRect, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Intersect Left = Not Path and Intersect Left.
 	verifyCombinePathWithRect (path, &intersectLeftRect, CombineModeComplement, 0, 20, 10, 40, FALSE, FALSE, &intersectLeftScan, sizeof (intersectLeftScan));
@@ -8137,10 +8206,12 @@ static void test_combineComplement ()
 	verifyCombinePathWithPath (path, emptyPath, CombineModeComplement, 0, 0,0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Negative Path = Empty.
-	verifyCombinePathWithPath (path, negativePath, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, negativePath, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Equal Path = Empty.
-	verifyCombinePathWithPath (path, path, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
+	verifyCombinePathWithPath (path, path, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Super Path = Not Path and Super Path.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/358
@@ -8149,7 +8220,7 @@ static void test_combineComplement ()
 #endif
 
 	// Path + Sub Path = Empty
-	verifyCombinePathWithPath (path, subPath, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, subPath, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
 
 	// Path + Intersect Left = Not Path and Intersect Left.
 	verifyCombinePathWithPath (path, intersectLeftPath, CombineModeComplement, 0, 20, 10, 40, FALSE, FALSE, &intersectLeftScan, sizeof (intersectLeftScan));


### PR DESCRIPTION
Reverts mono/libgdiplus#434

It caused testregion to fail:

```
../test-driver: line 107: 11856 Aborted                 (core dumped) "$@" > $log_file 2>&1
FAIL: testregion
```

/cc @hughbe maybe a side effect of the other merged PRs ?
