### PR TITLE
Reapply "Fix combine for negative rects/paths and IsEmpty"

### DIFF
--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -1021,7 +1021,7 @@ GdipAddPathRectangle (GpPath *path, float x, float y, float width, float height)
 	if (!path)
 		return InvalidParameter;
 
-	if ((width == 0.0) || (height == 0.0))
+	if ((width <= 0.0) || (height <= 0.0))
 		return Ok;
 
 	if (!gdip_path_ensure_size (path, path->count + 4))

--- a/src/region.c
+++ b/src/region.c
@@ -527,7 +527,6 @@ gdip_copy_region (GpRegion *source, GpRegion *dest)
 static GpStatus
 gdip_region_convert_to_path (GpRegion *region)
 {
-	int i;
 	GpRectF *rect;
 	GpStatus status;
 
@@ -545,13 +544,16 @@ gdip_region_convert_to_path (GpRegion *region)
 
 	switch (region->type) {
 	case RegionTypeRect:
-	case RegionTypeInfinite:
+	case RegionTypeInfinite: {
 		/* all rectangles are converted into a single path */
-		for (i = 0, rect = region->rects; i < region->cnt; i++, rect++) {
-			GdipAddPathRectangle (region->tree->path, rect->X, rect->Y, rect->Width, rect->Height);
+		for (int i = 0; i < region->cnt; i++) {
+			RectF normalized;
+			gdip_normalize_rectangle (&region->rects[i], &normalized);
+			GdipAddPathRectangle (region->tree->path, normalized.X, normalized.Y, normalized.Width, normalized.Height);
 		}
 
 		break;
+	}
 	default:
 		g_warning ("unknown type 0x%08X", region->type);
 		return NotImplemented;

--- a/src/region.c
+++ b/src/region.c
@@ -307,6 +307,8 @@ gdip_is_region_empty (const GpRegion *region, BOOL allowNegative)
 			if (!gdip_path_closed (region->tree->path))
 				return TRUE;
 		}
+		if (region->bitmap && (region->bitmap->Width == 0 || region->bitmap->Height == 0))
+			return TRUE;
 
 		return FALSE;
 	default:
@@ -1326,9 +1328,12 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 		return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, (GpRectF *)rect);
 	}
 
+	GpRectF normalized;
+	gdip_normalize_rectangle (rect, &normalized);
+
 	BOOL infinite = gdip_is_InfiniteRegion (region);
 	BOOL empty = gdip_is_region_empty (region, /* allowNegative */ TRUE);
-	BOOL rectEmpty = gdip_is_rectF_empty (rect, /* allowNegative */ FALSE);
+	BOOL rectEmpty = gdip_is_rectF_empty (&normalized, /* allowNegative */ FALSE);
 
 	if (rectEmpty) {
 		switch (combineMode) {
@@ -1359,8 +1364,6 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 		case CombineModeIntersect: {
 			/* The intersection of the infinite region with X is X */
 			GdipSetEmpty (region);
-			GpRectF normalized;
-			gdip_normalize_rectangle (rect, &normalized);
 			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, &normalized);
 		}
 		case CombineModeUnion:
@@ -1386,7 +1389,7 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 			/* The XOR of the empty region and X is X */
 			/* Everything is outside the empty region */
 			GdipSetEmpty (region);
-			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, (GpRectF *)rect);
+			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, &normalized);
 		default:
 			break;
 		}
@@ -1398,30 +1401,35 @@ GdipCombineRegionRect (GpRegion *region, GDIPCONST GpRectF *rect, CombineMode co
 		region->type = RegionTypeRect;
 		switch (combineMode) {
 		case CombineModeExclude:
-			return gdip_combine_exclude (region, (GpRectF *) rect, 1);
+			return gdip_combine_exclude (region, &normalized, 1);
 		case CombineModeComplement:
-			return gdip_combine_complement (region, (GpRectF *) rect, 1);
+			return gdip_combine_complement (region, &normalized, 1);
 		case CombineModeIntersect:
-			return gdip_combine_intersect (region, (GpRectF *) rect, 1);
+			return gdip_combine_intersect (region, &normalized, 1);
 		case CombineModeUnion:
-			return gdip_combine_union (region, (GpRectF *) rect, 1);
+			return gdip_combine_union (region, &normalized, 1);
 		case CombineModeXor:
-			return gdip_combine_xor (region, (GpRectF *) rect, 1);
+			return gdip_combine_xor (region, &normalized, 1);
 		case CombineModeReplace: /* Used by Graphics clipping */
-			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, (GpRectF *)rect);
+			return gdip_add_rect_to_array (&region->rects, &region->cnt, NULL, &normalized);
 		default:
 			return NotImplemented;
 		}
 	}
 	case RegionTypePath: {
 		/* Convert GpRectF to GpPath and use GdipCombineRegionPath */
-		GpPath *path = NULL;
+		GpPath *path;
 		GpStatus status = GdipCreatePath (FillModeAlternate, &path);
-		if (status == Ok) {
-			GdipAddPathRectangle (path, rect->X, rect->Y, rect->Width, rect->Height);
-			status = GdipCombineRegionPath (region, path, combineMode);
+		if (status != Ok)
+			return status;
+
+		status = GdipAddPathRectangle (path, normalized.X, normalized.Y, normalized.Width, normalized.Height);
+		if (status != Ok) {
+			GdipDeletePath (path);
+			return status;
 		}
 
+		status = GdipCombineRegionPath (region, path, combineMode);
 		GdipDeletePath (path);
 		return status;
 	}

--- a/tests/testregion.c
+++ b/tests/testregion.c
@@ -4410,6 +4410,7 @@ static void test_combineIntersect ()
 
 	// Rect + No Intersect Bottom Left = Empty.
 	verifyCombineRectWithRect (&rect, &noIntersectBottomLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+
 	// Rect + Infinite Path = Path.
 	// FIXME: this fails with OutOfMemory: https://github.com/mono/libgdiplus/issues/338
 #if defined(USE_WINDOWS_GDIPLUS)
@@ -4420,10 +4421,7 @@ static void test_combineIntersect ()
 	verifyCombineRectWithPath (&rect, emptyPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Negative Path = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-#if defined(USE_WINDOWS_GDIPLUS)
 	verifyCombineRectWithPath (&rect, negativePath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
-#endif
 
 	// Rect + Equal Path = Equal Path.
 	verifyCombineRectWithPath (&rect, path, CombineModeIntersect, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
@@ -4459,68 +4457,52 @@ static void test_combineIntersect ()
 	verifyCombineRectWithPath (&rect, intersectBottomLeftPath, CombineModeIntersect, 10, 30, 20, 30, FALSE, FALSE, &intersectBottomLeftScan, sizeof (intersectBottomLeftScan));
 
 	// Rect + Touching Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, touchingLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, touchingLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Touching Top = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, touchingTopPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, touchingTopPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Touching Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, touchingRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, touchingRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Touching Bottom = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, touchingBottomPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, touchingBottomPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Touching Top Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, touchingTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, touchingTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Touching Top Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, touchingTopRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, touchingTopRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Touching Bottom Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, touchingBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, touchingBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Touching Bottom Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, touchingBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, touchingBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, noIntersectLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, noIntersectLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Top = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, noIntersectTopPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, noIntersectTopPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, noIntersectRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, noIntersectRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Bottom = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, noIntersectBottomPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, noIntersectBottomPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Top Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, noIntersectTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, noIntersectTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Top Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, noIntersectTopRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, noIntersectTopRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Bottom Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, noIntersectBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, noIntersectBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + No Intersect Bottom Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, noIntersectBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, noIntersectBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 	
 	// Infinite Path + Infinite = Infinite.
 	verifyCombinePathWithRegion (infinitePath, infiniteRegion, CombineModeIntersect, -4194304, -4194304, 8388608, 8388608, FALSE, TRUE, infiniteScans, sizeof (infiniteScans));
@@ -4643,68 +4625,52 @@ static void test_combineIntersect ()
 	verifyCombinePathWithRect (path, &intersectBottomLeftRect, CombineModeIntersect, 10, 30, 20, 30, FALSE, FALSE, &intersectBottomLeftScan, sizeof (intersectBottomLeftScan));
 
 	// Path + Touching Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &touchingLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &touchingLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Top = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &touchingTopRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &touchingTopRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &touchingRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &touchingRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &touchingBottomRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &touchingBottomRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Top Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &touchingTopLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &touchingTopLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Top Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &touchingTopRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &touchingTopRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &touchingBottomRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &touchingBottomRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &touchingBottomLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &touchingBottomLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &noIntersectLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &noIntersectLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &noIntersectTopRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &noIntersectTopRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &noIntersectRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &noIntersectRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &noIntersectBottomRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &noIntersectBottomRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &noIntersectTopLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &noIntersectTopLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &noIntersectTopRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &noIntersectTopRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &noIntersectBottomRightRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &noIntersectBottomRightRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &noIntersectBottomLeftRect, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &noIntersectBottomLeftRect, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Equal Path = Equal Path.
 	verifyCombinePathWithPath (path, path, CombineModeIntersect, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
@@ -4738,69 +4704,54 @@ static void test_combineIntersect ()
 
 	// Path + Intersect Bottom Left = Calculation.
 	verifyCombinePathWithPath (path, intersectBottomLeftPath, CombineModeIntersect, 10, 30, 20, 30, FALSE, FALSE, &intersectBottomLeftScan, sizeof (intersectBottomLeftScan));
-		// Path + Touching Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, touchingLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	
+	// Path + Touching Left = Empty.
+	verifyCombinePathWithPath (path, touchingLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Top = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, touchingTopPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, touchingTopPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, touchingRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, touchingRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, touchingBottomPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, touchingBottomPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Top Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, touchingTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, touchingTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Top Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, touchingTopRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, touchingTopRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, touchingBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, touchingBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Touching Bottom Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, touchingBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, touchingBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, noIntersectLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, noIntersectLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, noIntersectTopPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, noIntersectTopPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, noIntersectRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, noIntersectRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, noIntersectBottomPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, noIntersectBottomPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, noIntersectTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, noIntersectTopLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Top Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, noIntersectTopRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, noIntersectTopRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom Right = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, noIntersectBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, noIntersectBottomRightPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + No Intersect Bottom Left = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, noIntersectBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, noIntersectBottomLeftPath, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	GdipDeleteRegion (infiniteRegion);
 	GdipDeleteRegion (emptyRegion);
@@ -6289,8 +6240,7 @@ static void test_combineXor ()
 	verifyCombineRectWithPath (&rect, emptyPath, CombineModeXor, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
 
 	// Rect + Equal Path = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, path, CombineModeXor, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, path, CombineModeXor, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/347.
 #if defined(USE_WINDOWS_GDIPLUS)
@@ -6567,14 +6517,10 @@ static void test_combineXor ()
 	verifyCombinePathWithPath (path, emptyPath, CombineModeXor, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
 
 	// Path + Negative Path = Path.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-#if defined(USE_WINDOWS_GDIPLUS)
 	verifyCombinePathWithPath (path, negativePath, CombineModeXor, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
-#endif
 
 	// Path + Equal Path = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, path, CombineModeXor, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, path, CombineModeXor, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/347.
 #if defined(USE_WINDOWS_GDIPLUS)
@@ -7118,12 +7064,10 @@ static void test_combineExclude ()
 	}
 
 	// Rect + Equal Path = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, path, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, path, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Super Path = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, superPath, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, superPath, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Sub Path = Rect and Not Sub Path.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/354
@@ -7297,12 +7241,10 @@ static void test_combineExclude ()
 	}
 
 	// Path + Equal Rect = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &rect, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &rect, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Super Rect = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &superRect, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &superRect, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Sub Rect = Path and Not Sub Rect.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/354
@@ -7392,18 +7334,13 @@ static void test_combineExclude ()
 	verifyCombinePathWithPath (path, emptyPath, CombineModeExclude, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
 
 	// Path + Negative Path = Path.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-#if defined(USE_WINDOWS_GDIPLUS)
 	verifyCombinePathWithPath (path, negativePath, CombineModeExclude, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
-#endif
 
 	// Path + Equal Path = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, path, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, path, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Super Path = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, superPath, CombineModeExclude, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, superPath, CombineModeExclude, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Sub Path = Path and Not Sub Path.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/354
@@ -7832,7 +7769,7 @@ static void test_combineComplement ()
 	// Rect + No Intersect Bottom Left = No Intersect Bottom Left.
 	verifyCombineRectWithRect (&rect, &noIntersectBottomLeftRect, CombineModeComplement, -21, 61, 30, 40, FALSE, FALSE, &noIntersectBottomLeftRect, sizeof (noIntersectBottomLeftRect));
 
-  // Rect + Infinite Path = Infinite.
+  	// Rect + Infinite Path = Infinite.
 	// FIXME: this fails with OutOfMemory: https://github.com/mono/libgdiplus/issues/338
 #if defined(USE_WINDOWS_GDIPLUS)
 	verifyCombineRectWithPath (&rect, infinitePath, CombineModeComplement, -4194304, -4194304, 8388608, 8388608, FALSE, FALSE, rectWithInfiniteScans, sizeof (rectWithInfiniteScans));
@@ -7842,10 +7779,10 @@ static void test_combineComplement ()
 	verifyCombineRectWithPath (&rect, emptyPath, CombineModeComplement, 0, 0,0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Negative Path = Empty.
-	verifyCombineRectWithPath (&rect, negativePath, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, negativePath, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Equal Path = Empty.
-	verifyCombineRectWithPath (&rect, path, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, path, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Super Path = Not Rect and Super Path.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/358
@@ -7854,8 +7791,7 @@ static void test_combineComplement ()
 #endif
 
 	// Rect + Sub Path = Empty
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombineRectWithPath (&rect, subPath, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombineRectWithPath (&rect, subPath, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Rect + Intersect Left = Not Rect and Intersect Left.
 	verifyCombineRectWithPath (&rect, intersectLeftPath, CombineModeComplement, 0, 20, 10, 40, FALSE, FALSE, &intersectLeftScan, sizeof (intersectLeftScan));
@@ -7999,14 +7935,10 @@ static void test_combineComplement ()
 	verifyCombinePathWithRect (path, &emptyRect, CombineModeComplement, 0, 0,0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Negative Rect = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-#if defined(USE_WINDOWS_GDIPLUS)
 	verifyCombinePathWithRect (path, &negativeRect, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
-#endif
 
 	// Path + Equal Rect = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &rect, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &rect, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Super Rect = Not Rect and Super Rect.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/358
@@ -8015,8 +7947,7 @@ static void test_combineComplement ()
 #endif
 
 	// Path + Sub Rect = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithRect (path, &subRect, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithRect (path, &subRect, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Intersect Left = Not Path and Intersect Left.
 	verifyCombinePathWithRect (path, &intersectLeftRect, CombineModeComplement, 0, 20, 10, 40, FALSE, FALSE, &intersectLeftScan, sizeof (intersectLeftScan));
@@ -8100,12 +8031,10 @@ static void test_combineComplement ()
 	verifyCombinePathWithPath (path, emptyPath, CombineModeComplement, 0, 0,0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Negative Path = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, negativePath, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, negativePath, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Equal Path = Empty.
-	// FIXME: this should set to empty: https://github.com/mono/libgdiplus/issues/336
-	verifyCombinePathWithPath (path, path, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, path, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Super Path = Not Path and Super Path.
 	// FIXME: incorrect scans: https://github.com/mono/libgdiplus/issues/358
@@ -8114,7 +8043,7 @@ static void test_combineComplement ()
 #endif
 
 	// Path + Sub Path = Empty
-	verifyCombinePathWithPath (path, subPath, CombineModeComplement, 0, 0, 0, 0, WINDOWS_GDIPLUS, FALSE, emptyScans, 0);
+	verifyCombinePathWithPath (path, subPath, CombineModeComplement, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
 
 	// Path + Intersect Left = Not Path and Intersect Left.
 	verifyCombinePathWithPath (path, intersectLeftPath, CombineModeComplement, 0, 20, 10, 40, FALSE, FALSE, &intersectLeftScan, sizeof (intersectLeftScan));


### PR DESCRIPTION
The failure in the tests was due to a PR that fixed the behaviour of `GdipTransformRegion` that we didn't account for when normalizing things

/cc @akoeplinger 