### PR TITLE
Refactor bmpcodec

### DIFF
--- a/src/bitmap-private.h
+++ b/src/bitmap-private.h
@@ -77,7 +77,7 @@ typedef struct {
 	unsigned int	width;
 	unsigned int	height;
 	int		stride;
-	int		pixel_format;
+	PixelFormat		pixel_format;
 	BYTE 		*scan0;
 	UINT_PTR	reserved;
 	/* the rest of the structure isn't part of MS GDI+ definition */

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -2001,16 +2001,6 @@ GdipBitmapUnlockBits (GpBitmap *bitmap, BitmapData *lockedBitmapData)
 	return status;
 }
 
-static void gdip_setpixel_32bppARGB (BYTE *scan, INT x, BYTE a, BYTE r, BYTE g, BYTE b)
-{
-	set_pixel_bgra (scan, x, a, r, g, b);
-}
-
-static void gdip_setpixel_32bppRGB (BYTE *scan, INT x, BYTE a, BYTE r, BYTE g, BYTE b)
-{
-	set_pixel_bgra (scan, x, a, r, g, b);
-}
-
 GpStatus WINGDIPAPI
 GdipBitmapSetPixel (GpBitmap *bitmap, INT x, INT y, ARGB color)
 {
@@ -2107,16 +2097,12 @@ GdipBitmapGetPixel (GpBitmap *bitmap, INT x, INT y, ARGB *color)
 			break;
 		}
 		case PixelFormat16bppARGB1555:
-		case PixelFormat16bppRGB555: {
-			WORD *scan = (WORD *) v;
-			*color = gdip_convert_16bppRGB555_ToARGB (scan[x]);
+		case PixelFormat16bppRGB555:
+			*color = gdip_getpixel_16bppRGB555 (v, x);
 			break;
-		}
-		case PixelFormat16bppRGB565: {
-			WORD *scan = (WORD *) v;
-			*color = gdip_convert_16bppRGB565_ToARGB (scan[x]);
+		case PixelFormat16bppRGB565:
+			*color = gdip_getpixel_16bppRGB565 (v, x);
 			break;
-		}
 		default:
 			return NotImplemented;
 		}

--- a/src/bmpcodec.c
+++ b/src/bmpcodec.c
@@ -318,15 +318,33 @@ gdip_read_bmp_rle_8bit (void *pointer, BYTE *scan0, BOOL upsidedown, int stride,
 	return Ok;
 }
 
+// PixelFormat32bppARGB.
 ARGB
-gdip_convert_16bppRGB555_ToARGB (WORD pixel)
+gdip_getpixel_32bppARGB (BYTE *scan, INT x)
 {
+	ARGB pixel = ((ARGB *) scan)[x];
+	return pixel;
+}
+
+void
+gdip_setpixel_32bppARGB (BYTE *scan, INT x, BYTE a, BYTE r, BYTE g, BYTE b)
+{
+	set_pixel_bgra (scan, x * 4, b, g, r, a);
+}
+
+// PixelFormat16bppRGB555.
+ARGB
+gdip_getpixel_16bppRGB555 (BYTE *scan, INT x)
+{
+	WORD pixel = ((WORD *) scan)[x];
 	return ((pixel & 0x1F) >> 2) | 8 * ((pixel & 0x1F) | 8 * (((((pixel >> 5) & 0x1F) | (((pixel >> 10) & 0x1C) << 8)) & 0xFFFFFFFC) | 32 * (((pixel >> 5) & 0x1F) | ((((pixel >> 10) & 0x1F) | 0xFFFFFFE0) << 8))));
 }
 
+// PixelFormat16bppRGB565.
 ARGB
-gdip_convert_16bppRGB565_ToARGB (WORD pixel)
+gdip_getpixel_16bppRGB565 (BYTE *scan, INT x)
 {
+	WORD pixel = ((WORD *) scan)[x];
 	return ((pixel & 0x1F) >> 2) | 8 * ((pixel & 0x1F) | 2 * (((((pixel >> 5) & 0x3F) | (((pixel >> 11) & 0xFFFFFFFC) << 10)) & 0xFFFFFFF0) | ((((pixel >> 5) & 0x3F) | ((((pixel >> 11)) | 0xFFFFFFE0) << 9)) << 6)));
 }
 

--- a/src/bmpcodec.h
+++ b/src/bmpcodec.h
@@ -76,7 +76,7 @@ ARGB gdip_getpixel_16bppRGB555 (BYTE *scan, INT x) GDIP_INTERNAL;
 ARGB gdip_getpixel_16bppRGB565 (BYTE *scan, INT x) GDIP_INTERNAL;
 
 /* helper functions / shared with ICOn codec */
-GpStatus gdip_read_BITMAPINFOHEADER (void *pointer, ImageSource source, BITMAPV5HEADER *bmi, BOOL *os2format, 
+GpStatus gdip_read_BITMAPINFOHEADER (void *pointer, ImageSource source, BITMAPV5HEADER *bmi, 
 	BOOL *upsidedown) GDIP_INTERNAL;
 int gdip_read_bmp_data (void *pointer, BYTE *data, int size, ImageSource source) GDIP_INTERNAL;
 

--- a/src/bmpcodec.h
+++ b/src/bmpcodec.h
@@ -68,8 +68,12 @@ GpStatus gdip_save_bmp_image_to_stream_delegate (PutBytesDelegate putBytesFunc, 
 ImageCodecInfo *gdip_getcodecinfo_bmp () GDIP_INTERNAL;
 
 /* Conversion functions */
-ARGB gdip_convert_16bppRGB555_ToARGB (WORD pixel);
-ARGB gdip_convert_16bppRGB565_ToARGB (WORD pixel);
+ARGB gdip_getpixel_32bppARGB (BYTE *scan, INT x) GDIP_INTERNAL;
+void gdip_setpixel_32bppARGB (BYTE *scan, INT x, BYTE a, BYTE r, BYTE g, BYTE b) GDIP_INTERNAL;
+
+ARGB gdip_getpixel_16bppRGB555 (BYTE *scan, INT x) GDIP_INTERNAL;
+
+ARGB gdip_getpixel_16bppRGB565 (BYTE *scan, INT x) GDIP_INTERNAL;
 
 /* helper functions / shared with ICOn codec */
 GpStatus gdip_read_BITMAPINFOHEADER (void *pointer, ImageSource source, BITMAPV5HEADER *bmi, BOOL *os2format, 

--- a/src/icocodec.c
+++ b/src/icocodec.c
@@ -112,7 +112,6 @@ gdip_read_ico_image_from_file_stream (void *pointer, GpImage **image, ImageSourc
 	ICONDIRENTRY entry;
 	int i, pos;
 	BOOL upsidedown = TRUE;
-	BOOL os2format = FALSE;
 	BITMAPV5HEADER bih;
 	int palette_entries = -1;
 	ARGB *colors = NULL;
@@ -163,7 +162,7 @@ gdip_read_ico_image_from_file_stream (void *pointer, GpImage **image, ImageSourc
 	}
 
 	/* BITMAPINFOHEADER */
-	status = gdip_read_BITMAPINFOHEADER (pointer, source, &bih, &os2format, &upsidedown);
+	status = gdip_read_BITMAPINFOHEADER (pointer, source, &bih, &upsidedown);
 	if (status != Ok)
 		goto error;
 	

--- a/src/win32structs.h
+++ b/src/win32structs.h
@@ -378,6 +378,7 @@ typedef gpointer LPVOID;
 typedef gboolean BOOL;
 typedef guint32 *LPDWORD;
 typedef gint16 SHORT;
+typedef guint16 USHORT;
 typedef gint32 LONG;
 typedef guint32 ULONG;
 typedef gint32 *PLONG;


### PR DESCRIPTION
Aims:
- Make it simpler to read this 1000 line long function
- Make it clearer what we're doing

There are a number of discrete stages involved in decoding a bmp image
- Reading the header
- Reading the palette if any
- Calculating the stride
- Reading the scans
- Converting the scans to a target pixel format if necessary

This PR splits the core bmp decoding into several routines that clarify these stages and will make it easier for me to make future changes