### PR TITLE
Update definition for X11 definition in config.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -464,7 +464,7 @@ fi
 if test x$x11_available = xyes; then
 	AC_DEFINE(HAVE_X11, 1, Define if x11 is available.)
 fi
-AM_CONDITIONAL(HAVE_X11, test x$libexif_pkgconfig = xyes)
+AM_CONDITIONAL(HAVE_X11, test x$x11_available = xyes)
 
 dnl Test for libexif
 if test x$with_libexif != xno && test -z "$LIBEXIF"; then

--- a/configure.ac
+++ b/configure.ac
@@ -461,11 +461,10 @@ else
   x11_available=no
 fi
 
-AS_IF(
-	[test x$x11_available = xyes],
-	[AC_DEFINE([HAS_X11], [1], [Define X11 support])],
-	[AC_DEFINE([HAS_X11], [0], [Skip X11 support])])
-AM_CONDITIONAL([HAS_X11], [test x$x11_available = xyes])
+if test x$x11_available = xyes; then
+	AC_DEFINE(HAVE_X11, 1, Define if x11 is available.)
+fi
+AM_CONDITIONAL(HAVE_X11, test x$libexif_pkgconfig = xyes)
 
 dnl Test for libexif
 if test x$with_libexif != xno && test -z "$LIBEXIF"; then

--- a/src/gdiplus-private.h
+++ b/src/gdiplus-private.h
@@ -61,13 +61,13 @@
 	#include <cairo/cairo-ft.h>
 #endif
 
-#if HAS_X11
+#if defined(HAVE_X11)
 #ifdef CAIRO_HAS_XLIB_SURFACE
 	#include <cairo/cairo-xlib.h>
 #endif
 #endif
 
-#if HAS_X11
+#if defined(HAVE_X11)
 #include <X11/Xlib.h>
 #endif
 

--- a/src/general.c
+++ b/src/general.c
@@ -190,7 +190,7 @@ gdip_get_display_dpi ()
 
 		dpis = h_dpi;
 		return dpis;
-#elif HAS_X11 && CAIRO_HAS_XLIB_SURFACE
+#elif defined(HAVE_X11) && CAIRO_HAS_XLIB_SURFACE
 		char *val;
 
 		Display* display;

--- a/src/graphics-private.h
+++ b/src/graphics-private.h
@@ -111,7 +111,7 @@ typedef struct _Graphics {
 	cairo_t			*ct;
 	GpMatrix		*copy_of_ctm;
 	cairo_matrix_t		previous_matrix;
-#if HAS_X11
+#if defined(HAVE_X11)
 #ifdef CAIRO_HAS_XLIB_SURFACE
 	Display			*display;
 	Drawable		drawable;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -155,7 +155,7 @@ gdip_graphics_common_init (GpGraphics *graphics)
 	graphics->dpi_x = graphics->dpi_y = 0;
 	graphics->state = GraphicsStateValid;
 
-#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
+#if defined(HAVE_X11) && CAIRO_HAS_XLIB_SURFACE
 	graphics->display = (Display*)NULL;
 	graphics->drawable = (Drawable)NULL;
 #endif
@@ -219,7 +219,7 @@ GpStatus WINGDIPAPI
 GdipCreateFromHDC (HDC hdc, GpGraphics **graphics)
 {
 	GpGraphics *clone = (GpGraphics *)hdc;
-#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
+#if defined(HAVE_X11) && CAIRO_HAS_XLIB_SURFACE
 	cairo_surface_t *surface;
 	int x, y;
 	unsigned int w, h, border_w, depth;
@@ -245,7 +245,7 @@ GdipCreateFromHDC (HDC hdc, GpGraphics **graphics)
 	if (clone->type == gtMemoryBitmap)
 		return GdipGetImageGraphicsContext (clone->image, graphics);
 
-#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
+#if defined(HAVE_X11) && CAIRO_HAS_XLIB_SURFACE
 	Window root;
 	XGetGeometry (clone->display, clone->drawable, &root,
 		      &x, &y, &w, &h, &border_w, &depth);
@@ -342,7 +342,7 @@ GdipCreateFromContext_macosx (void *ctx, int width, int height, GpGraphics **gra
 
 #endif
 
-#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
+#if defined(HAVE_X11) && CAIRO_HAS_XLIB_SURFACE
 
 // coverity[+alloc : arg-*2]
 GpStatus
@@ -384,7 +384,7 @@ GdipCreateFromXDrawable_linux(Drawable d, Display *dpy, GpGraphics **graphics)
 
 #endif
 
-#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
+#if defined(HAVE_X11) && CAIRO_HAS_XLIB_SURFACE
 static int
 ignore_error_handler (Display *dpy, XErrorEvent *event)
 {
@@ -418,7 +418,7 @@ GdipDeleteGraphics (GpGraphics *graphics)
 	}
 
 	if (graphics->ct) {
-#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
+#if defined(HAVE_X11) && CAIRO_HAS_XLIB_SURFACE
 		int (*old_error_handler)(Display *dpy, XErrorEvent *ev) = NULL;
 		if (graphics->type == gtX11Drawable)
 			old_error_handler = XSetErrorHandler (ignore_error_handler);
@@ -427,7 +427,7 @@ GdipDeleteGraphics (GpGraphics *graphics)
 		cairo_destroy (graphics->ct);
 		graphics->ct = NULL;
 
-#if HAS_X11 && CAIRO_HAS_XLIB_SURFACE
+#if defined(HAVE_X11) && CAIRO_HAS_XLIB_SURFACE
 		if (graphics->type == gtX11Drawable)
 			XSetErrorHandler (old_error_handler);
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -44,7 +44,7 @@ noinst_PROGRAMS =			\
 	testtiffcodec \
 	testwmfcodec
 
-if HAS_X11
+if HAVE_X11
 noinst_PROGRAMS += testgdi
 
 testgdi_DEPENDENCIES = $(TEST_DEPS)
@@ -52,7 +52,7 @@ testgdi_LDADD = $(LDADDS)
 
 testgdi_SOURCES =		\
 	testgdi.c
-endif HAS_X11
+endif HAVE_X11
 
 testadjustablearrowcap_SOURCES =		\
 	testadjustablearrowcap.c
@@ -348,6 +348,6 @@ TESTS = \
 	testwmfcodec \
 	$(NULL)
 
-if HAS_X11
+if HAVE_X11
 # TESTS += testgdi
 endif


### PR DESCRIPTION
All other libraries in libgdiplus follow the schema of defining (or not) a definition (e.g. `HAVE_LIBJPEG`)

However, the one for x11 is inconsistent, as it is either 1 or 0 and is called `HAS_X11`.

- Rename this to `HAVE_X11`
- Change it to be defined or not, rather than 1 or 0