### PR TITLE
Avoid unnecessary/dangerous compatibility flags on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,8 +152,6 @@ case "$host" in
 
 	*-*-darwin*)
 		AC_DEFINE_UNQUOTED(OSX,1,[OS X])
-		CFLAGS="-no-cpp-precomp $CFLAGS"
-		LDFLAGS="-flat_namespace -undefined suppress $LDFLAGS"
 		no_libpng16=yes # workaround until we can upgrade the libpng used by bockbuild
 		;;
 


### PR DESCRIPTION
These flags were added [quite some time ago](https://github.com/mono/libgdiplus/commit/bce17c28c445c49e9349aace2eb0e4a9bd235aad).
It is not entirely clear why they were needed since the original bug report is not easily accessible.
`-no-cpp-precomp` either [does nothing or causes errors](http://www.mistys-internet.website/blog/blog/2013/10/20/no-cpp-precomp-the-compiler-flag-that-time-forgot/).
`-flat_namespace -undefined suppress` is not a standard practice and causes [problems that are difficult to track down](https://trac.macports.org/ticket/24501).