### PR TITLE
Add text mode settings

### DIFF
--- a/src/text-cairo.c
+++ b/src/text-cairo.c
@@ -184,17 +184,34 @@ MeasureString (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, int *length
 			break;
 		}
 
-		// FIXME - pick matching settings for each text mode
-		case TextRenderingHintSingleBitPerPixelGridFit:
-		case TextRenderingHintSingleBitPerPixel:
-		case TextRenderingHintAntiAliasGridFit:
-		case TextRenderingHintAntiAlias: {
-			cairo_font_options_set_antialias(FontOptions, CAIRO_ANTIALIAS_DEFAULT);
+		case TextRenderingHintSingleBitPerPixelGridFit: {
+			cairo_font_options_set_antialias(FontOptions, CAIRO_ANTIALIAS_NONE);
+			cairo_font_options_set_hint_style(FontOptions, CAIRO_HINT_STYLE_MEDIUM);
+			cairo_font_options_set_hint_metrics(FontOptions, CAIRO_HINT_METRICS_ON);
 			break;
 		}
-
+		case TextRenderingHintSingleBitPerPixel: {
+			cairo_font_options_set_antialias(FontOptions, CAIRO_ANTIALIAS_NONE);
+			cairo_font_options_set_hint_style(FontOptions, CAIRO_HINT_STYLE_NONE);
+			cairo_font_options_set_hint_metrics(FontOptions, CAIRO_HINT_METRICS_OFF);
+			break;
+		}
+		case TextRenderingHintAntiAliasGridFit: {
+			cairo_font_options_set_antialias(FontOptions, CAIRO_ANTIALIAS_GRAY);
+			cairo_font_options_set_hint_style(FontOptions, CAIRO_HINT_STYLE_MEDIUM);
+			cairo_font_options_set_hint_metrics(FontOptions, CAIRO_HINT_METRICS_ON);
+			break;
+		}
+		case TextRenderingHintAntiAlias: {
+			cairo_font_options_set_antialias(FontOptions, CAIRO_ANTIALIAS_GRAY);
+			cairo_font_options_set_hint_style(FontOptions, CAIRO_HINT_STYLE_NONE);
+			cairo_font_options_set_hint_metrics(FontOptions, CAIRO_HINT_METRICS_OFF);
+			break;
+		}
 		case TextRenderingHintClearTypeGridFit: {
-			cairo_font_options_set_antialias(FontOptions, CAIRO_ANTIALIAS_DEFAULT);
+			cairo_font_options_set_antialias(FontOptions, CAIRO_ANTIALIAS_SUBPIXEL);
+			cairo_font_options_set_hint_style(FontOptions, CAIRO_HINT_STYLE_MEDIUM);
+			cairo_font_options_set_hint_metrics(FontOptions, CAIRO_HINT_METRICS_ON);
 			break;
 		}
 	}


### PR DESCRIPTION
Having this hooked up allows for better rendering for two/three color displays.

The text geometry isn't identical to Windows, but the aliasing is very similar, at least on Ubuntu running under the WSL. Note that CAIRO_ANTIALIAS_GRAY still generates non-gray pixels on Raspbian on RPi3B+. Presumably an issue with Cairo itself?

I've included the results of running the code in #535 on Ubuntu.

**Before**
![textaliasingubuntu](https://user-images.githubusercontent.com/8184940/53463703-8fe1ea00-39fc-11e9-9d0d-3b966b092f06.png)
**After**
![ta2](https://user-images.githubusercontent.com/8184940/53463659-632dd280-39fc-11e9-86bc-de6e41250794.png)

Fixes #535
