### PR TITLE
[WIP] GdipCloneBitmapAreaI sets pixel format correct

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -1118,6 +1118,7 @@ GdipCloneBitmapAreaI (INT x, INT y, INT width, INT height, PixelFormat format,
 	}
 
 	result->image_format = original->image_format;
+	result->active_bitmap->pixel_format = format;
 
 	status = gdip_bitmap_clone_data_rect (original->active_bitmap, &sr, result->active_bitmap, &dr);
 	if (status != Ok) {
@@ -1183,7 +1184,6 @@ gdip_bitmap_clone_data_rect (ActiveBitmapData *srcData, Rect *srcRect, ActiveBit
 	if (destData->scan0 == NULL) {
 		dest_components = gdip_get_pixel_format_components (srcData->pixel_format);
 		dest_depth = gdip_get_pixel_format_depth (srcData->pixel_format);
-		destData->pixel_format = srcData->pixel_format;
 
 		destData->stride = ((destRect->Width * dest_components * dest_depth) >> 3);
 		gdip_align_stride (destData->stride);
@@ -1195,7 +1195,6 @@ gdip_bitmap_clone_data_rect (ActiveBitmapData *srcData, Rect *srcRect, ActiveBit
 		
 		destData->width = destRect->Width;
 		destData->height = destRect->Height;
-		destData->pixel_format = srcData->pixel_format;
 		destData->reserved = GBD_OWN_SCAN0;
 
 		if (srcData->palette) {

--- a/tests/testbitmap.c
+++ b/tests/testbitmap.c
@@ -758,6 +758,25 @@ static void test_createBitmapFromGraphics ()
 	GdipDeleteGraphics (graphicsWithResolution);
 }
 
+static void test_cloneBitmap()
+{
+	GpStatus status;
+	GpBitmap *bitmap;
+	GpBitmap *clone;
+	
+	status = GdipCreateBitmapFromScan0(1, 1, 0, PixelFormat32bppARGB, NULL, &bitmap);
+	assertEqualInt(status, Ok);
+
+	status = GdipCloneBitmapAreaI(0, 0, 1, 1, PixelFormat4bppIndexed, bitmap, &clone);
+	assertEqualInt(status, Ok);
+
+	PixelFormat actual;
+	status = GdipGetImagePixelFormat(clone, &actual);
+	assertEqualInt(status, Ok);
+
+	assertEqualInt(actual, PixelFormat4bppIndexed);
+}
+
 int
 main(int argc, char**argv)
 {
@@ -769,6 +788,7 @@ main(int argc, char**argv)
 	test_createBitmapFromFileICM ();
 	test_createBitmapFromScan0 ();
 	test_createBitmapFromGraphics ();
+	test_cloneBitmap ();
 
 	SHUTDOWN;
 	return 0;

--- a/tests/testbitmap.c
+++ b/tests/testbitmap.c
@@ -760,21 +760,59 @@ static void test_createBitmapFromGraphics ()
 
 static void test_cloneBitmap()
 {
-	GpStatus status;
-	GpBitmap *bitmap;
-	GpBitmap *clone;
+	GpStatus    status;
+	GpBitmap    *bitmap;
+	GpBitmap    *clone;
+	PixelFormat actualFormat;
+	ARGB        color;
+
+	BYTE bpp32ArgbData[] = {
+		0xFF, 0x00, 0x00, 0xFF,
+		0x00, 0x00, 0xFF, 0xFF
+	};
 	
-	status = GdipCreateBitmapFromScan0(1, 1, 0, PixelFormat32bppARGB, NULL, &bitmap);
+	status = GdipCreateBitmapFromScan0 (1, 2, 4, PixelFormat32bppARGB, bpp32ArgbData, &bitmap);
+	assertEqualInt (status, Ok);
+	
+	status = GdipCloneBitmapAreaI (0, 0, 1, 2, PixelFormat24bppRGB, bitmap, &clone);
+	assertEqualInt (status, Ok);
+
+	status = GdipGetImagePixelFormat (clone, &actualFormat);
+	assertEqualInt (status, Ok);
+
+	assertEqualInt (actualFormat, PixelFormat24bppRGB);
+	verifyBitmap (clone, memoryBmpRawFormat, PixelFormat24bppRGB, 1, 2, 0, 0, TRUE);
+	
+	status = GdipBitmapGetPixel (clone, 0, 0, &color);
+	assertEqualInt (status, Ok);
+	assertEqualARGB (color, 0xFF0000FF);
+
+	status = GdipBitmapGetPixel(clone, 0, 1, &color);
+	assertEqualInt (status, Ok);
+	assertEqualARGB (color, 0xFFFF0000);
+
+	GdipDisposeImage ((GpImage *) clone);
+
+	status = GdipCloneBitmapAreaI(0, 0, 1, 2, PixelFormat4bppIndexed, bitmap, &clone);
 	assertEqualInt(status, Ok);
 
-	status = GdipCloneBitmapAreaI(0, 0, 1, 1, PixelFormat4bppIndexed, bitmap, &clone);
+	status = GdipGetImagePixelFormat(clone, &actualFormat);
 	assertEqualInt(status, Ok);
 
-	PixelFormat actual;
-	status = GdipGetImagePixelFormat(clone, &actual);
-	assertEqualInt(status, Ok);
+	assertEqualInt(actualFormat, PixelFormat4bppIndexed);
+	verifyBitmap(clone, memoryBmpRawFormat, PixelFormat4bppIndexed, 1, 2, 0, 0, TRUE);
 
-	assertEqualInt(actual, PixelFormat4bppIndexed);
+	status = GdipBitmapGetPixel(clone, 0, 0, &color);
+	assertEqualInt(status, Ok);
+	assertEqualARGB(color, 0xFF0000FF);
+
+	status = GdipBitmapGetPixel(clone, 0, 1, &color);
+	assertEqualInt(status, Ok);
+	assertEqualARGB(color, 0xFFFF0000);
+
+	GdipDisposeImage((GpImage*)clone);
+
+	GdipDisposeImage ((GpImage *) bitmap);
 }
 
 int


### PR DESCRIPTION
The pixel format was set from the source-bitmap, not from the argument passed to the method.

Fixes https://github.com/mono/libgdiplus/issues/541
Fixes https://github.com/mono/mono/issues/9903