### PR TITLE
GdipBitmapSetPixel correct bounds-check

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -2013,7 +2013,7 @@ GdipBitmapSetPixel (GpBitmap *bitmap, INT x, INT y, ARGB color)
 	
 	data = bitmap->active_bitmap;
 
-	if ((x < 0) || (x > data->width) || (y < 0) || (y > data->height) || (data->reserved & GBD_LOCKED)) {
+	if ((UINT)x >= data->width || (UINT) y >= data->height || data->reserved & GBD_LOCKED) {
 		return InvalidParameter;
 	}
 
@@ -2052,7 +2052,7 @@ GdipBitmapGetPixel (GpBitmap *bitmap, INT x, INT y, ARGB *color)
 
 	data = bitmap->active_bitmap;
 
-	if ((x < 0) || (x >= data->width) || (y < 0) || (y >= data->height) || (data->reserved & GBD_LOCKED)) {
+	if ((UINT)x >= data->width || (UINT)y >= data->height || data->reserved & GBD_LOCKED) {
 		return InvalidParameter;
 	}
 

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -2013,7 +2013,7 @@ GdipBitmapSetPixel (GpBitmap *bitmap, INT x, INT y, ARGB color)
 	
 	data = bitmap->active_bitmap;
 
-	if ((UINT)x >= data->width || (UINT) y >= data->height || data->reserved & GBD_LOCKED) {
+	if (x < 0 || y < 0 || x >= data->width || y >= data->height || data->reserved & GBD_LOCKED) {
 		return InvalidParameter;
 	}
 
@@ -2052,7 +2052,7 @@ GdipBitmapGetPixel (GpBitmap *bitmap, INT x, INT y, ARGB *color)
 
 	data = bitmap->active_bitmap;
 
-	if ((UINT)x >= data->width || (UINT)y >= data->height || data->reserved & GBD_LOCKED) {
+	if (x < 0 || y < 0 || x >= data->width || y >= data->height || data->reserved & GBD_LOCKED) {
 		return InvalidParameter;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/mono/libgdiplus/issues/443

The condition is simplified with the cast to `UINT`, as it reduces the branches in the method.