### PR TITLE
Add support for utf16 high/low surrogates in measurestring/drawstring.

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -222,7 +222,7 @@ GdipPrivateAddFontFile (GpFontCollection *fontCollection, GDIPCONST WCHAR *filen
 	if (!fontCollection || !filename)
 		return InvalidParameter;
     
-	file = (BYTE*) ucs2_to_utf8 ((const gunichar2 *)filename, -1);
+	file = (BYTE*) utf16_to_utf8 ((const gunichar2 *)filename, -1);
 	if (!file)
 		return OutOfMemory;
 
@@ -578,7 +578,7 @@ GdipCreateFontFamilyFromName (GDIPCONST WCHAR *name, GpFontCollection *font_coll
 	if (!name || !fontFamily)
 		return InvalidParameter;
 
-	string = (char*)ucs2_to_utf8 ((const gunichar2 *)name, -1);
+	string = (char*)utf16_to_utf8 ((const gunichar2 *)name, -1);
 	if (!string)
 		return OutOfMemory;
 
@@ -1294,7 +1294,7 @@ gdip_create_font_from_logfont (HDC hdc, void *lf, GpFont **font, BOOL ucs2)
 	}
 
 	if (ucs2) {
-		result->face = (BYTE*) ucs2_to_utf8 ((WCHAR *) logfont->lfFaceName, -1);
+		result->face = (BYTE*) utf16_to_utf8 ((WCHAR *) logfont->lfFaceName, -1);
 		if (!result->face){
 			GdipDeleteFont (result);
 			return OutOfMemory;

--- a/src/general-private.h
+++ b/src/general-private.h
@@ -115,7 +115,7 @@ float gdip_get_display_dpi () GDIP_INTERNAL;
 GpStatus gdip_get_status (cairo_status_t status) GDIP_INTERNAL;
 GpStatus gdip_get_pattern_status (cairo_pattern_t *pat) GDIP_INTERNAL;
 
-gchar *ucs2_to_utf8 (const gunichar2 *ucs2, int length) GDIP_INTERNAL;
+gchar *utf16_to_utf8 (const gunichar2 *ucs2, int length) GDIP_INTERNAL;
 BOOL utf8_to_ucs2 (const gchar *utf8, gunichar2 *ucs2, int ucs2_len) GDIP_INTERNAL;
 int utf8_encode_ucs2char (gunichar2 unichar, unsigned char *dest) GDIP_INTERNAL;
 

--- a/src/general.c
+++ b/src/general.c
@@ -361,12 +361,12 @@ gdip_erf (float x, float std, float mean)
 }
 
 /*
- convert a ucs2 string to utf8
+ convert a utf16 string to utf8
  length = number of characters to convert, -1 to indicate the whole string
 */
 
 gchar *
-ucs2_to_utf8(const gunichar2 *ucs2, int length) {
+utf16_to_utf8(const gunichar2 *ucs2, int length) {
 	const gunichar2	*ptr;
 	const gunichar2	*end;
 	gunichar	*dest;

--- a/src/general.c
+++ b/src/general.c
@@ -396,6 +396,10 @@ ucs2_to_utf8(const gunichar2 *ucs2, int length) {
 		if (*ptr < 0xd800 || *ptr >= 0xe000) {
 			*dest = *ptr;
 			dest++;
+		} else if (ptr + 1 != end && ptr[1] < 0xe000 && ptr[1] >= 0xdc00) {
+			/* UTF-16 support: Convert high and low surrogate to 32-bit code. */
+			*dest++ = ((gunichar)ptr[0] - 0xd800) * 0x400 + ((gunichar)ptr[1] - 0xdc00) + 0x10000;
+			ptr++;
 		}
 		ptr++;
 	}

--- a/src/graphics-path.c
+++ b/src/graphics-path.c
@@ -1296,7 +1296,7 @@ GdipAddPathString (GpPath *path, GDIPCONST WCHAR *string, int length,
 	}
 #else
 	{
-	BYTE *utf8 = (BYTE*) ucs2_to_utf8 (string, length);
+	BYTE *utf8 = (BYTE*) utf16_to_utf8 (string, length);
 	if (!utf8) {
 		GdipDeleteFont (font);
 		cairo_destroy (cr);

--- a/src/image.c
+++ b/src/image.c
@@ -1131,7 +1131,7 @@ GdipLoadImageFromFile (GDIPCONST WCHAR *file, GpImage **image)
 	if (!image || !file)
 		return InvalidParameter;
 	
-	file_name = (char *) ucs2_to_utf8 ((const gunichar2 *)file, -1);
+	file_name = (char *) utf16_to_utf8 ((const gunichar2 *)file, -1);
 	if (!file_name) {
 		*image = NULL;
 		return InvalidParameter;
@@ -1245,7 +1245,7 @@ GdipSaveImageToFile (GpImage *image, GDIPCONST WCHAR *file, GDIPCONST CLSID *enc
 	if (format == INVALID)
 		return UnknownImageFormat;
 	
-	file_name = (char *) ucs2_to_utf8 ((const gunichar2 *)file, -1);
+	file_name = (char *) utf16_to_utf8 ((const gunichar2 *)file, -1);
 	if (file_name == NULL)
 		return InvalidParameter;
 	

--- a/src/imageattributes.c
+++ b/src/imageattributes.c
@@ -524,7 +524,7 @@ GdipSetImageAttributesOutputChannelColorProfile (GpImageAttributes *imageattr, C
 		if (!colorProfileFilename)
 			return Win32Error;
 
-		char *utf8 = ucs2_to_utf8 (colorProfileFilename, -1);
+		char *utf8 = utf16_to_utf8 (colorProfileFilename, -1);
 		if (!utf8)
 			return OutOfMemory;
 

--- a/src/metafile.c
+++ b/src/metafile.c
@@ -1613,7 +1613,7 @@ GdipCreateMetafileFromFile (GDIPCONST WCHAR *file, GpMetafile **metafile)
 	if (!file || !metafile)
 		return InvalidParameter;
 
-	file_name = (char *) ucs2_to_utf8 ((const gunichar2 *)file, -1);
+	file_name = (char *) utf16_to_utf8 ((const gunichar2 *)file, -1);
 	if (!file_name)
 		return InvalidParameter;
 
@@ -1780,7 +1780,7 @@ GdipGetMetafileHeaderFromFile (GDIPCONST WCHAR *filename, MetafileHeader *header
 	if (!filename || !header)
 		return InvalidParameter;
 
-	file_name = (char *) ucs2_to_utf8 ((const gunichar2 *)filename, -1);
+	file_name = (char *) utf16_to_utf8 ((const gunichar2 *)filename, -1);
 	if (!file_name)
 		return InvalidParameter;
 	
@@ -1980,7 +1980,7 @@ GdipRecordMetafileFileName (GDIPCONST WCHAR *fileName, HDC referenceHdc, EmfType
 	if (!fileName)
 		return InvalidParameter;
 
-	file_name = (char *) ucs2_to_utf8 ((const gunichar2 *)fileName, -1);
+	file_name = (char *) utf16_to_utf8 ((const gunichar2 *)fileName, -1);
 	if (!file_name) {
 		*metafile = NULL;
 		return InvalidParameter;

--- a/src/text-cairo.c
+++ b/src/text-cairo.c
@@ -323,7 +323,7 @@ MeasureString (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, int *length
 	}
 	
 	/* Convert string from Gdiplus format to UTF8, suitable for cairo */
-	String = (BYTE*) ucs2_to_utf8 ((const gunichar2 *)CleanString, -1);
+	String = (BYTE*) utf16_to_utf8 ((const gunichar2 *)CleanString, -1);
 	if (!String)
 		return OutOfMemory;
 
@@ -873,7 +873,7 @@ DrawString (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, int length, GD
 
 			if (length > StringLen - i)
 				length = StringLen - i;
-			String = (BYTE*) ucs2_to_utf8 ((const gunichar2 *)(CleanString+i), length);
+			String = (BYTE*) utf16_to_utf8 ((const gunichar2 *)(CleanString+i), length);
 #ifdef DRAWSTRING_DEBUG
 			printf("Displaying line >%s< (%d chars)\n", String, length);
 #endif

--- a/src/text-pango.c
+++ b/src/text-pango.c
@@ -33,7 +33,7 @@
 #include "fontcollection-private.h"
 
 int
-utf8_length_for_ucs2_string (GDIPCONST WCHAR *stringUnicode, int offset, int length)
+utf8_length_for_utf16_string (GDIPCONST WCHAR *stringUnicode, int offset, int length)
 {
 	int utf8_length = 0;
 	int end = offset + length;
@@ -46,7 +46,8 @@ utf8_length_for_ucs2_string (GDIPCONST WCHAR *stringUnicode, int offset, int len
 			utf8_length += 2;
 		else if (ch < 0xD800 || ch >= 0xE000)
 			utf8_length += 3;
-		/* ignore surrogate pairs as they are ignored in ucs2_to_utf8() */
+		else
+			utf8_length += 4;
 	}
 	return utf8_length;
 }
@@ -197,7 +198,7 @@ gdip_pango_setup_layout (cairo_t *cr, GDIPCONST WCHAR *stringUnicode, int length
 	int trimSpace;      /* whether or not to trim the space */
 	BOOL use_horizontal_layout;
 
-	gchar *text = ucs2_to_utf8 (stringUnicode, length);
+	gchar *text = utf16_to_utf8 (stringUnicode, length);
 	if (!text)
 		return NULL;
 	length = strlen(text);
@@ -711,7 +712,7 @@ pango_MeasureCharacterRanges (GpGraphics *graphics, GDIPCONST WCHAR *stringUnico
 		}
 
 		/* calculate the initial UTF-8 index */
-		int idxUtf8 = utf8_length_for_ucs2_string (stringUnicode, 0, start);
+		int idxUtf8 = utf8_length_for_utf16_string (stringUnicode, 0, start);
 
 		/* calculate the regions */
 		for (j = start; j < end; j++) {
@@ -747,7 +748,7 @@ pango_MeasureCharacterRanges (GpGraphics *graphics, GDIPCONST WCHAR *stringUnico
 				break;
 
 			// update the UTF-8 index
-			idxUtf8 += utf8_length_for_ucs2_string (stringUnicode, j, 1);
+			idxUtf8 += utf8_length_for_utf16_string (stringUnicode, j, 1);
 		}
 		if (status != Ok)
 			break;


### PR DESCRIPTION
This patch allows Garphics.MeasureString() and Graphics.DrawString() to correctly measure and draw unicode characters with a codepoint greater than 0xffff.