### PR TITLE
Respect page units when current transformation matrix is passed to cairo

### DIFF
--- a/src/customlinecap.c
+++ b/src/customlinecap.c
@@ -253,7 +253,7 @@ gdip_custom_linecap_draw (GpGraphics *graphics, GpPen *pen, GpCustomLineCap *cus
 
 		gdip_pen_setup (graphics, pen);
 		cairo_stroke (graphics->ct);
-		cairo_set_matrix (graphics->ct, graphics->copy_of_ctm);
+		gdip_cairo_set_matrix (graphics, graphics->copy_of_ctm);
 	}
 
 	/* FIXME: handle fill_path */

--- a/src/general.c
+++ b/src/general.c
@@ -611,6 +611,32 @@ gdip_cairo_curve_to (GpGraphics *graphics, double x1, double y1, double x2, doub
 	cairo_curve_to (graphics->ct, x1, y1, x2, y2, x3, y3);
 }
 
+void
+gdip_cairo_set_matrix (GpGraphics *graphics, GpMatrix *matrixPageUnits)
+{
+	float x0 = matrixPageUnits->x0;
+	float y0 = matrixPageUnits->y0;
+
+	/* avoid unit conversion whenever possible */
+	if (!OPTIMIZE_CONVERSION (graphics)) {
+		x0 = gdip_unitx_convgr (graphics, x0);
+		y0 = gdip_unity_convgr (graphics, y0);
+	}
+
+	/* do not apply antialiasing trick to transformation matrix */
+
+	/* put everything between cairo limits */
+	x0 = CAIRO_LIMIT (x0);
+	y0 = CAIRO_LIMIT (y0);
+
+	GpMatrix matrixCopy;
+	gdip_cairo_matrix_copy (&matrixCopy, matrixPageUnits);
+	matrixCopy.x0 = x0;
+	matrixCopy.y0 = y0;
+
+	cairo_set_matrix (graphics->ct, &matrixCopy);
+}
+
 void gdip_RectF_from_Rect (const GpRect* rect, GpRectF* rectf)
 {
 	rectf->X = rect->X;

--- a/src/graphics-cairo.c
+++ b/src/graphics-cairo.c
@@ -853,12 +853,14 @@ cairo_SetGraphicsClip (GpGraphics *graphics)
 			gdip_plot_path (graphics, work->tree->path, FALSE);
 		else {
 			UINT count;
+			GpMatrix matrix;
+			cairo_matrix_init_identity (&matrix);
 			/* I admit that's a (not so cute) hack - anyone with a better idea ? */
-			if ((GdipGetRegionScansCount (work, &count, NULL) == Ok) && (count > 0)) {
+			if ((GdipGetRegionScansCount (work, &count, &matrix) == Ok) && (count > 0)) {
 				GpRectF *rects = (GpRectF*) GdipAlloc (count * sizeof (GpRectF));
 				if (rects) {
 					INT countTemp;
-					GdipGetRegionScans (work, rects, &countTemp, NULL);
+					GdipGetRegionScans (work, rects, &countTemp, &matrix);
 					for (i = 0, rect = rects; i < countTemp; i++, rect++) {
 						gdip_cairo_rectangle (graphics, rect->X, rect->Y, rect->Width, rect->Height, FALSE);
 					}

--- a/src/graphics-cairo.c
+++ b/src/graphics-cairo.c
@@ -54,7 +54,7 @@ fill_graphics_with_brush (GpGraphics *graphics, GpBrush *brush, BOOL stroke)
 	/* Set the matrix back to graphics->copy_of_ctm for other functions.
 	 * This overwrites the matrix set by brush setup.
 	 */
-	cairo_set_matrix (graphics->ct, graphics->copy_of_ctm);
+	gdip_cairo_set_matrix (graphics, graphics->copy_of_ctm);
 
 	return gdip_get_status (cairo_status (graphics->ct));
 }
@@ -69,7 +69,7 @@ stroke_graphics_with_pen (GpGraphics *graphics, GpPen *pen)
 	/* Set the matrix back to graphics->copy_of_ctm for other functions.
 	 * This overwrites the matrix set by pen setup.
 	 */
-	cairo_set_matrix (graphics->ct, graphics->copy_of_ctm);
+	gdip_cairo_set_matrix (graphics, graphics->copy_of_ctm);
 
 	return gdip_get_status (cairo_status (graphics->ct));
 }
@@ -895,7 +895,7 @@ cairo_ResetClip (GpGraphics *graphics)
 GpStatus
 cairo_ResetWorldTransform (GpGraphics *graphics)
 {
-	cairo_set_matrix (graphics->ct, graphics->copy_of_ctm);
+	gdip_cairo_set_matrix (graphics, graphics->copy_of_ctm);
 	cairo_reset_clip (graphics->ct);
 	cairo_SetGraphicsClip (graphics);
 	return gdip_get_status (cairo_status (graphics->ct));
@@ -904,7 +904,7 @@ cairo_ResetWorldTransform (GpGraphics *graphics)
 GpStatus
 cairo_SetWorldTransform (GpGraphics *graphics, GpMatrix *matrix)
 {
-	cairo_set_matrix (graphics->ct, graphics->copy_of_ctm);
+	gdip_cairo_set_matrix (graphics, matrix);
 	cairo_SetGraphicsClip (graphics);
 	return gdip_get_status (cairo_status (graphics->ct));
 }

--- a/src/graphics-private.h
+++ b/src/graphics-private.h
@@ -169,6 +169,8 @@ void gdip_cairo_line_to (GpGraphics *graphics, double x, double y, BOOL convert_
 void gdip_cairo_curve_to (GpGraphics *graphics, double x1, double y1, double x2, double y2, double x3, double y3, 
 	BOOL convert_units, BOOL antialiasing) GDIP_INTERNAL;
 
+void gdip_cairo_set_matrix (GpGraphics *graphics, GpMatrix *matrixPageUnits) GDIP_INTERNAL;
+
 #ifdef CAIRO_HAS_QUARTZ_SURFACE
 
 #if __i386__

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -529,7 +529,7 @@ GdipRestoreGraphics (GpGraphics *graphics, GraphicsState state)
 	graphics->saved_status_pos = state;
 
 	/* re-adjust clipping (region and matrix) */
-	cairo_set_matrix (graphics->ct, graphics->copy_of_ctm);
+	gdip_cairo_set_matrix (graphics, graphics->copy_of_ctm);
 
 	/* GdipCloneRegion was called, but for some reason, not registred as an allocation */
 	/* coverity[freed_arg] */

--- a/src/image.c
+++ b/src/image.c
@@ -544,7 +544,7 @@ GdipDrawImagePoints (GpGraphics *graphics, GpImage *image, GDIPCONST GpPointF *d
 		metacontext = gdip_metafile_play_setup ((GpMetafile*)image, graphics, tRect.X, tRect.Y, tRect.Width, tRect.Height);
 
 		cairo_get_matrix (graphics->ct, &orig_matrix);
-		cairo_set_matrix (graphics->ct, matrix);
+		gdip_cairo_set_matrix (graphics, matrix);
 		status = gdip_metafile_play (metacontext);
 		GdipDeleteMatrix (matrix);
 
@@ -575,7 +575,7 @@ GdipDrawImagePoints (GpGraphics *graphics, GpImage *image, GDIPCONST GpPointF *d
 	cairo_pattern_reference(org_pattern);
 	
 	cairo_get_matrix(graphics->ct, &orig_matrix);
-	cairo_set_matrix (graphics->ct, matrix);
+	gdip_cairo_set_matrix (graphics, matrix);
 	cairo_set_source_surface (graphics->ct, image->surface, 0, 0);
 	
 	cairo_paint (graphics->ct);	
@@ -1056,7 +1056,7 @@ GdipDrawImagePointsRect (GpGraphics *graphics, GpImage *image, GDIPCONST GpPoint
 	}
 
 	cairo_get_matrix (graphics->ct, &orig_matrix);
-	cairo_set_matrix (graphics->ct, matrix);
+	gdip_cairo_set_matrix (graphics, matrix);
 	status = GdipDrawImageRectRect (graphics, image, rect.X, rect.Y, rect.Width, rect.Height, srcx, srcy, 
 		srcwidth, srcheight, srcUnit, imageAttributes, callback, callbackData);
 	cairo_set_matrix (graphics->ct, &orig_matrix);

--- a/src/pen.c
+++ b/src/pen.c
@@ -168,7 +168,7 @@ gdip_pen_setup (GpGraphics *graphics, GpPen *pen)
 		/* *both* X and Y are affected if either is 0 */
 		product.xx = product.yy = 0.0001f;
 	}
-	cairo_set_matrix (graphics->ct, &product);
+	gdip_cairo_set_matrix (graphics, &product);
 
 	/* Don't need to setup, if pen is the same as the cached pen and
 	 * it is not changed. Just comparing pointers may not be sufficient

--- a/tests/testclip.c
+++ b/tests/testclip.c
@@ -211,7 +211,7 @@ test_gdip_clip_path ()
 	{
 		C (GdipAddPathRectangle (path, rc.X, rc.Y, rc.Width, rc.Height));
 
-	    // This rectangle should be overlapped by the black rectangle
+		// This rectangle should be overlapped by the black rectangle
 		GpSolidFill *pathBrush;
 		C (GdipCreateSolidFill (0xFF00FF00, &pathBrush));
 		C (GdipFillPath (graphics, pathBrush, path));


### PR DESCRIPTION
Fixes #545. Also fixes a typo in cairo_SetWorldTransform where input 'matrix' argument was not used.