### PR TITLE
Fix clipping of non-rectangular paths

### DIFF
--- a/src/graphics-cairo.c
+++ b/src/graphics-cairo.c
@@ -853,12 +853,14 @@ cairo_SetGraphicsClip (GpGraphics *graphics)
 			gdip_plot_path (graphics, work->tree->path, FALSE);
 		else {
 			UINT count;
+			GpMatrix matrix;
+			cairo_matrix_init_identity (&matrix);
 			/* I admit that's a (not so cute) hack - anyone with a better idea ? */
-			if ((GdipGetRegionScansCount (work, &count, NULL) == Ok) && (count > 0)) {
+			if ((GdipGetRegionScansCount (work, &count, &matrix) == Ok) && (count > 0)) {
 				GpRectF *rects = (GpRectF*) GdipAlloc (count * sizeof (GpRectF));
 				if (rects) {
 					INT countTemp;
-					GdipGetRegionScans (work, rects, &countTemp, NULL);
+					GdipGetRegionScans (work, rects, &countTemp, &matrix);
 					for (i = 0, rect = rects; i < countTemp; i++, rect++) {
 						gdip_cairo_rectangle (graphics, rect->X, rect->Y, rect->Width, rect->Height, FALSE);
 					}

--- a/tests/testclip.c
+++ b/tests/testclip.c
@@ -211,7 +211,7 @@ test_gdip_clip_path ()
 	{
 		C (GdipAddPathRectangle (path, rc.X, rc.Y, rc.Width, rc.Height));
 
-	    // This rectangle should be overlapped by the black rectangle
+		// This rectangle should be overlapped by the black rectangle
 		GpSolidFill *pathBrush;
 		C (GdipCreateSolidFill (0xFF00FF00, &pathBrush));
 		C (GdipFillPath (graphics, pathBrush, path));


### PR DESCRIPTION
Fixes #547, fixes #552. Clipping of paths and path-based regions was broken in
5dd3b5da1565a99912ff8570054dad26a04e9c08 (NULL matrix is not accepted in GdipGetRegionScans and GdipGetRegionScansCount).