### PR TITLE
GdipGetRegionScans: Avoid segfault, use work instead of region

### DIFF
--- a/src/region.c
+++ b/src/region.c
@@ -566,6 +566,7 @@ gdip_region_convert_to_path (GpRegion *region)
 
 	if (region->rects) {
 		GdipFree (region->rects);
+		region->cnt = 0;
 		region->rects = NULL;
 	}
 
@@ -2055,7 +2056,7 @@ GdipGetRegionScans (GpRegion *region, GpRectF* rects, INT* count, GpMatrix* matr
 
 		*count = 1;
 	} else {
-		switch (region->type) {
+		switch (work->type) {
 		case RegionTypeRect:
 			if (rects) {
 				for (int i = 0; i < work->cnt; i++) {


### PR DESCRIPTION
`GdipGetRegionScans` transforms `region` and stores the result in `work`.  From that point on, all work is done on `work` and no longer on region.

However, there still was a switch on `region->type` instead of `work->type` which would send `GdipGetRegionScans` down the wrong path if the type has changed.

To make things worse, `gdip_region_convert_to_path` changes the `type` and clears `rects`, but did not reset `cnt` to 0.

`RegionTests.GetRegionScans_CustomMatrix_TransformsRegionScans` in the corefx test suite could trigger this.