### PR TITLE
Don't attempt to implement GdipCreateFromHDC on Windows

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -234,6 +234,13 @@ GdipCreateFromHDC (HDC hdc, GpGraphics **graphics)
 	if (!hdc)
 		return OutOfMemory;
 
+#if defined(WIN32)
+	// HDC returns to a device context. The remainer of this function assumes that hdc really
+	// is a GpGrahpics, but that's almost guaranteed to be not the case on Windows. Just fail
+	// quickly instead of segfauling.
+	return NotImplemented;
+#endif
+
 #ifdef CAIRO_HAS_PS_SURFACE
 
 	if (clone->type == gtPostScript) {


### PR DESCRIPTION
The first thing `GdipCreateFromHdc` does, is to cast this from `HDC` to `GpGraphics`.  This is almost guaranteed to fail on Windows, and even something as simple as `clone->type` will cause an access violation.

Instead, just return `NotImplemented` when compiled for Win32.

A more robust strategy may be to keep track of all `GpGraphics` objects we allocate, and check whether `hdc` points to any of those, before casting `hdc` to `GpGraphics`.