### PR TITLE
GdipCreateBitmapFromScan0: Fix a buffer overflow with pixel formats < 32 bpp

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -902,14 +902,14 @@ GdipCreateBitmapFromScan0 (int width, int height, int stride, PixelFormat format
 			goto fail;
 		}
 
-		if ((gdip_get_pixel_format_bpp(format) < 16) || gdip_is_an_alpha_pixelformat(format)) {
+		if ((gdip_get_pixel_format_bpp(format) < 32) || gdip_is_an_alpha_pixelformat(format)) {
 			memset (scan0, 0, stride * height);
 		} else {
 			/* Since the pixel format is not an alpha pixel format (i.e., it is
-			 * either PixelFormat24bppRGB or PixelFormat32bppRGB), the image should be
-			 * initially black, not initially transparent. Thus, we need to set
-			 * the alpha channel, which the user code doesn't think exists but
-			 * Cairo is still paying attention to, to 0xFF.
+			 * PixelFormat32bppRGB), the image should be initially black, not
+			 * initially transparent. Thus, we need to set the alpha channel,
+			 * which the user code doesn't think exists but Cairo is still paying
+			 * attention to, to 0xFF.
 			 */
 			int	x;
 			int	y;


### PR DESCRIPTION
If you create a new bitmap from scratch (that is, `scan0` is `NULL`), `GdipCreateBitmapFromScan0` will allocate memory to hold the raw bitmap data for you.

It then attempts to initialize this. By default, it will `memset` all bytes to 0, so you should get a black image in most formats. However, for formats with alpha-channels, this would set alpha to `0`, causing the image to be "completely translucent black" (AKA white).

So the method goes on a quest to set the alpha channel to 1. It iterates over the framebuffer using a 32-bit `ARGB` value. For pixel formats with < 32 bpp, this would cause a buffer overflow for the last pixel.

Fix the check for the bpp, and make sure we really have a 32bpp pixel format.
