### PR TITLE
Don't implement GdipCreateBitmapFromHICON on Windows

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -1059,6 +1059,10 @@ GdipCreateBitmapFromHICON (HICON hicon, GpBitmap** bitmap)
 	if (!hicon || !bitmap)
 		return InvalidParameter;
 
+#if defined(WIN32)
+	return NotImplemented;
+#endif
+
 	status = GdipCloneImage ((GpImage *)hicon, (GpImage**)bitmap);
 	if (status == Ok) {
 		if ((*bitmap)->active_bitmap->palette)


### PR DESCRIPTION
Simlar to #557, assuming a `HICON` is a `GpImage` will very likely not work on Windows; so just return `NotImplemented` instead of risking taking down the entire process.

Simlar to #557, the corefx unit tests will call this with HICON set to a value of `0xa` (i.e. an invalid pointer), not sure how we can validate that pointer short of tracking all `GpGraphics` objects.