### PR TITLE
Keep GraphicsContainer/GraphicsState non-zero

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -496,7 +496,7 @@ GdipRestoreGraphics (GpGraphics *graphics, GraphicsState state)
 	if (!graphics)
 		return InvalidParameter;
 
-	if (state >= MAX_GRAPHICS_STATE_STACK || state > graphics->saved_status_pos)
+	if ((state - 1) >= MAX_GRAPHICS_STATE_STACK || (state - 1) > graphics->saved_status_pos)
 		return InvalidParameter;
 
 	pos_state = graphics->saved_status;
@@ -583,7 +583,7 @@ GdipSaveGraphics (GpGraphics *graphics, GraphicsState *state)
 	pos_state->pixel_mode = graphics->pixel_mode;
 	pos_state->text_contrast = graphics->text_contrast;
 	
-	*state = graphics->saved_status_pos + 1;
+	*state = graphics->saved_status_pos + 1; // make sure GraphicsState is non-zero for compat with GDI+
 	graphics->saved_status_pos++;
 	return Ok;
 }

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -496,7 +496,7 @@ GdipRestoreGraphics (GpGraphics *graphics, GraphicsState state)
 	if (!graphics)
 		return InvalidParameter;
 
-	if ((state - 1) >= MAX_GRAPHICS_STATE_STACK || (state - 1) > graphics->saved_status_pos)
+	if (state <= 0 || (state - 1) >= MAX_GRAPHICS_STATE_STACK || (state - 1) > graphics->saved_status_pos)
 		return InvalidParameter;
 
 	pos_state = graphics->saved_status;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -500,7 +500,7 @@ GdipRestoreGraphics (GpGraphics *graphics, GraphicsState state)
 		return InvalidParameter;
 
 	pos_state = graphics->saved_status;
-	pos_state += state;	
+	pos_state += (state - 1);	
 
 	/* Save from GpState to Graphics  */
 	gdip_cairo_matrix_copy (graphics->copy_of_ctm, &pos_state->matrix);
@@ -583,7 +583,7 @@ GdipSaveGraphics (GpGraphics *graphics, GraphicsState *state)
 	pos_state->pixel_mode = graphics->pixel_mode;
 	pos_state->text_contrast = graphics->text_contrast;
 	
-	*state = graphics->saved_status_pos;
+	*state = graphics->saved_status_pos + 1;
 	graphics->saved_status_pos++;
 	return Ok;
 }


### PR DESCRIPTION
The current implementation of `GdipSaveGraphics` would set `GraphicsState` to the zero-based index of the current state in an array. The Windows implementation of System.Drawing [asserts that `GraphicsState` is non-zero](https://github.com/dotnet/corefx/blob/master/src/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs#L2690).

So simply increment `GraphicsState` by one when setting it, and substract one when reading it.