### PR TITLE
Return OutOfMemory for 0-length gradient brushes

### DIFF
--- a/src/lineargradientbrush.c
+++ b/src/lineargradientbrush.c
@@ -493,6 +493,10 @@ GdipCreateLineBrush (GDIPCONST GpPointF *point1, GDIPCONST GpPointF *point2, ARG
 	if (!point1 || !point2 || !lineGradient || wrapMode == WrapModeClamp)
 		return InvalidParameter;
 
+	// For GDI+ compat. A zero-length gradient isn't well-defined.
+	if (point1->X == point2->X && point1->Y == point2->Y)
+		return OutOfMemory;
+
 	linear = gdip_linear_gradient_new ();
 	if (!linear)
 		return OutOfMemory;


### PR DESCRIPTION
A gradient on from point A to itself doesn't make much sense, and GDI+ returns OOM. Make libgdiplus do the same thing.

This is covered by the corefx `LinearGradientBrushTests.Ctor_EqualPoints_ThrowsOutOfMemoryException` test.