### PR TITLE
CustomLineCap: Better argument validation

### DIFF
--- a/src/customlinecap.c
+++ b/src/customlinecap.c
@@ -320,7 +320,12 @@ GdipCreateCustomLineCap (GpPath *fillPath, GpPath *strokePath, GpLineCap baseCap
 		}
 	}
 
-	result->base_cap = baseCap;
+	if (baseCap >= LineCapFlat && baseCap <= LineCapTriangle) {
+		result->base_cap = baseCap;
+	} else {
+		result->base_cap = LineCapFlat;
+	}
+
 	result->base_inset = baseInset;
 
 	*customCap = result;
@@ -358,7 +363,7 @@ GdipGetCustomLineCapType (GpCustomLineCap *customCap, CustomLineCapType *capType
 GpStatus WINGDIPAPI
 GdipSetCustomLineCapStrokeCaps (GpCustomLineCap *customCap, GpLineCap startCap, GpLineCap endCap)
 {
-	if (!customCap || startCap > LineCapTriangle || endCap > LineCapTriangle)
+	if (!customCap || startCap < LineCapFlat || startCap > LineCapTriangle || endCap < LineCapFlat || endCap > LineCapTriangle)
 		return InvalidParameter;
 
 	customCap->start_cap = startCap;

--- a/tests/testcustomlinecap.c
+++ b/tests/testcustomlinecap.c
@@ -30,9 +30,7 @@ static void verifyCustomLineCap (GpCustomLineCap *cap, LineCap expectedBaseCap, 
 	assert (cap && "Expected cap to be initialized.");
 
 	GpStatus status;
-#if !defined(USE_WINDOWS_GDIPLUS)
 	LineCap baseCap;
-#endif
 	REAL baseInset;
 	LineCap startCap;
 	LineCap endCap;
@@ -40,12 +38,9 @@ static void verifyCustomLineCap (GpCustomLineCap *cap, LineCap expectedBaseCap, 
 	REAL widthScale;
 	CustomLineCapType type;
 
-	// GDI+ returns 0 here each time. This looks like a GDI+ bug.
-#if !defined(USE_WINDOWS_GDIPLUS)
 	status = GdipGetCustomLineCapBaseCap (cap, &baseCap);
 	assertEqualInt (status, Ok);
 	assertEqualInt (baseCap, expectedBaseCap);
-#endif
 
 	status = GdipGetCustomLineCapBaseInset (cap, &baseInset);
 	assertEqualInt (status, Ok);
@@ -81,22 +76,22 @@ static void test_createCustomLineCap ()
 
 	status = GdipCreateCustomLineCap (fillPath, strokePath, LineCapDiamondAnchor, 10, &cap);
 	assertEqualInt (status, Ok);
-	verifyCustomLineCap (cap, LineCapDiamondAnchor, 10);
+	verifyCustomLineCap (cap, LineCapFlat, 10);
 	GdipDeleteCustomLineCap (cap);
 
 	status = GdipCreateCustomLineCap (NULL, strokePath, LineCapCustom, 0, &cap);
 	assertEqualInt (status, Ok);
-	verifyCustomLineCap (cap, LineCapCustom, 0);
+	verifyCustomLineCap (cap, LineCapFlat, 0);
 	GdipDeleteCustomLineCap (cap);
 
 	status = GdipCreateCustomLineCap (fillPath, NULL, (LineCap)(LineCapFlat - 1), -1, &cap);
 	assertEqualInt (status, Ok);
-	verifyCustomLineCap (cap, (LineCap)(LineCapFlat - 1), -1);
+	verifyCustomLineCap (cap, LineCapFlat, -1);
 	GdipDeleteCustomLineCap (cap);
 
 	status = GdipCreateCustomLineCap (fillPath, strokePath, (LineCap)(LineCapCustom + 1), 100, &cap);
 	assertEqualInt (status, Ok);
-	verifyCustomLineCap (cap, (LineCap)(LineCapCustom + 1), 100);
+	verifyCustomLineCap (cap, LineCapFlat, 100);
 	GdipDeleteCustomLineCap (cap);
 
 	// Negative tests.
@@ -148,7 +143,7 @@ static void test_cloneCustomLineCap ()
 
 	status = GdipCloneCustomLineCap (cap, &clonedCap);
 	assertEqualInt (status, Ok);
-	verifyCustomLineCap (clonedCap, LineCapDiamondAnchor, 10);
+	verifyCustomLineCap (clonedCap, LineCapFlat, 10);
 	GdipDeleteCustomLineCap (clonedCap);
 
 	// Negative tests.


### PR DESCRIPTION
Only a couple of `LineCap` values are accepted by GDI+. All other values are ignored, and silently reset to `LineCapFlat`.

This behavior is covered by the `CustomLineCapTests` tests in corefx.