### PR TITLE
font-config: Use a rudimentary default configuration when no config file can be found

### DIFF
--- a/src/general.c
+++ b/src/general.c
@@ -82,13 +82,13 @@ GdiplusStartup (ULONG_PTR *token, const GdiplusStartupInput *input, GdiplusStart
 		fprintf(fi, "<fontconfig>\n");
 #if defined(WIN32)
 		fprintf(fi, "<dir>WINDOWSFONTDIR</dir>\n");
-#elif defined(_APPLE_) && defined(_MACH_)
+#elif defined(__APPLE__)
 		fprintf(fi, "<dir>/System/Library/Fonts</dir>\n");
 #else
 		fprintf(fi, "<dir>~/.fonts</dir>\n");
 #endif
 
-#ifdef WIN32
+#if defined(WIN32)
 		fprintf(fi, "<cachedir>WINDOWSTEMPDIR_FONTCONFIG_CACHE</cachedir>\n");
 #else
 		fprintf(fi, "<cachedir>~/.fontconfig</cachedir>\n");

--- a/src/general.c
+++ b/src/general.c
@@ -64,12 +64,12 @@ GdiplusStartup (ULONG_PTR *token, const GdiplusStartupInput *input, GdiplusStart
 	if (status != Ok)
 		return status;
 
-	FcInit();
+	FcInit ();
 
 	/* A fontconfig instance which didn't find a configfile is unbelievably
 		cranky, so let's just write out a small xml file and make fontconfig
 		happy */
-	if (FcConfigFilename(0) == NULL)
+	if (FcConfigFilename (0) == NULL)
 	{
 		/* Newer versions of font-config have FcConfigParseAndLoadFromMemory,
 		   which we could use to avoid generating a temporary file. But meanwhile,
@@ -84,33 +84,33 @@ GdiplusStartup (ULONG_PTR *token, const GdiplusStartupInput *input, GdiplusStart
 #endif
 
 		if (fi) {
-			fprintf(fi, "<?xml version=\"1.0\"?>\n");
-			fprintf(fi, "<fontconfig>\n");
+			fprintf (fi, "<?xml version=\"1.0\"?>\n");
+			fprintf (fi, "<fontconfig>\n");
 #if defined(WIN32)
-			fprintf(fi, "<dir>WINDOWSFONTDIR</dir>\n");
+			fprintf (fi, "<dir>WINDOWSFONTDIR</dir>\n");
 #elif defined(__APPLE__)
-			fprintf(fi, "<dir>/System/Library/Fonts</dir>\n");
+			fprintf (fi, "<dir>/System/Library/Fonts</dir>\n");
 #else
-			fprintf(fi, "<dir>~/.fonts</dir>\n");
+			fprintf (fi, "<dir>~/.fonts</dir>\n");
 #endif
 
 #if defined(WIN32)
-			fprintf(fi, "<cachedir>WINDOWSTEMPDIR_FONTCONFIG_CACHE</cachedir>\n");
+			fprintf (fi, "<cachedir>WINDOWSTEMPDIR_FONTCONFIG_CACHE</cachedir>\n");
 #else
-			fprintf(fi, "<cachedir>~/.fontconfig</cachedir>\n");
+			fprintf (fi, "<cachedir>~/.fontconfig</cachedir>\n");
 #endif
-			fprintf(fi, "</fontconfig>\n");
-			fclose(fi);
+			fprintf (fi, "</fontconfig>\n");
+			fclose (fi);
 
-			FcConfig* c = FcConfigCreate();
-			FcConfigParseAndLoad(c, (FcChar8*)namebuf, 1);
-			remove(namebuf);
+			FcConfig* c = FcConfigCreate ();
+			FcConfigParseAndLoad (c, (FcChar8*)namebuf, 1);
+			remove (namebuf);
 
-			FcConfigBuildFonts(c);
-			FcConfigSetCurrent(c);
+			FcConfigBuildFonts (c);
+			FcConfigSetCurrent (c);
 
 			// FcConfig is reference-counted, so it's OK to call destroy here.
-			FcConfigDestroy(c);
+			FcConfigDestroy (c);
 		}
 	}
 

--- a/src/general.c
+++ b/src/general.c
@@ -75,9 +75,15 @@ GdiplusStartup (ULONG_PTR *token, const GdiplusStartupInput *input, GdiplusStart
 		   which we could use to avoid generating a temporary file. But meanwhile,
 		   we are stuck with this workaround. */
 		char namebuf[512];
-		if (tmpnam(namebuf) != NULL) {
-			FILE* fi = fopen(namebuf, "wb");
+#ifdef WIN32
+		FILE *fi = CreateTempFile (namebuf);
+#else
+		strcpy ((char *) namebuf, "/tmp/ffXXXXXX");
+		int fd = mkstemp ((char *) namebuf);
+		FILE *fi = fdopen (fd, "wb");
+#endif
 
+		if (fi) {
 			fprintf(fi, "<?xml version=\"1.0\"?>\n");
 			fprintf(fi, "<fontconfig>\n");
 #if defined(WIN32)

--- a/src/general.c
+++ b/src/general.c
@@ -75,36 +75,37 @@ GdiplusStartup (ULONG_PTR *token, const GdiplusStartupInput *input, GdiplusStart
 		   which we could use to avoid generating a temporary file. But meanwhile,
 		   we are stuck with this workaround. */
 		char namebuf[512];
-		tmpnam(namebuf);
-		FILE* fi = fopen(namebuf, "wb");
+		if (tmpnam(namebuf) != NULL) {
+			FILE* fi = fopen(namebuf, "wb");
 
-		fprintf(fi, "<?xml version=\"1.0\"?>\n");
-		fprintf(fi, "<fontconfig>\n");
+			fprintf(fi, "<?xml version=\"1.0\"?>\n");
+			fprintf(fi, "<fontconfig>\n");
 #if defined(WIN32)
-		fprintf(fi, "<dir>WINDOWSFONTDIR</dir>\n");
+			fprintf(fi, "<dir>WINDOWSFONTDIR</dir>\n");
 #elif defined(__APPLE__)
-		fprintf(fi, "<dir>/System/Library/Fonts</dir>\n");
+			fprintf(fi, "<dir>/System/Library/Fonts</dir>\n");
 #else
-		fprintf(fi, "<dir>~/.fonts</dir>\n");
+			fprintf(fi, "<dir>~/.fonts</dir>\n");
 #endif
 
 #if defined(WIN32)
-		fprintf(fi, "<cachedir>WINDOWSTEMPDIR_FONTCONFIG_CACHE</cachedir>\n");
+			fprintf(fi, "<cachedir>WINDOWSTEMPDIR_FONTCONFIG_CACHE</cachedir>\n");
 #else
-		fprintf(fi, "<cachedir>~/.fontconfig</cachedir>\n");
+			fprintf(fi, "<cachedir>~/.fontconfig</cachedir>\n");
 #endif
-		fprintf(fi, "</fontconfig>\n");
-		fclose(fi);
+			fprintf(fi, "</fontconfig>\n");
+			fclose(fi);
 
-		FcConfig* c = FcConfigCreate();
-		FcConfigParseAndLoad(c, (FcChar8*)namebuf, 1);
-		remove(namebuf);
+			FcConfig* c = FcConfigCreate();
+			FcConfigParseAndLoad(c, (FcChar8*)namebuf, 1);
+			remove(namebuf);
 
-		FcConfigBuildFonts(c);
-		FcConfigSetCurrent(c);
+			FcConfigBuildFonts(c);
+			FcConfigSetCurrent(c);
 
-		// FcConfig is reference-counted, so it's OK to call destroy here.
-		FcConfigDestroy(c);
+			// FcConfig is reference-counted, so it's OK to call destroy here.
+			FcConfigDestroy(c);
+		}
 	}
 
 	gdip_get_display_dpi();


### PR DESCRIPTION
fontconfig will not enumerate _any_ fonts if it cannot find a configuration file.
This PR tries to set some sensible defaults in that scenario, so that at least the system-wide fonts can be found.