### PR TITLE
fix libm not getting used when building

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,8 @@ GDIPLUS_CFLAGS="$GDIPLUS_CFLAGS $FONTCONFIG_CFLAGS $FREETYPE2_CFLAGS"
 
 AC_CHECK_HEADERS(byteswap.h)
 
+AC_SEARCH_LIBS(sqrt, m)
+
 AC_MSG_CHECKING([host threading settings])
 case "$host" in
 	*-*-mingw*|*-*-cygwin*)


### PR DESCRIPTION
this is needed for AIX/PASE