### PR TITLE
Fix a couple static analyzer warnings

### DIFF
--- a/src/adjustablearrowcap.c
+++ b/src/adjustablearrowcap.c
@@ -132,8 +132,8 @@ gdip_adjust_arrowcap_draw (GpGraphics *graphics, GpPen *pen, GpCustomLineCap *cu
 	cairo_rotate (graphics->ct, angle);
 
 	gdip_cairo_move_to (graphics, 0, 0, TRUE, TRUE);
-	gdip_cairo_line_to (graphics, -w * penwidth, -h * penwidth, TRUE, TRUE);
-	gdip_cairo_line_to (graphics, w * penwidth, -h * penwidth, TRUE, TRUE);
+	gdip_cairo_line_to (graphics, (double)-w * penwidth, (double)-h * penwidth, TRUE, TRUE);
+	gdip_cairo_line_to (graphics, (double)w * penwidth, (double)-h * penwidth, TRUE, TRUE);
 	gdip_cairo_line_to (graphics, 0, 0, TRUE, TRUE);
 
 	if (arrowcap->fill_state) {

--- a/src/bmpcodec.c
+++ b/src/bmpcodec.c
@@ -990,10 +990,8 @@ gdip_read_BITMAPINFOHEADER (void *pointer, ImageSource source, BITMAPV5HEADER *b
 				return OutOfMemory;
 			size -= sizeof (DWORD);
 		}
-		if (size > 0) {
-			if (gdip_read_bmp_data (pointer, data_read, size, source) != size)
-				return OutOfMemory;
-		}
+		if (gdip_read_bmp_data (pointer, data_read, size, source) != size)
+			return OutOfMemory;
 	}
 
     return Ok;

--- a/src/customlinecap.c
+++ b/src/customlinecap.c
@@ -219,11 +219,11 @@ gdip_custom_linecap_draw (GpGraphics *graphics, GpPen *pen, GpCustomLineCap *cus
 			/* mask the bits so that we get only the type value not the other flags */
 			switch (type & PathPointTypePathTypeMask) {
 			case PathPointTypeStart:
-				gdip_cairo_move_to (graphics, point.X * penwidth, point.Y * penwidth, TRUE, TRUE);
+				gdip_cairo_move_to (graphics, (double)point.X * penwidth, point.Y * penwidth, TRUE, TRUE);
 				break;
 
 			case PathPointTypeLine:
-				gdip_cairo_line_to (graphics, point.X * penwidth, point.Y * penwidth, TRUE, TRUE);
+				gdip_cairo_line_to (graphics, (double)point.X * penwidth, point.Y * penwidth, TRUE, TRUE);
 				break;
 
 			case PathPointTypeBezier:
@@ -235,7 +235,7 @@ gdip_custom_linecap_draw (GpGraphics *graphics, GpPen *pen, GpCustomLineCap *cus
 
 				/* once we've added 3 pts, we can draw the curve */
 				if (idx == 3) {
-					gdip_cairo_curve_to (graphics, pts[0].X * penwidth, pts[0].Y * penwidth, pts[1].X * penwidth, pts[1].Y * penwidth, pts[2].X * penwidth, pts[2].Y * penwidth, TRUE, TRUE);
+					gdip_cairo_curve_to (graphics, (double)pts[0].X * penwidth, (double)pts[0].Y * penwidth, (double)pts[1].X * penwidth, (double)pts[1].Y * penwidth, (double)pts[2].X * penwidth, (double)pts[2].Y * penwidth, TRUE, TRUE);
 					idx = 0;
 				}
 				break;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1538,7 +1538,7 @@ GdipFillClosedCurve2 (GpGraphics *graphics, GpBrush *brush, GDIPCONST GpPointF *
 	if (tension == 0)
 		return GdipFillPolygon2 (graphics, brush, points, count);
 
-	if (!graphics || !brush || !points || count <= 0)
+	if (!graphics || !brush || !points)
 		return InvalidParameter;
 
 	switch (graphics->backend) {

--- a/src/icocodec.c
+++ b/src/icocodec.c
@@ -241,7 +241,12 @@ gdip_read_ico_image_from_file_stream (void *pointer, GpImage **image, ImageSourc
 	 * - ANDBitmap is *always* a monochrome (1bpp) bitmap
 	 * - in every case each line is padded to 32 bits boundary
 	 */
-	pixels = GdipAlloc (result->active_bitmap->stride * result->active_bitmap->height);
+	unsigned long long int size = (unsigned long long int)result->active_bitmap->stride * result->active_bitmap->height;
+	if (size > G_MAXINT32) {
+		status = OutOfMemory;
+		goto error;
+	}
+	pixels = GdipAlloc (size);
 	if (pixels == NULL) {
 		status = OutOfMemory;
 		goto error;

--- a/src/image.c
+++ b/src/image.c
@@ -1697,7 +1697,11 @@ gdip_rotate_orthogonal_flip_x (GpImage *image, int angle, BOOL flip_x)
 		}
 	}
 
-	rotated = GdipAlloc (target_height * target_stride);
+	unsigned long long int size = (unsigned long long int)target_height * target_stride;
+	if (size > G_MAXINT32)
+		return OutOfMemory;
+
+	rotated = GdipAlloc (size);
 
 	if (rotated == NULL) {
 		return OutOfMemory;
@@ -1775,7 +1779,11 @@ gdip_rotate_flip_packed_indexed (GpImage *image, PixelFormat pixel_format, int a
 		return gdip_flip_y(image);
 	}
 
-	rotated = GdipAlloc (target_height * target_stride);
+	unsigned long long int size = (unsigned long long int)target_height * target_stride;
+	if (size > G_MAXINT32)
+		return OutOfMemory;
+
+	rotated = GdipAlloc (size);
 	if (rotated == NULL) {
 		return OutOfMemory;
 	}

--- a/src/pngcodec.c
+++ b/src/pngcodec.c
@@ -320,7 +320,13 @@ gdip_load_png_image_from_file_or_stream (FILE *fp, GetBytesDelegate getBytesFunc
 		/* Copy image data. */
 		row_pointers = png_get_rows (png_ptr, info_ptr);
 
-		rawdata = GdipAlloc(dest_stride * height);
+		unsigned long long int size = (unsigned long long int)dest_stride * height;
+		if (size > G_MAXINT32) {
+			status = OutOfMemory;
+			goto error;
+		}
+
+		rawdata = GdipAlloc(size);
 		if (!rawdata) {
 			status = OutOfMemory;
 			goto error;
@@ -466,7 +472,13 @@ gdip_load_png_image_from_file_or_stream (FILE *fp, GetBytesDelegate getBytesFunc
 
 		row_pointers = png_get_rows (png_ptr, info_ptr);
 
-		rawdata = GdipAlloc (stride * height);
+		unsigned long long int size = (unsigned long long int)stride * height;
+		if (size > G_MAXINT32) {
+			status = OutOfMemory;
+			goto error;
+		}
+
+		rawdata = GdipAlloc (size);
 		if (!rawdata) {
 			status = OutOfMemory;
 			goto error;

--- a/src/region-bitmap.c
+++ b/src/region-bitmap.c
@@ -454,7 +454,7 @@ gdip_region_bitmap_from_path (GpPath *path)
 	GpRegionBitmap *bitmap;
 	int i, idx;
 	int length = path->count;
-	unsigned long size;
+	unsigned long long int size;
 	cairo_surface_t *surface = NULL;
 	cairo_t *cr = NULL;
 
@@ -474,9 +474,9 @@ gdip_region_bitmap_from_path (GpPath *path)
 		return alloc_bitmap_with_buffer (bounds.X, bounds.Y, bounds.Width, bounds.Height, NULL);
 
 	/* replay the path list and the operations to reconstruct the bitmap */
-	size = (bounds.Width >> 3) * bounds.Height;
+	size = (unsigned long long int)(bounds.Width >> 3) * bounds.Height;
 	if ((size < 1) || (size > REGION_MAX_BITMAP_SIZE)) {
-		g_warning ("Path conversion requested %lu bytes (%d x %d). Maximum size is %d bytes.",
+		g_warning ("Path conversion requested %llu bytes (%d x %d). Maximum size is %d bytes.",
 			size, bounds.Width, bounds.Height, REGION_MAX_BITMAP_SIZE);
 		return NULL;
 	}

--- a/src/tiffcodec.c
+++ b/src/tiffcodec.c
@@ -959,6 +959,7 @@ gdip_save_tiff_image (TIFF* tiff, GpImage *image, GDIPCONST EncoderParameters *p
 	BYTE		*pixbuf;
 	int		samples_per_pixel;
 	int		bits_per_sample;
+	unsigned long long int size;
 
 	if (tiff == NULL) {
 		return InvalidParameter;
@@ -1008,7 +1009,12 @@ gdip_save_tiff_image (TIFF* tiff, GpImage *image, GDIPCONST EncoderParameters *p
 			TIFFSetField (tiff, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize (tiff, bitmap_data->stride));
 			TIFFSetField (tiff, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
 
-			pixbuf = GdipAlloc (bitmap_data->width * samples_per_pixel);
+			size = (unsigned long long int)bitmap_data->width * samples_per_pixel;
+			if (size > G_MAXINT32) {
+				goto error;
+			}
+
+			pixbuf = GdipAlloc (size);
 			if (pixbuf == NULL) {
 				goto error;
 			}


### PR DESCRIPTION
Various instances of "Multiplication result may overflow 'unsigned int' before it is converted to 'size_t'." and "comparison is always the same" warnings.