### PR TITLE
Fix warnings running autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -131,7 +131,7 @@ do
   shift
 done
 
-conf_flags="--enable-maintainer-mode --enable-compile-warnings" #--enable-iso-c
+conf_flags="--enable-maintainer-mode"
 
 if test x$NOCONFIGURE = x; then
   echo Running $srcdir/configure $conf_flags $CONF_OPTIONS ...

--- a/configure.ac
+++ b/configure.ac
@@ -31,12 +31,12 @@ PKG_CHECK_MODULES(CAIRO, cairo >= $CAIRO_REQUIRED_VERSION)
 # Optional use of Pango's text rendering on top of Cairo
 AC_ARG_WITH(pango, [  --with-pango            use Pango to measure and draw text],[text_v=pango],[text_v=default])
 
-GDIPLUS_CFLAGS="$GDIPLUS_CFLAGS -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -std=gnu99"
+GDIPLUS_CFLAGS="$GDIPLUS_CFLAGS -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -std=gnu11"
 
 AC_ARG_ENABLE(warnaserror, AS_HELP_STRING([--enable-warnaserror],[Enable treating warnings as errors.]),[warnaserror=yes],[warnaserror=no])
 
 if test $warnaserror = "yes"; then
-  GDIPLUS_CFLAGS="$GDIPLUS_CFLAGS -Werror -Wno-unknown-warning-option -Wno-clobbered -Wno-typedef-redefinition"
+  GDIPLUS_CFLAGS="$GDIPLUS_CFLAGS -Werror -Wno-unknown-warning-option -Wno-clobbered"
 fi
 
 AC_ARG_ENABLE(asan, AS_HELP_STRING([--enable-asan],[Enable address sanitizer.]),[asan=yes],[asan=no])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,7 @@ LIBS = $(GDIPLUS_LIBS)
 
 AM_CPPFLAGS =					\
 	-I$(top_srcdir)				\
-	-I$(top_builddir)/src			\
+	-I$(top_builddir)/src		\
 	-I$(top_srcdir)/src			\
 	$(GDIPLUS_CFLAGS)
 
@@ -306,7 +306,22 @@ EXTRA_DIST =			\
 	$(testtexturebrush_SOURCES)	\
 	$(testtext_SOURCES)	\
 	$(testtiffcodec_SOURCES) \
-	$(testwmfcodec_SOURCES)
+	$(testwmfcodec_SOURCES) \
+	AdobeRGB1998.icc \
+	test-gsa.png \
+	test-trns.png \
+	test.bmp \
+	test.emf \
+	test.gif \
+	test.ico \
+	test.jpg \
+	test.otf \
+	test.png \
+	test.tif \
+	test.ttf \
+	test.wmf \
+	testhelpers.h \
+	$(NULL)
 
 #	$(testgdi_SOURCES)
 
@@ -352,19 +367,3 @@ TESTS = \
 if HAVE_X11
 # TESTS += testgdi
 endif
-
-EXTRA_DIST = \
-	AdobeRGB1998.icc \
-	test-gsa.png \
-	test-trns.png \
-	test.bmp \
-	test.emf \
-	test.gif \
-	test.ico \
-	test.jpg \
-	test.otf \
-	test.png \
-	test.tif \
-	test.ttf \
-	test.wmf \
-	testhelpers.h


### PR DESCRIPTION
```In file included from jpegcodec.c:40:
In file included from /usr/local/include/jpeglib.h:27:
/usr/local/include/jmorecfg.h:199:24: warning: redefinition of typedef 'UINT16'
      is a C11 feature [-Wtypedef-redefinition]
typedef unsigned short UINT16;
                       ^
./win32structs.h:347:17: note: previous definition is here
typedef guint16 UINT16;
```