### PR TITLE
Fix ImageAttributes clone crash with color profile names

### DIFF
--- a/src/imageattributes.c
+++ b/src/imageattributes.c
@@ -75,8 +75,7 @@ gdip_clone_image_attribute(const GpImageAttribute* attr, GpImageAttribute* clone
 	if (attr->colormap && attr->colormap_elem > 0) {
 		clone->colormap = GdipAlloc(sizeof(ColorMap) * attr->colormap_elem);
 
-		if (!clone->colormap)
-		{
+		if (!clone->colormap) {
 			gdip_dispose_image_attribute(clone);
 			return OutOfMemory;
 		}
@@ -87,8 +86,7 @@ gdip_clone_image_attribute(const GpImageAttribute* attr, GpImageAttribute* clone
 	if (attr->colormatrix) {
 		clone->colormatrix = GdipAlloc(sizeof(ColorMatrix));
 
-		if (!clone->colormatrix)
-		{
+		if (!clone->colormatrix) {
 			gdip_dispose_image_attribute(clone);
 			return OutOfMemory;
 		}
@@ -99,8 +97,7 @@ gdip_clone_image_attribute(const GpImageAttribute* attr, GpImageAttribute* clone
 	if (attr->graymatrix) {
 		clone->graymatrix = GdipAlloc(sizeof(ColorMatrix));
 
-		if (!clone->graymatrix)
-		{
+		if (!clone->graymatrix) {
 			gdip_dispose_image_attribute(clone);
 			return OutOfMemory;
 		}
@@ -109,10 +106,8 @@ gdip_clone_image_attribute(const GpImageAttribute* attr, GpImageAttribute* clone
 	}
 
 	if (attr->colorprofile_filename) {
-		strcpy(clone->colorprofile_filename, attr->colorprofile_filename);
-
-		if (!clone->colorprofile_filename)
-		{
+		clone->colorprofile_filename = strdup (attr->colorprofile_filename);
+		if (!clone->colorprofile_filename) {
 			gdip_dispose_image_attribute(clone);
 			return OutOfMemory;
 		}

--- a/tests/testimageattributes.c
+++ b/tests/testimageattributes.c
@@ -45,21 +45,87 @@ static void test_cloneImageAttributes ()
 	GpStatus status;
 	GpImageAttributes *attributes;
 	GpImageAttributes *clonedAttributes;
+	ColorMatrix colorMatrix;
+	ColorMatrix grayMatrix;
+	WCHAR *colorProfileName = createWchar ("AdobeRGB1998.icc");
+	ColorMap remapTable[2] = {
+		{ {123}, {234} },
+		{ {345}, {678} }
+	};
 
+	memset ((void *) &colorMatrix, 0, sizeof (ColorMatrix));
+	memset ((void *) &grayMatrix, 0, sizeof (ColorMatrix));
+
+	// Simple.
 	GdipCreateImageAttributes (&attributes);
 
 	status = GdipCloneImageAttributes (attributes, &clonedAttributes);
 	assertEqualInt (status, Ok);
 	assert (attributes && attributes != clonedAttributes);
 
+	GdipDisposeImageAttributes (clonedAttributes);
+	GdipDisposeImageAttributes (attributes);
+
+	// Complex.
+	GdipCreateImageAttributes (&attributes);
+	GdipSetImageAttributesColorMatrix (attributes, ColorAdjustTypeDefault, TRUE, &colorMatrix, &grayMatrix, ColorMatrixFlagsDefault);
+	GdipSetImageAttributesColorMatrix (attributes, ColorAdjustTypeBitmap, TRUE, &colorMatrix, &grayMatrix, ColorMatrixFlagsDefault);
+	GdipSetImageAttributesColorMatrix (attributes, ColorAdjustTypeBrush, TRUE, &colorMatrix, &grayMatrix, ColorMatrixFlagsDefault);
+	GdipSetImageAttributesColorMatrix (attributes, ColorAdjustTypePen, TRUE, &colorMatrix, &grayMatrix, ColorMatrixFlagsDefault);
+	GdipSetImageAttributesColorMatrix (attributes, ColorAdjustTypeText, TRUE, &colorMatrix, &grayMatrix, ColorMatrixFlagsDefault);
+	GdipSetImageAttributesThreshold (attributes, ColorAdjustTypeDefault, TRUE, 100);
+	GdipSetImageAttributesThreshold (attributes, ColorAdjustTypeBitmap, TRUE, 101);
+	GdipSetImageAttributesThreshold (attributes, ColorAdjustTypeBrush, TRUE, 102);
+	GdipSetImageAttributesThreshold (attributes, ColorAdjustTypePen, TRUE, 103);
+	GdipSetImageAttributesThreshold (attributes, ColorAdjustTypeText, TRUE, 104);
+	GdipSetImageAttributesGamma (attributes, ColorAdjustTypeDefault, TRUE, 100);
+	GdipSetImageAttributesGamma (attributes, ColorAdjustTypeBitmap, TRUE, 101);
+	GdipSetImageAttributesGamma (attributes, ColorAdjustTypeBrush, TRUE, 102);
+	GdipSetImageAttributesGamma (attributes, ColorAdjustTypePen, TRUE, 103);
+	GdipSetImageAttributesGamma (attributes, ColorAdjustTypeText, TRUE, 104);
+	GdipSetImageAttributesColorKeys (attributes, ColorAdjustTypeDefault, TRUE, 0x01020304, 0x02030406);
+	GdipSetImageAttributesColorKeys (attributes, ColorAdjustTypeBitmap, TRUE, 0x01020305, 0x02030407);
+	GdipSetImageAttributesColorKeys (attributes, ColorAdjustTypeBrush, TRUE, 0x01020306, 0x02030408);
+	GdipSetImageAttributesColorKeys (attributes, ColorAdjustTypePen, TRUE, 0x01020307, 0x02030409);
+	GdipSetImageAttributesColorKeys (attributes, ColorAdjustTypeText, TRUE, 0x01020308, 0x02030400);
+	GdipSetImageAttributesOutputChannel (attributes, ColorAdjustTypeDefault, TRUE, ColorChannelFlagsC);
+	GdipSetImageAttributesOutputChannel (attributes, ColorAdjustTypeBitmap, TRUE, ColorChannelFlagsM);
+	GdipSetImageAttributesOutputChannel (attributes, ColorAdjustTypeBrush, TRUE, ColorChannelFlagsY);
+	GdipSetImageAttributesOutputChannel (attributes, ColorAdjustTypePen, TRUE, ColorChannelFlagsK);
+	GdipSetImageAttributesOutputChannel (attributes, ColorAdjustTypeText, TRUE, ColorChannelFlagsC);
+	GdipSetImageAttributesOutputChannelColorProfile (attributes, ColorAdjustTypeDefault, TRUE, colorProfileName);
+	GdipSetImageAttributesOutputChannelColorProfile (attributes, ColorAdjustTypeBitmap, TRUE, colorProfileName);
+	GdipSetImageAttributesOutputChannelColorProfile (attributes, ColorAdjustTypeBrush, TRUE, colorProfileName);
+	GdipSetImageAttributesOutputChannelColorProfile (attributes, ColorAdjustTypePen, TRUE, colorProfileName);
+	GdipSetImageAttributesOutputChannelColorProfile (attributes, ColorAdjustTypeText, TRUE, colorProfileName);
+	GdipSetImageAttributesRemapTable (attributes, ColorAdjustTypeDefault, TRUE, 1, remapTable);
+	GdipSetImageAttributesRemapTable (attributes, ColorAdjustTypeBitmap, TRUE, 1, remapTable);
+	GdipSetImageAttributesRemapTable (attributes, ColorAdjustTypeBrush, TRUE, 1, remapTable);
+	GdipSetImageAttributesRemapTable (attributes, ColorAdjustTypePen, TRUE, 1, remapTable);
+	GdipSetImageAttributesRemapTable (attributes, ColorAdjustTypeText, TRUE, 1, remapTable);
+	GdipSetImageAttributesWrapMode (attributes, WrapModeTile, 10, TRUE);
+	GdipSetImageAttributesCachedBackground (attributes, TRUE);
+
+	status = GdipCloneImageAttributes (attributes, &clonedAttributes);
+	assertEqualInt (status, Ok);
+	assert (attributes && attributes != clonedAttributes);
+
+	GdipDisposeImageAttributes (clonedAttributes);
+	GdipDisposeImageAttributes (attributes);
+
 	// Negative tests.
+	GdipCreateImageAttributes (&attributes);
+
+	clonedAttributes = (GpImageAttributes *) 0xCC;
 	status = GdipCloneImageAttributes (NULL, &clonedAttributes);
 	assertEqualInt (status, InvalidParameter);
+	assert (clonedAttributes == (GpImageAttributes *) 0xCC);
 
 	status = GdipCloneImageAttributes (attributes, NULL);
 	assertEqualInt (status, InvalidParameter);
 
 	GdipDisposeImageAttributes (attributes);
+	freeWchar (colorProfileName);
 }
 
 static void test_disposeImageAttributes ()


### PR DESCRIPTION
Regression from https://github.com/mono/libgdiplus/pull/560

/cc @qmfrederik 