### PR TITLE
Fix leak in GdipSetPenColor

### DIFF
--- a/src/pen.c
+++ b/src/pen.c
@@ -536,7 +536,10 @@ GdipSetPenColor (GpPen *pen, ARGB argb)
 		return status;
 
 	pen->color = argb;
+	if (pen->own_brush)
+		GdipDeleteBrush (pen->brush);
 	pen->brush = (GpBrush *) brush;
+	pen->own_brush = TRUE;
 	pen->changed = TRUE;
 
 	return Ok;


### PR DESCRIPTION
- When overriding the brush, dispose of it if we own it
- When setting the new brush, we actually own it, so want to dispose it when we dispose the pen