### PR TITLE
Fix memory leaks cloning Path/Line gradient brushes

### DIFF
--- a/src/lineargradientbrush.c
+++ b/src/lineargradientbrush.c
@@ -111,7 +111,7 @@ gdip_linear_gradient_clone_brush (GpBrush *brush, GpBrush **clonedBrush)
 	if (!brush || !clonedBrush)
 		return InvalidParameter;
 
-	newbrush = gdip_linear_gradient_new ();
+	newbrush = (GpLineGradient *) GdipAlloc (sizeof (GpLineGradient));
 	if (!newbrush)
 		return OutOfMemory;
 

--- a/src/pathgradientbrush.c
+++ b/src/pathgradientbrush.c
@@ -127,7 +127,7 @@ gdip_pgrad_clone_brush (GpBrush *brush, GpBrush **clonedBrush)
 	if (!brush || !clonedBrush)
 		return InvalidParameter;
 
-	newbrush = gdip_pathgradient_new ();
+	newbrush = (GpPathGradient *) GdipAlloc (sizeof (GpPathGradient));
 	if (!newbrush)
 		return OutOfMemory;
 


### PR DESCRIPTION
We'd allocate memory in `gdip_linear_gradient_new` and then override it immediately. Avoid allocating by just calling GdipAlloc instead of that method