### PR TITLE
JPEG codec: initialize cinfo.mem

### DIFF
--- a/src/jpegcodec.c
+++ b/src/jpegcodec.c
@@ -719,6 +719,8 @@ gdip_save_jpeg_image_internal (FILE *fp, PutBytesDelegate putBytesFunc, GpImage 
 	int		need_argb_conversion = 0;
 	GpStatus	status;
 
+	cinfo.mem = NULL;
+
 	/* Verify that we can support this pixel format */
 	switch (image->active_bitmap->pixel_format) {
 		case PixelFormat32bppARGB:


### PR DESCRIPTION
If `image->active_bitmap->pixel_format` is not a valid pixel format, the call to `goto error` would cause a call to `jpeg_destroy_compress` which would access `cinfo.mem`. Initialize it to `NULL` to avoid an AV.