### PR TITLE
Use pango 1.42.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
     - git
 
 install:
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; brew install glib cairo libexif libjpeg giflib libtiff autoconf libtool automake pango pkg-config || true; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/a8ac7ea5fe9339558c9fbe49acaa1a2452bcd4d0/Formula/pango.rb; brew install glib cairo libexif libjpeg giflib libtiff autoconf libtool automake pkg-config || true; fi
 
 script:
 - set -e


### PR DESCRIPTION
`pango_fc_font_unlock_face` is depcreated in Pango 1.44, which got pulled into the Travis build via a Homebrew update.

This PR pins pango to 1.42 to resolve that issue.