### PR TITLE
Add bitmap flushing to gdip_bitmap_clone

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -639,6 +639,8 @@ gdip_bitmap_clone (GpBitmap *bitmap, GpBitmap **clonedbitmap)
 		return OutOfMemory;
 	}
 
+	gdip_bitmap_flush_surface (bitmap);
+
 	/* Copy simple types */
 	result->type = bitmap->type;
 	result->image_format = bitmap->image_format;


### PR DESCRIPTION
…to fix possible inconsistencies for drawing flipped images.

There were few usages of `gdip_bitmap_clone` with missing flush calls. Unfortunately there is zero code coverage for these paths. The chances of actually turning this into visible bug are thin. One would have to create an ARGB32 bitmap, draw into it and then try to paint it flipped into another bitmap. Adding the flush call down the stack is a safety precaution that should prevent any incorrect usage.