### PR TITLE
Fix: an issue where Japanese characters are recognized as spaces

### DIFF
--- a/src/text-cairo.c
+++ b/src/text-cairo.c
@@ -27,7 +27,7 @@
 
 #ifndef USE_PANGO_RENDERING
 
-#include <ctype.h>
+#include <wctype.h>
 
 #include "text-cairo-private.h"
 #include "graphics-private.h"
@@ -254,7 +254,7 @@ MeasureString (GpGraphics *graphics, GDIPCONST WCHAR *stringUnicode, int *length
 
 	/* unless specified we don't consider the trailing spaces, unless there is just one space (#80680) */
 	if ((format->formatFlags & StringFormatFlagsMeasureTrailingSpaces) == 0) {
-		while ((StringLen > 0) && (isspace ((int) ( *(Src + StringLen - 1)))))
+		while ((StringLen > 0) && (iswspace(*(Src + StringLen - 1))))
 			StringLen--;
 		if (StringLen == 0)
 			StringLen = 1;


### PR DESCRIPTION
This PR fix an issue where Japanese characters are recognized as spaces. (#627)

This fix does not recur issue (https://github.com/mono/mono/issues/8272) fixed by #370.