### PR TITLE
Bugfix/font style issue

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -890,7 +890,8 @@ gdip_get_cairo_font_face (GpFont *font)
 {
 	if (!font->cairofnt) {
 		FcPattern *pattern = FcPatternBuild (
-			FcPatternDuplicate (font->family->pattern),
+			NULL,
+			FC_FAMILY, FcTypeString,  font->face,
 			FC_SLANT,  FcTypeInteger, ((font->style & FontStyleItalic) ? FC_SLANT_ITALIC : FC_SLANT_ROMAN), 
 			FC_WEIGHT, FcTypeInteger, ((font->style & FontStyleBold)   ? FC_WEIGHT_BOLD  : FC_WEIGHT_MEDIUM),
 			NULL);


### PR DESCRIPTION
This fixes the wrong font-weight from issue #626 

Sadly I it breaks the tests, but it does render the font as Bold.

I'll check what's wrong with the tests. Is this maybe a Mono issue instead of a libgdiplus issue?