### PR TITLE
Fix multiple memory leaks for GpBitmap image data

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -590,6 +590,7 @@ gdip_bitmap_setactive(GpBitmap *bitmap, const GUID *dimension, int index)
 	}
 
 	/* Invalidate the cached surface */
+	gdip_bitmap_flush_surface (bitmap);
 	gdip_bitmap_invalidate_surface (bitmap);
 
 	if ((bitmap->num_of_frames == 0) || (bitmap->frames == NULL)) {
@@ -728,6 +729,8 @@ gdip_bitmap_dispose (GpBitmap *bitmap)
 	if (!bitmap)
 		return Ok;
 
+	gdip_bitmap_invalidate_surface (bitmap);
+
 	if (bitmap->frames) {
 		int frame;
 		for (frame = 0; frame < bitmap->num_of_frames; frame++) {
@@ -735,11 +738,6 @@ gdip_bitmap_dispose (GpBitmap *bitmap)
 		}
 		GdipFree (bitmap->frames);
 		bitmap->frames = NULL;
-	}
-
-	if (bitmap->surface) {
-		cairo_surface_destroy (bitmap->surface);
-		bitmap->surface = NULL;
 	}
 
 	GdipFree (bitmap);
@@ -2253,7 +2251,6 @@ void gdip_bitmap_invalidate_surface (GpBitmap *bitmap)
 {
 	if (bitmap->surface != NULL) {
 		BYTE *surface_scan0 = cairo_image_surface_get_data (bitmap->surface);
-		gdip_bitmap_flush_surface (bitmap);
 		cairo_surface_destroy (bitmap->surface);
 		bitmap->surface = NULL;
 		if (surface_scan0 != bitmap->active_bitmap->scan0) {

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -2000,7 +2000,10 @@ GdipSetClipRect (GpGraphics *graphics, REAL x, REAL y, REAL width, REAL height, 
 			return status;
 	}
 
-	return GdipSetClipRegion (graphics, region, combineMode);
+	status = GdipSetClipRegion (graphics, region, combineMode);
+	GdipDeleteRegion (region);
+
+	return status;
 }
 
 GpStatus WINGDIPAPI

--- a/src/image.c
+++ b/src/image.c
@@ -859,10 +859,11 @@ GdipDrawImageRectRect (GpGraphics *graphics, GpImage *image,
 	}
 
 	if (allocated) {
+		gdip_bitmap_invalidate_surface (image);
 		image->active_bitmap->scan0 = org;
 		image->active_bitmap->pixel_format = org_format;
 		image->surface = org_surface;
-		GdipFree (dest);
+		// NOTE: dest is freed by gdip_bitmap_invalidate_surface above
 	}
 	
 	return Ok;
@@ -1623,9 +1624,10 @@ gdip_rotate_orthogonal_flip_x (GpImage *image, int angle, BOOL flip_x)
 	image->active_bitmap->scan0 = rotated;
 	image->active_bitmap->reserved |= GBD_OWN_SCAN0;
 
-	if (isSurfaceSource == 0)
-		gdip_bitmap_invalidate_surface(image);
-	else {
+	if (isSurfaceSource == 0) {
+		gdip_bitmap_flush_surface (image);
+		gdip_bitmap_invalidate_surface (image);
+	} else {
 		/* recalculate surface from rotated scan0 */
 		cairo_surface_destroy(image->surface);
 		image->surface = NULL;
@@ -1808,6 +1810,7 @@ gdip_rotate_flip_packed_indexed (GpImage *image, PixelFormat pixel_format, int a
 
 	/* It shouldn't be possible for an indexed image to have one,
 	 * but if it does, it needs to be killed. */
+	gdip_bitmap_flush_surface (image);
 	gdip_bitmap_invalidate_surface (image);
 
 	return Ok;


### PR DESCRIPTION
`gdip_bitmap_dispose` was leaking the bitmap backing data for certain image formats. This is essentially the same issue as in https://github.com/mono/libgdiplus/commit/1afe4711f10bd52e14a4c7985eae7414eda4108c but on a different place. I now unified both of the places to use the same code.