### PR TITLE
WIP: Fix ownership of GpFontFamily objects returned by GdipGetFontCollectionFamilyList

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -69,7 +69,6 @@ gdip_fontfamily_init (GpFontFamily *fontFamily)
 	fontFamily->celldescent = -1;
 	fontFamily->cellascent = -1;
 	fontFamily->pattern = NULL;
-	fontFamily->allocated = FALSE;
 }
 
 static GpFontFamily *
@@ -271,11 +270,7 @@ GdipCloneFontFamily (GpFontFamily *fontFamily, GpFontFamily **clonedFontFamily)
 	result->linespacing = fontFamily->linespacing;
 	result->celldescent = fontFamily->celldescent;
 	result->cellascent = fontFamily->cellascent;
-
-	if (fontFamily->pattern) {
-		result->pattern = FcPatternDuplicate (fontFamily->pattern);
-		result->allocated = TRUE;
-	}
+	result->pattern = fontFamily->pattern;
 
 	*clonedFontFamily = result;
 	return Ok;
@@ -337,10 +332,6 @@ GdipDeleteFontFamily (GpFontFamily *fontFamily)
 #endif
 	
 	if (delete) {
-		if (fontFamily->allocated) {
-			FcPatternDestroy (fontFamily->pattern);
-			fontFamily->pattern = NULL;
-		}
 		GdipFree (fontFamily);
 	}
 	
@@ -376,7 +367,6 @@ gdpi_ensureFamiliesCreated (GpFontCollection *font_collection)
 			gdip_fontfamily_init (font_collection->families + i);
 			font_collection->families[i].collection = font_collection;
 			font_collection->families[i].pattern = font_collection->fontset->fonts[i];
-			font_collection->families[i].allocated = FALSE;
 		}
 	}
 
@@ -536,7 +526,6 @@ create_fontfamily_from_name (char* name, GpFontFamily **fontFamily)
 		ff = gdip_fontfamily_new ();
 		if (ff) {
 			ff->pattern = pat;
-			ff->allocated = FALSE;
 			ff->collection = font_collection;
 			status = Ok;
 		} else 
@@ -600,7 +589,6 @@ create_fontfamily_from_collection (char* name, GpFontCollection *font_collection
 					return OutOfMemory;
 
 				result->pattern = *gpfam;
-				result->allocated = FALSE;
 				result->collection = font_collection;
 
 				*fontFamily = result;

--- a/src/font.c
+++ b/src/font.c
@@ -362,12 +362,14 @@ gdpi_ensureFamiliesCreated (GpFontCollection *font_collection)
 	}
 
 	font_collection->families = GdipAlloc (sizeof (GpFontFamily) * font_collection->fontset->nfont);
-	if (font_collection->families != NULL) {
-		for (int i = 0; i < font_collection->fontset->nfont; i++) {
-			gdip_fontfamily_init (font_collection->families + i);
-			font_collection->families[i].collection = font_collection;
-			font_collection->families[i].pattern = font_collection->fontset->fonts[i];
-		}
+	if (font_collection->families == NULL) {
+		return OutOfMemory;
+	}
+
+	for (int i = 0; i < font_collection->fontset->nfont; i++) {
+		gdip_fontfamily_init (font_collection->families + i);
+		font_collection->families[i].collection = font_collection;
+		font_collection->families[i].pattern = font_collection->fontset->fonts[i];
 	}
 
 	return Ok;

--- a/src/fontcollection-private.h
+++ b/src/fontcollection-private.h
@@ -40,6 +40,7 @@
 struct _FontCollection {
 	FcFontSet*	fontset;
 	FcConfig*	config;		/* Only for private collections */
+	GpFontFamily*	families;
 #ifdef USE_PANGO_RENDERING
 	PangoFontMap*	pango_font_map;
 #endif

--- a/src/fontfamily-private.h
+++ b/src/fontfamily-private.h
@@ -40,7 +40,6 @@
 struct _FontFamily {
 	struct _FontCollection *collection;
 	FcPattern*	pattern;
-	BOOL		allocated;
 	short 		height;
 	short 		linespacing;
 	short		celldescent;


### PR DESCRIPTION
The returned objects are owned by GpFontCollection and the font collection is responsible for their lifetime. The managed implementation of System.Drawing in Mono and System.Drawing.Common in .NET Core already treated the ownership correctly which resulted in memory leaks. Change GdipDeleteFontFamily to detect accidental attempts to delete the font family objects.