### PR TITLE
Fix some pen width problems

### DIFF
--- a/src/pen.c
+++ b/src/pen.c
@@ -144,7 +144,7 @@ gdip_pen_setup (GpGraphics *graphics, GpPen *pen)
 {
 	GpStatus status;
 	cairo_matrix_t product;
-	double widthx;
+	double widthx, widthy;
 
 	if (!graphics || !pen)
 		return InvalidParameter;
@@ -179,12 +179,12 @@ gdip_pen_setup (GpGraphics *graphics, GpPen *pen)
 	if (pen == graphics->last_pen && !pen->changed)
 		return Ok;
 
-	if (pen->width < 1.0) { /* we draw a pixel wide line if width is < 1.0 */
-		double widthy = 1.0;
-		widthx = 1.0;
-
-		cairo_device_to_user_distance (graphics->ct, &widthx, &widthy);
-	} else {
+	widthx = 1.0;
+	widthy = 1.0;
+	cairo_device_to_user_distance (graphics->ct, &widthx, &widthy);
+	widthx = fmax(fabs(widthx), fabs(widthy));
+	
+	if (pen->width > widthx) { /* we draw a pixel wide line if the output width is < 1.0 */
 		widthx = (double) pen->width;
 	}
 	cairo_set_line_width (graphics->ct, widthx);


### PR DESCRIPTION
First, base the 1px minimum line width on output line width, not pen width. If scaling up with a pen width < 1, the output width may well be more than 1px, in which case the correct output is that width, not 1px.

Second, `cairo_device_to_user_distance()` can provide negative values. Use the absolute value of its outputs. The negative comes from mirror-type transforms (negative scale values). Using a negative value results in no line being drawn; and if dash_count > 0, also an error from Cairo.

Third, use the maximum of `widthx` and `widthy`, because scaling is not necessarily uniform. Setting a minimum line width is only necessary because Cairo produces dashed lines when scaling up and the output width is < 1px, and we don't want that happening when scaling Y more than X.