### PR TITLE
Keep clipping inside containers.

### DIFF
--- a/src/graphics-private.h
+++ b/src/graphics-private.h
@@ -129,6 +129,7 @@ typedef struct _Graphics {
 	GpMetafile		*metafile;
 	cairo_surface_t		*metasurface;	/* bogus surface to satisfy some API calls */
 	/* common-stuff */
+	GpRegion		*overall_clip;
 	GpRegion*		clip;
 	GpRegion		*previous_clip;
 	GpMatrix*		clip_matrix;
@@ -158,6 +159,7 @@ typedef struct _Graphics {
 float gdip_unit_conversion (Unit from, Unit to, float dpi, GraphicsType type, float nSrc) GDIP_INTERNAL;
 
 void gdip_set_cairo_clipping (GpGraphics *graphics) GDIP_INTERNAL;
+GpStatus gdip_calculate_overall_clipping (GpGraphics *graphics) GDIP_INTERNAL;
 
 GpGraphics* gdip_graphics_new (cairo_surface_t *surface) GDIP_INTERNAL;
 GpGraphics* gdip_metafile_graphics_new (GpMetafile *metafile) GDIP_INTERNAL;

--- a/src/graphics-private.h
+++ b/src/graphics-private.h
@@ -86,6 +86,7 @@ typedef struct {
 	cairo_matrix_t		matrix;
 	cairo_matrix_t		previous_matrix;
 	GpRegion*		clip;
+	GpRegion		*previous_clip;
 	cairo_matrix_t		clip_matrix;
 	CompositingMode    	composite_mode;
 	CompositingQuality 	composite_quality;
@@ -129,6 +130,7 @@ typedef struct _Graphics {
 	cairo_surface_t		*metasurface;	/* bogus surface to satisfy some API calls */
 	/* common-stuff */
 	GpRegion*		clip;
+	GpRegion		*previous_clip;
 	GpMatrix*		clip_matrix;
 	GpRect			bounds;
 	GpRect			orig_bounds;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -2451,8 +2451,7 @@ GdipIsVisiblePointI (GpGraphics *graphics, INT x, INT y, BOOL *result)
 GpStatus WINGDIPAPI
 GdipIsVisibleRect (GpGraphics *graphics, REAL x, REAL y, REAL width, REAL height, BOOL *result)
 {
-	float posy, posx;
-	GpRectF recthit, boundsF;
+	GpRectF boundsF;
 
 	if (!graphics || !result)
 		return InvalidParameter;

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -531,9 +531,12 @@ GdipRestoreGraphics (GpGraphics *graphics, GraphicsState state)
 
 	GdipSetRenderingOrigin (graphics, pos_state->org_x, pos_state->org_y);
 
+	if (graphics->overall_clip != graphics->clip) {
+		GdipDeleteRegion (graphics->overall_clip);
+	}
+	graphics->overall_clip = NULL;
+
 	if (graphics->clip) {
-		if (graphics->overall_clip == graphics->clip)
-			graphics->overall_clip = NULL; // Don't double-free!
 		GdipDeleteRegion (graphics->clip);
 	}
 	status = GdipCloneRegion (pos_state->clip, &graphics->clip);


### PR DESCRIPTION
Containers need to maintain the clipping that exists outside them.

I have implemented this by storing the overall clip region outside the current container (`graphics->previous_clip`, `NULL` if not in a container or if no clipping outside) in addition to any clip region set (`graphics->clip`), and then intersecting them in `cairo_SetGraphicsClip()`, `GdipBeginContainer2()` and `GdipGetVisibleClipBounds()` (the three places that need the overall clip). `previous_clip` goes on the save stack on saving, in addition to `clip`.

Alternatively the intersection could be done when modifying the clip and when restoring it off the save stack (four places), but that would mean storing the resulting region as well as the other two, although the overall clip wouldn't need to be stored on the save stack. (`GdipTranslateClip()`, `GdipGetClip()` and `GdipGetClipBounds()` need the clip that was set.)

Also, I modified `GdipResetClip()` to call `cairo_SetGraphicsClip()` rather than `cairo_ResetClip()` when `previous_clip` exists, as it needs to keep that. Alternatively, it would be possible to modify `cairo_ResetClip()` to set the clip to `previous_clip` itself.

I have implemented this into `GdipGetVisibleClipBounds()`, as that should provide the overall clip bounds. And I changed `GdipIsVisiblePoint()` and `GdipIsVisibleRect()` to use that instead of the `graphics->bounds` (they should take clipping into account). I won't mention the insane check previously used in the latter of those two methods, but the replacement was taken from region.c – ideally I'd have added a declaration for it to region-private.h, but I didn't think `gdip_intersects()` was a descriptive enough name for that, and I didn't want to do a rename.

I guess I should write some tests too, so I'll try to get around to that some time soon. But I'll put this out there now for any comments.