### PR TITLE
Fix System.OutOfMemoryException when 512 calls to BeginContainer were made since application start

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -534,7 +534,7 @@ GdipRestoreGraphics (GpGraphics *graphics, GraphicsState state)
 	graphics->pixel_mode = pos_state->pixel_mode;
 	graphics->text_contrast = pos_state->text_contrast;
 
-	graphics->saved_status_pos = state;
+	graphics->saved_status_pos = state - 1;
 
 	/* re-adjust clipping (region and matrix) */
 	gdip_cairo_set_matrix (graphics, graphics->copy_of_ctm);


### PR DESCRIPTION
Fixing an issue with the state count not being decremented (stack not popped) when EndContainer is called. This would cause a System.OutOfMemoryException when 512 calls to BeginContainer were made since application start.