### PR TITLE
Fix memory leak when setting pen dash style from custom to predefined

### DIFF
--- a/src/pen.c
+++ b/src/pen.c
@@ -817,6 +817,13 @@ GdipSetPenDashStyle (GpPen *pen, GpDashStyle dashstyle)
 	if (!pen)
 		return InvalidParameter;
 
+	/* Free old custom dash style if we are going to override it */
+	if (pen->dash_count != 0 && pen->own_dash_array && dashstyle < DashStyleCustom) {
+		GdipFree (pen->dash_array);
+		pen->dash_count = 0;
+		pen->dash_array = NULL;
+	}
+
 	switch (dashstyle) {
 	case DashStyleSolid:
 		pen->dash_array = NULL;


### PR DESCRIPTION
This fixes part of #647 that I complained about in comment.

I tested locally that Windows libgdiplus in fact resets the dash array on `DashStyleCustom` -> `DashStyleDashDot` -> `DashStyleCustom` transition done using `GdipSetPenDashStyle`. Following this transition `GdipGetPenDashArray` returns the Dash-Dot pattern and not the original custom one.