### PR TITLE
Various memory leak fixes

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -534,7 +534,14 @@ gdip_font_clear_pattern_cache (void)
 	if (patterns_hashtable) {
 		g_hash_table_foreach_remove (patterns_hashtable, free_cached_pattern, NULL);
 		g_hash_table_destroy (patterns_hashtable);
+		patterns_hashtable = NULL;
 	}
+	familySerif = NULL;
+	familySansSerif = NULL;
+	familyMonospace = NULL;
+	ref_familySerif = 0;
+	ref_familySansSerif = 0;
+	ref_familyMonospace = 0;
 #if GLIB_CHECK_VERSION(2,32,0)
 	g_mutex_unlock (&patterns_mutex);
 #else

--- a/src/image.c
+++ b/src/image.c
@@ -663,6 +663,11 @@ GdipDrawImageRectRect (GpGraphics *graphics, GpImage *image,
 		srcheight = gdip_unit_conversion (srcUnit, UnitCairoPoint, graphics->dpi_y, graphics->type, srcheight);
 	}
 
+	if (gdip_near_zero (srcwidth) || gdip_near_zero (dstwidth) ||
+	    gdip_near_zero (srcheight) || gdip_near_zero (dstheight)) {
+		return Ok;
+	}
+
 	org = dest = image->active_bitmap->scan0; 
 	org_format = image->active_bitmap->pixel_format;
 	org_surface = image->surface;
@@ -834,7 +839,7 @@ GdipDrawImageRectRect (GpGraphics *graphics, GpImage *image,
 
 		cairo_matrix_translate (&mat, srcx, srcy);
 
-		if (!gdip_near_zero(srcwidth - dstwidth) || !gdip_near_zero(srcheight - dstheight))
+		if (!gdip_near_zero(srcwidth - dstwidth) && !gdip_near_zero(srcheight - dstheight))
 			cairo_matrix_scale (&mat, srcwidth / dstwidth, srcheight / dstheight);
 
 		cairo_matrix_translate (&mat, -dstx, -dsty);
@@ -842,14 +847,16 @@ GdipDrawImageRectRect (GpGraphics *graphics, GpImage *image,
 		pattern = cairo_pattern_create_for_surface(original);
 		cairo_pattern_set_matrix (pattern, &mat);
 
-		orig = cairo_get_source(graphics->ct);
-		cairo_pattern_reference(orig);
+		g_assert (cairo_status (graphics->ct) == CAIRO_STATUS_SUCCESS);
 
-		cairo_set_source(graphics->ct, pattern);
+		orig = cairo_get_source (graphics->ct);
+		cairo_pattern_reference (orig);
+
+		cairo_set_source (graphics->ct, pattern);
 		cairo_rectangle (graphics->ct, dstx, dsty, dstwidth, dstheight);
 		cairo_fill (graphics->ct);
 		
-		cairo_set_source(graphics->ct, orig);
+		cairo_set_source (graphics->ct, orig);
 		cairo_pattern_destroy (orig);
 
 		cairo_matrix_init_identity (&mat);
@@ -916,6 +923,12 @@ GdipDrawImagePointsRect (GpGraphics *graphics, GpImage *image, GDIPCONST GpPoint
 	if (count == 4)
 		return NotImplemented;
 
+	/* Short circuit empty destination rectangle to avoid creating non-invertible matrix */
+	if (points[2].X + points[1].X - points[0].X - points[0].X == 0 &&
+	    points[2].Y + points[1].Y - points[0].Y - points[0].Y == 0) {
+		return Ok;
+	}
+
 	rect.X = 0; 
 	rect.Y = 0; 
 	if (image->type == ImageTypeBitmap) {
@@ -935,6 +948,7 @@ GdipDrawImagePointsRect (GpGraphics *graphics, GpImage *image, GDIPCONST GpPoint
 
 	cairo_get_matrix (graphics->ct, &orig_matrix);
 	gdip_cairo_set_matrix (graphics, matrix);
+	g_assert (cairo_status (graphics->ct) == CAIRO_STATUS_SUCCESS);
 	status = GdipDrawImageRectRect (graphics, image, rect.X, rect.Y, rect.Width, rect.Height, srcx, srcy, 
 		srcwidth, srcheight, srcUnit, imageAttributes, callback, callbackData);
 	cairo_set_matrix (graphics->ct, &orig_matrix);

--- a/src/image.c
+++ b/src/image.c
@@ -870,7 +870,7 @@ GdipDrawImageRectRect (GpGraphics *graphics, GpImage *image,
 		image->active_bitmap->scan0 = org;
 		image->active_bitmap->pixel_format = org_format;
 		image->surface = org_surface;
-		// NOTE: dest is freed by gdip_bitmap_invalidate_surface above
+		GdipFree (dest);
 	}
 	
 	return Ok;

--- a/tests/gtest.cpp
+++ b/tests/gtest.cpp
@@ -24,7 +24,7 @@
 TEST(RegionTests, GetRegionScans_CustomMatrix_TransformsRegionScans) {
 	STARTUP
 
-		GpMatrix* matrix = NULL;
+	GpMatrix* matrix = NULL;
 
 	ASSERT_EQ(0, GdipCreateMatrix(&matrix));
 	ASSERT_EQ(0, GdipTranslateMatrix(matrix, 10, 11, MatrixOrderPrepend));
@@ -43,13 +43,16 @@ TEST(RegionTests, GetRegionScans_CustomMatrix_TransformsRegionScans) {
 	int scansCount;
 	ASSERT_EQ(0, GdipGetRegionScans(region, &rects, &scansCount, matrix));
 
+	ASSERT_EQ(Ok, GdipDeleteRegion(region));
+	ASSERT_EQ(Ok, GdipDeleteMatrix(matrix));
+
 	SHUTDOWN
 }
 
 TEST(RegionTests, GdipGetPathWorldBounds) {
 	STARTUP
 
-		GpRegion* region = NULL;
+	GpRegion* region = NULL;
 	ASSERT_EQ(0, GdipCreateRegion(&region));
 
 	GpRectF rectangles[] =
@@ -67,6 +70,9 @@ TEST(RegionTests, GdipGetPathWorldBounds) {
 	ASSERT_EQ(bounds.Y, rectangles[0].Y);
 	ASSERT_EQ(bounds.Width, rectangles[0].Width);
 	ASSERT_EQ(bounds.Height, rectangles[0].Height);
+
+	ASSERT_EQ(Ok, GdipDeletePath(path));
+	ASSERT_EQ(Ok, GdipDeleteRegion(region));
 
 	SHUTDOWN
 }
@@ -169,6 +175,9 @@ TEST(MatrixTests, Ctor_FloatingPointBoundsInElements) {
 		GdipGetMatrixElements(matrix, elements);
 		ASSERT_EQ(0, elements[4]);
 		ASSERT_EQ(0, elements[5]);
+
+		ASSERT_EQ(Ok, GdipDeleteMatrix(matrix));
+		free(elements);
 	}
 
 	SHUTDOWN
@@ -187,6 +196,8 @@ TEST(MatrixTests, Invert_FloatBounds_ThrowsArgumentException) {
 		ASSERT_EQ(0, GdipCreateMatrix2(f, 0, 0, 1, 0, 0, &matrix));
 
 		ASSERT_EQ(InvalidParameter, GdipInvertMatrix(matrix));
+
+		ASSERT_EQ(Ok, GdipDeleteMatrix(matrix));
 	}
 
 	SHUTDOWN
@@ -212,6 +223,10 @@ TEST(MatrixTests, Multiply_Matrix_Success) {
 		ASSERT_EQ(FLT_MAX, elements[i]);
 	}
 
+	ASSERT_EQ(Ok, GdipDeleteMatrix(matrix));
+	ASSERT_EQ(Ok, GdipDeleteMatrix(multiple));
+	free(elements);
+
 	SHUTDOWN
 }
 
@@ -226,7 +241,6 @@ TEST(MatrixTests, Multiply_Matrix_Success2) {
 
 	ASSERT_EQ(0, GdipMultiplyMatrix(matrix, multiple, MatrixOrderAppend));
 
-
 	REAL* elements = (REAL*)malloc(6 * sizeof(float));
 	GdipGetMatrixElements(matrix, elements);
 
@@ -234,6 +248,10 @@ TEST(MatrixTests, Multiply_Matrix_Success2) {
 	{
 		ASSERT_EQ(0, elements[i]);
 	}
+
+	ASSERT_EQ(Ok, GdipDeleteMatrix(matrix));
+	ASSERT_EQ(Ok, GdipDeleteMatrix(multiple));
+	free(elements);
 
 	SHUTDOWN
 }
@@ -258,6 +276,10 @@ TEST(MatrixTests, Multiply_Matrix_Success3) {
 	}
 	ASSERT_EQ(50, elements[4]);
 	ASSERT_EQ(60, elements[5]);
+
+	ASSERT_EQ(Ok, GdipDeleteMatrix(matrix));
+	ASSERT_EQ(Ok, GdipDeleteMatrix(multiple));
+	free(elements);
 
 	SHUTDOWN
 }
@@ -294,6 +316,10 @@ TEST(CustomLineCapTests, Ctor_InvalidLineCap_ReturnsFlat) {
 		LineCap baseCap;
 		ASSERT_EQ(Ok, GdipGetCustomLineCapBaseCap(lineCap, &baseCap));
 		ASSERT_EQ(LineCapFlat, baseCap);
+
+		ASSERT_EQ(Ok, GdipDeleteCustomLineCap(lineCap));
+		ASSERT_EQ(Ok, GdipDeletePath(fillPath));
+		ASSERT_EQ(Ok, GdipDeletePath(strokePath));
 	}
 
 	SHUTDOWN
@@ -364,6 +390,10 @@ TEST(CustomLineCapTests, Ctor_Path_Path_LineCap_Float) {
 		LineCap baseCap;
 		ASSERT_EQ(Ok, GdipGetCustomLineCapBaseCap(lineCap, &baseCap));
 		ASSERT_EQ(expectedCap, baseCap);
+
+		ASSERT_EQ(Ok, GdipDeleteCustomLineCap(lineCap));
+		ASSERT_EQ(Ok, GdipDeletePath(fillPath));
+		ASSERT_EQ(Ok, GdipDeletePath(strokePath));
 	}
 
 	SHUTDOWN
@@ -445,6 +475,7 @@ TEST(ImageAttributesTests, ClearColorMatrix_Success) {
 	ASSERT_EQ(Ok, GdipBitmapGetPixel(bitmap, 0, 0, &actualColor));
 	ASSERT_EQ(green, actualColor);
 
+	ASSERT_EQ(Ok, GdipDisposeImageAttributes(attributes));
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
 	ASSERT_EQ(Ok, GdipDeleteGraphics(graphics));
 
@@ -484,6 +515,7 @@ TEST(ImageAttributesTests, ClearNoOp_Type_Success) {
 	ASSERT_EQ(Ok, GdipBitmapGetPixel(bitmap, 0, 0, &actualColor));
 	ASSERT_EQ(0xFF210000, actualColor);
 
+	ASSERT_EQ(Ok, GdipDisposeImageAttributes(attributes));
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
 	ASSERT_EQ(Ok, GdipDeleteGraphics(graphics));
 
@@ -511,6 +543,7 @@ TEST(ImageAttributesTests, SetGamma_Gamma_Success) {
 	ASSERT_EQ(Ok, GdipBitmapGetPixel(bitmap, 0, 0, &actualColor));
 	ASSERT_EQ(0xFF21FF00, actualColor);
 
+	ASSERT_EQ(Ok, GdipDisposeImageAttributes(attributes));
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
 	ASSERT_EQ(Ok, GdipDeleteGraphics(graphics));
 
@@ -539,6 +572,7 @@ TEST(ImageAttributesTests, ClearColorKey_Success) {
 	ASSERT_EQ(Ok, GdipBitmapGetPixel(bitmap, 0, 0, &actualColor));
 	ASSERT_EQ(green, actualColor);
 
+	ASSERT_EQ(Ok, GdipDisposeImageAttributes(attributes));
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
 	ASSERT_EQ(Ok, GdipDeleteGraphics(graphics));
 
@@ -567,6 +601,7 @@ TEST(ImageAttributesTests, ClearGamma_Type_Success) {
 	ASSERT_EQ(Ok, GdipBitmapGetPixel(bitmap, 0, 0, &actualColor));
 	ASSERT_EQ(green, actualColor);
 
+	ASSERT_EQ(Ok, GdipDisposeImageAttributes(attributes));
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
 	ASSERT_EQ(Ok, GdipDeleteGraphics(graphics));
 
@@ -595,6 +630,7 @@ TEST(ImageAttributesTests, ClearOutputChannelColorProfile_Success) {
 	ASSERT_EQ(Ok, GdipBitmapGetPixel(bitmap, 0, 0, &actualColor));
 	ASSERT_EQ(green, actualColor);
 
+	ASSERT_EQ(Ok, GdipDisposeImageAttributes(attributes));
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
 	ASSERT_EQ(Ok, GdipDeleteGraphics(graphics));
 
@@ -625,6 +661,7 @@ TEST(ImageAttributesTests, ClearRemapTable_Success) {
 	ASSERT_EQ(Ok, GdipBitmapGetPixel(bitmap, 0, 0, &actualColor));
 	ASSERT_EQ(colorMap[0].oldColor.Argb, actualColor);
 
+	ASSERT_EQ(Ok, GdipDisposeImageAttributes(attributes));
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
 	ASSERT_EQ(Ok, GdipDeleteGraphics(graphics));
 
@@ -652,6 +689,7 @@ TEST(ImageAttributesTests, ClearThreshold_ThresholdTypeI_Success) {
 	ASSERT_EQ(Ok, GdipBitmapGetPixel(bitmap, 0, 0, &actualColor));
 	ASSERT_EQ(green, actualColor);
 
+	ASSERT_EQ(Ok, GdipDisposeImageAttributes(attributes));
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
 	ASSERT_EQ(Ok, GdipDeleteGraphics(graphics));
 
@@ -678,6 +716,7 @@ TEST(ImageAttributesTests, GetAdjustedPalette_Disposed_ThrowsArgumentException) 
 	ASSERT_EQ(InvalidParameter, GdipGetImageAttributesAdjustedPalette(attributes, palette, ColorAdjustTypeDefault));
 
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
+	free(palette);
 
 	SHUTDOWN
 }
@@ -745,9 +784,9 @@ TEST(ImageAttributesTests, SetNoOp_Success) {
 	ASSERT_EQ(Ok, GdipBitmapGetPixel(bitmap, 0, 0, &actualColor));
 	ASSERT_EQ(green, actualColor);
 
+	ASSERT_EQ(Ok, GdipDisposeImageAttributes(attributes));
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
 	ASSERT_EQ(Ok, GdipDeleteGraphics(graphics));
-
 
 	SHUTDOWN
 }
@@ -774,6 +813,7 @@ TEST(ImageAttributesTests, SetThreshold_Threshold_Success) {
 	ASSERT_EQ(Ok, GdipBitmapGetPixel(bitmap, 0, 0, &actualColor));
 	ASSERT_EQ(0xFFFF00FF, actualColor);
 
+	ASSERT_EQ(Ok, GdipDisposeImageAttributes(attributes));
 	ASSERT_EQ(Ok, GdipDisposeImage(bitmap));
 	ASSERT_EQ(Ok, GdipDeleteGraphics(graphics));
 
@@ -822,6 +862,10 @@ TEST(GraphicsPathTests, AddArc_Rectangle_Success) {
 	ASSERT_NEAR(2.01370716, bounds.Y, 0.001);
 	ASSERT_NEAR(0, bounds.Width, 0.001);
 	ASSERT_NEAR(0.0137047768, bounds.Height, 0.001);
+
+	ASSERT_EQ(Ok, GdipDeletePath(path));
+	free(points);
+	free(types);
 
 	SHUTDOWN
 }

--- a/tests/lsansuppressions.txt
+++ b/tests/lsansuppressions.txt
@@ -1,1 +1,2 @@
 leak:XGetDefault
+leak:FcConfigAppFontAddFile

--- a/tests/testclip.c
+++ b/tests/testclip.c
@@ -133,7 +133,10 @@ test_gdip_clip()
 
 	C (GdipDeleteRegion (clip));
 	C (GdipDeleteGraphics (graphics));
+	C (GdipDeletePath (path));
+	C (GdipDeletePath (other_path));
 	C (GdipDisposeImage (bitmap));
+	C (GdipDisposeImage (other_bitmap));
 
 	GdipFree (scan0);
 }
@@ -188,6 +191,7 @@ test_gdip_clip_transform()
 
 	C (GdipDeleteRegion (clip));
 	C (GdipDeleteGraphics (graphics));
+	C (GdipDeletePath (path));
 	C (GdipDisposeImage (bitmap));
 
 	GdipFree (scan0);

--- a/tests/testclip.c
+++ b/tests/testclip.c
@@ -96,6 +96,8 @@ test_gdip_clip()
 	// Clear the clipped image (background)
 	C (GdipGraphicsClear (graphics, 0x80ff0000));
 
+	C (GdipDeleteGraphics (graphics));
+
 	// Now onto the second image
 
 	// Get the graphics

--- a/tests/testfont.c
+++ b/tests/testfont.c
@@ -225,6 +225,10 @@ static void test_privateAddFontFile ()
 	assertEqualInt (status, Ok);
 	assert (stringsEqual (name, "Code New Roman"));
 
+	// This causes a crash in GDI+.
+#if !defined(USE_WINDOWS_GDIPLUS)
+	GdipDeleteFontFamily (families[0]);
+#endif
 	GdipDeletePrivateFontCollection (&collection);
 
 	// Valid OTF file.
@@ -245,6 +249,10 @@ static void test_privateAddFontFile ()
 	assertEqualInt (status, Ok);
 	assert (stringsEqual (name, "Code New Roman"));
 
+	// This causes a crash in GDI+.
+#if !defined(USE_WINDOWS_GDIPLUS)
+	GdipDeleteFontFamily (families[0]);
+#endif
 	GdipDeletePrivateFontCollection (&collection);
 
 	// Invalid file.
@@ -306,6 +314,10 @@ static void test_privateAddMemoryFont ()
 	assert (stringsEqual (name, "Code New Roman"));
 
 	free (memory);
+	// This causes a crash in GDI+.
+#if !defined(USE_WINDOWS_GDIPLUS)
+	GdipDeleteFontFamily (families[0]);
+#endif
 	GdipDeletePrivateFontCollection (&collection);
 
 	// Valid OTF file.
@@ -328,6 +340,10 @@ static void test_privateAddMemoryFont ()
 	assert (stringsEqual (name, "Code New Roman"));
 
 	free (memory);
+	// This causes a crash in GDI+.
+#if !defined(USE_WINDOWS_GDIPLUS)
+	GdipDeleteFontFamily (families[0]);
+#endif
 	GdipDeletePrivateFontCollection (&collection);
 
 	// Invalid memory is ignored.
@@ -603,6 +619,7 @@ static void test_cloneFont ()
 
 	GdipDeleteFont (font);
 	GdipDeleteFont (clonedFont);
+	GdipDeleteFontFamily (family);
 }
 
 static void test_deleteFont ()
@@ -810,6 +827,7 @@ static void test_getLogfontA ()
 
 	GdipDeleteFont (font);
 	GdipDeleteFontFamily (originalFamily);
+	GdipDeleteGraphics (graphics);
 	GdipDisposeImage ((GpImage *) image);
 }
 
@@ -855,6 +873,7 @@ static void test_getLogfontW ()
 
 	GdipDeleteFont (font);
 	GdipDeleteFontFamily (originalFamily);
+	GdipDeleteGraphics (graphics);
 	GdipDisposeImage ((GpImage *) image);
 }
 

--- a/tests/testgpimage.c
+++ b/tests/testgpimage.c
@@ -692,6 +692,8 @@ static void test_getEncoderParameterList ()
 	assertEqualInt (parameters->Parameter[1].Type, EncoderParameterValueTypeLong);
 	assertEqualInt (((LONG *) parameters->Parameter[1].Value)[0], EncoderValueMultiFrame);
 
+	free (parameters);
+
 	// PNG encoder.
 	GdipGetEncoderParameterListSize (image, &pngEncoderClsid, &pngSize);
 	parameters = (EncoderParameters *) malloc (pngSize);
@@ -704,6 +706,8 @@ static void test_getEncoderParameterList ()
 	assertEqualInt (parameters->Parameter[0].NumberOfValues, 0);
 	assertEqualInt (parameters->Parameter[0].Type, (EncoderParameterValueType) 9);
 	assert (!parameters->Parameter[0].Value);
+
+	free (parameters);
 
 	// JPEG encoder.
 	GdipGetEncoderParameterListSize (image, &jpegEncoderClsid, &jpegSize);
@@ -742,6 +746,8 @@ static void test_getEncoderParameterList ()
 	assertEqualInt (parameters->Parameter[4].NumberOfValues, 0);
 	assertEqualInt (parameters->Parameter[4].Type, (EncoderParameterValueType) 9);
 	assert (!parameters->Parameter[4].Value);
+
+	free (parameters);
 
 	// Negative tests.
 	status = GdipGetEncoderParameterList (NULL, &emfEncoderClsid, 100, &buffer);

--- a/tests/testgraphics.c
+++ b/tests/testgraphics.c
@@ -1531,6 +1531,7 @@ static void test_rotateWorldTransform ()
 	GdipReleaseDC (graphics, hdc);
 
 	GdipDeleteGraphics (graphics);
+	GdipDisposeImage (image);
 	GdipDeleteRegion (clip);
 	GdipDeleteMatrix (transform);
 	GdipDeleteMatrix (matrix);
@@ -1719,6 +1720,7 @@ static void test_getClip ()
 	GdipDeleteGraphics (graphics);
 	GdipDisposeImage (image);
 	GdipDeleteMatrix (transform);
+	GdipDeleteRegion (clip);
 }
 
 static void test_getClipBounds ()
@@ -2524,13 +2526,14 @@ static void test_setClipGraphics ()
 {
 	GpStatus status;
 	GpImage *image;
+	GpImage *otherImage;
 	GpGraphics *graphics;
 	GpGraphics *otherGraphics;
 	GpRegion *clip;
 	GpRectF bounds;
 
 	graphics = getImageGraphics (&image);
-	otherGraphics = getImageGraphics (&image);
+	otherGraphics = getImageGraphics (&otherImage);
 	GdipCreateRegion (&clip);
 
 	// No transform.
@@ -2616,6 +2619,8 @@ static void test_setClipGraphics ()
 	GdipDeleteGraphics (graphics);
 	GdipDeleteGraphics (otherGraphics);
 	GdipDisposeImage (image);
+	GdipDisposeImage (otherImage);
+	GdipDeleteRegion (clip);
 }
 
 static void test_setClipHrgn ()
@@ -2684,7 +2689,9 @@ static void test_setClipHrgn ()
 	GdipReleaseDC (graphics, hdc);
 
 	GdipDeleteGraphics (graphics);
+	GdipDisposeImage (image);
 	GdipDeleteRegion (region);
+	GdipDeleteRegion ((GpRegion *)hrgn);
 }
 
 static void test_setClipRect ()
@@ -3554,6 +3561,7 @@ static void test_world_transform_respects_page_unit_document ()
 	GdipDisposeImage ((GpImage *)bitmap);
 	GdipDeleteGraphics (graphics);
 	GdipDeleteBrush (brush);
+	GdipDeleteMatrix (matrix);
 }
 
 static void test_world_transform_respects_page_unit_point ()

--- a/tests/testgraphicsdraw.c
+++ b/tests/testgraphicsdraw.c
@@ -1440,6 +1440,7 @@ static void test_drawCurveI ()
 
 	GdipDeleteGraphics (graphics);
 	GdipDisposeImage (image);
+	GdipDeletePen (pen);
 }
 
 static void test_drawCurve2 ()
@@ -8602,6 +8603,9 @@ static void test_drawImagePointsRect ()
 	status = GdipDrawImagePointsRect (graphics, bitmapImage, negativePoints, 3, 10, 10, 150, 100, UnitPixel, NULL, NULL, NULL);
 	assertEqualInt (status, Ok);
 
+	GdipDeleteGraphics (graphics);
+	GdipDisposeImage (image);
+
 	// Max Positive origin.
 	createImageGraphics (256, 256, &image, &graphics);
 	status = GdipDrawImagePointsRect (graphics, bitmapImage, points, 3, (REAL) GDIPLUS_MAXFLOAT, (REAL) GDIPLUS_MAXFLOAT, 150, 100, UnitPixel, NULL, NULL, NULL);
@@ -9195,6 +9199,9 @@ static void test_drawImagePointsRectI ()
 	createImageGraphics (256, 256, &image, &graphics);
 	status = GdipDrawImagePointsRectI (graphics, bitmapImage, negativePoints, 3, 10, 10, 150, 100, UnitPixel, NULL, NULL, NULL);
 	assertEqualInt (status, Ok);
+
+	GdipDeleteGraphics (graphics);
+	GdipDisposeImage (image);
 
 	// Max Positive origin.
 	createImageGraphics (256, 256, &image, &graphics);

--- a/tests/testgraphicspath.c
+++ b/tests/testgraphicspath.c
@@ -1604,6 +1604,9 @@ static void test_getPointCount ()
 	assertEqualInt (status, Ok);
 	assertEqualInt (count, 0);
 
+	GdipDeletePath (emptyPath);
+	GdipDeletePath (path);
+
 	// Non Empty.
 	GdipCreatePath2 (points, types, 4, FillModeWinding, &path);
 	status = GdipGetPointCount (path, &count);
@@ -1617,7 +1620,6 @@ static void test_getPointCount ()
 	status = GdipGetPointCount (path, NULL);
 	assertEqualInt (status, InvalidParameter);
 	
-	GdipDeletePath (emptyPath);
 	GdipDeletePath (path);
 }
 
@@ -2970,6 +2972,8 @@ static void test_flattenPath ()
 	assertEqualInt (status, Ok);
 	verifyPath (path, FillModeWinding, 1, 2, 3, 4, nonEmptyPoints, nonEmptyTypes, 4);
 	
+	GdipDeletePath (path);
+
 	// Non empty ellipse - null, one flatness.
 	GdipCreatePath (FillModeWinding, &path);
 	GdipAddPathEllipse (path, 1, 2, 3, 4);
@@ -4050,6 +4054,8 @@ static void test_addPathStringI ()
 
 	status = GdipAddPathStringI (path, string, -1, family, 0, 72, &layoutRect, format);
 	assertEqualInt (status, Ok);
+
+	GdipDeletePath (path);
 
 	// Minus one length - empty string.
 	GdipCreatePath (FillModeAlternate, &path);

--- a/tests/testhelpers.h
+++ b/tests/testhelpers.h
@@ -391,6 +391,7 @@ ATTRIBUTE_USED static void verifyRegionScansImpl (GpRegion *region, RectF *expec
 	}
 
 	GdipDeleteMatrix (matrix);
+    free (scans);
 }
 
 #define verifyRegionScans(region, expectedScans, expectedCount) \

--- a/tests/testlineargradientbrush.c
+++ b/tests/testlineargradientbrush.c
@@ -1430,6 +1430,7 @@ static void test_resetLineTransform ()
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (matrix);
+    GdipDeleteMatrix (transform);
 }
 
 static void test_multiplyLineTransform ()

--- a/tests/testmatrix.c
+++ b/tests/testmatrix.c
@@ -257,6 +257,8 @@ static void test_setMatrixElements ()
 	// Negative tests.
 	status = GdipSetMatrixElements (NULL, 1, 2, 3, 4, 5, 6);
 	assertEqualInt (status, InvalidParameter);
+
+	GdipDeleteMatrix (matrix);
 }
 
 static void test_multiplyMatrix ()
@@ -679,6 +681,8 @@ static void test_transformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 4);
 	assertEqualFloat (points[2].X, 5);
 	assertEqualFloat (points[2].Y, 6);
+
+	GdipDeleteMatrix (matrix);
 	
 	// Translate only matrix.
 	GdipCreateMatrix2 (1, 0, 0, 1, 2, 3, &matrix);
@@ -697,7 +701,9 @@ static void test_transformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 7);
 	assertEqualFloat (points[2].X, 7);
 	assertEqualFloat (points[2].Y, 9);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Scale only matrix.
 	GdipCreateMatrix2 (2, 0, 0, 4, 0, 0, &matrix);
 	points[0].X = 1;
@@ -715,7 +721,9 @@ static void test_transformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 16);
 	assertEqualFloat (points[2].X, 10);
 	assertEqualFloat (points[2].Y, 24);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Shear only matrix.
 	GdipCreateMatrix2 (1, 2, 3, 1, 0, 0, &matrix);
 	points[0].X = 1;
@@ -733,7 +741,9 @@ static void test_transformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 10);
 	assertEqualFloat (points[2].X, 23);
 	assertEqualFloat (points[2].Y, 16);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate and scale only matrix.
 	GdipCreateMatrix2 (2, 0, 0, 4, 2, 3, &matrix);
 	points[0].X = 1;
@@ -751,7 +761,9 @@ static void test_transformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 19);
 	assertEqualFloat (points[2].X, 12);
 	assertEqualFloat (points[2].Y, 27);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate and shear only matrix.
 	GdipCreateMatrix2 (1, 2, 3, 1, 2, 3, &matrix);
 	points[0].X = 1;
@@ -769,7 +781,9 @@ static void test_transformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 13);
 	assertEqualFloat (points[2].X, 25);
 	assertEqualFloat (points[2].Y, 19);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Scale and shear only matrix.
 	GdipCreateMatrix2 (2, 2, 3, 4, 0, 0, &matrix);
 	points[0].X = 1;
@@ -788,6 +802,8 @@ static void test_transformMatrixPoints ()
 	assertEqualFloat (points[2].X, 28);
 	assertEqualFloat (points[2].Y, 34);
 
+	GdipDeleteMatrix (matrix);
+
 	// Complex matrix.
 	GdipCreateMatrix2 (1, 2, 3, 4, 5, 6, &matrix);
 	points[0].X = 1;
@@ -805,6 +821,8 @@ static void test_transformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 28);
 	assertEqualFloat (points[2].X, 28);
 	assertEqualFloat (points[2].Y, 40);
+
+	GdipDeleteMatrix (matrix);
 
 	// Rounding.
 	GdipCreateMatrix2 (1.5, 0, 0, 1.5, 0, 0, &matrix);
@@ -870,7 +888,9 @@ static void test_transformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 4);
 	assertEqualInt (points[2].X, 5);
 	assertEqualInt (points[2].Y, 6);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate only matrix.
 	GdipCreateMatrix2 (1, 0, 0, 1, 2, 3, &matrix);
 	points[0].X = 1;
@@ -888,7 +908,9 @@ static void test_transformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 7);
 	assertEqualInt (points[2].X, 7);
 	assertEqualInt (points[2].Y, 9);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Scale only matrix.
 	GdipCreateMatrix2 (2, 0, 0, 4, 0, 0, &matrix);
 	points[0].X = 1;
@@ -906,7 +928,9 @@ static void test_transformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 16);
 	assertEqualInt (points[2].X, 10);
 	assertEqualInt (points[2].Y, 24);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Shear only matrix.
 	GdipCreateMatrix2 (1, 2, 3, 1, 0, 0, &matrix);
 	points[0].X = 1;
@@ -924,7 +948,9 @@ static void test_transformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 10);
 	assertEqualInt (points[2].X, 23);
 	assertEqualInt (points[2].Y, 16);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate and scale only matrix.
 	GdipCreateMatrix2 (2, 0, 0, 4, 2, 3, &matrix);
 	points[0].X = 1;
@@ -942,7 +968,9 @@ static void test_transformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 19);
 	assertEqualInt (points[2].X, 12);
 	assertEqualInt (points[2].Y, 27);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate and shear only matrix.
 	GdipCreateMatrix2 (1, 2, 3, 1, 2, 3, &matrix);
 	points[0].X = 1;
@@ -960,7 +988,9 @@ static void test_transformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 13);
 	assertEqualInt (points[2].X, 25);
 	assertEqualInt (points[2].Y, 19);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Scale and shear only matrix.
 	GdipCreateMatrix2 (2, 2, 3, 4, 0, 0, &matrix);
 	points[0].X = 1;
@@ -979,6 +1009,8 @@ static void test_transformMatrixPointsI ()
 	assertEqualInt (points[2].X, 28);
 	assertEqualInt (points[2].Y, 34);
 
+	GdipDeleteMatrix (matrix);
+
 	// Complex matrix.
 	GdipCreateMatrix2 (1, 2, 3, 4, 5, 6, &matrix);
 	points[0].X = 1;
@@ -996,6 +1028,8 @@ static void test_transformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 28);
 	assertEqualInt (points[2].X, 28);
 	assertEqualInt (points[2].Y, 40);
+
+	GdipDeleteMatrix (matrix);
 
 	// Rounding.
 	GdipCreateMatrix2 (1.5, 0, 0, 1.5, 0, 0, &matrix);
@@ -1066,7 +1100,9 @@ static void test_vectorTransformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 4);
 	assertEqualFloat (points[2].X, 5);
 	assertEqualFloat (points[2].Y, 6);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate only matrix.
 	GdipCreateMatrix2 (1, 0, 0, 1, 2, 3, &matrix);
 	points[0].X = 1;
@@ -1084,7 +1120,9 @@ static void test_vectorTransformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 4);
 	assertEqualFloat (points[2].X, 5);
 	assertEqualFloat (points[2].Y, 6);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Scale only matrix.
 	GdipCreateMatrix2 (2, 0, 0, 4, 0, 0, &matrix);
 	points[0].X = 1;
@@ -1102,7 +1140,9 @@ static void test_vectorTransformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 16);
 	assertEqualFloat (points[2].X, 10);
 	assertEqualFloat (points[2].Y, 24);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Shear only matrix.
 	GdipCreateMatrix2 (1, 2, 3, 1, 0, 0, &matrix);
 	points[0].X = 1;
@@ -1120,7 +1160,9 @@ static void test_vectorTransformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 10);
 	assertEqualFloat (points[2].X, 23);
 	assertEqualFloat (points[2].Y, 16);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate and scale only matrix.
 	GdipCreateMatrix2 (2, 0, 0, 4, 2, 3, &matrix);
 	points[0].X = 1;
@@ -1138,7 +1180,9 @@ static void test_vectorTransformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 16);
 	assertEqualFloat (points[2].X, 10);
 	assertEqualFloat (points[2].Y, 24);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate and shear only matrix.
 	GdipCreateMatrix2 (1, 2, 3, 1, 2, 3, &matrix);
 	points[0].X = 1;
@@ -1156,7 +1200,9 @@ static void test_vectorTransformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 10);
 	assertEqualFloat (points[2].X, 23);
 	assertEqualFloat (points[2].Y, 16);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Scale and shear only matrix.
 	GdipCreateMatrix2 (2, 2, 3, 4, 0, 0, &matrix);
 	points[0].X = 1;
@@ -1175,6 +1221,8 @@ static void test_vectorTransformMatrixPoints ()
 	assertEqualFloat (points[2].X, 28);
 	assertEqualFloat (points[2].Y, 34);
 
+	GdipDeleteMatrix (matrix);
+
 	// Complex matrix.
 	GdipCreateMatrix2 (1, 2, 3, 4, 5, 6, &matrix);
 	points[0].X = 1;
@@ -1192,6 +1240,8 @@ static void test_vectorTransformMatrixPoints ()
 	assertEqualFloat (points[1].Y, 22);
 	assertEqualFloat (points[2].X, 23);
 	assertEqualFloat (points[2].Y, 34);
+
+	GdipDeleteMatrix (matrix);
 
 	// Rounding.
 	GdipCreateMatrix2 (1.5, 0, 0, 1.5, 0, 0, &matrix);
@@ -1257,7 +1307,9 @@ static void test_vectorTransformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 4);
 	assertEqualInt (points[2].X, 5);
 	assertEqualInt (points[2].Y, 6);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate only matrix.
 	GdipCreateMatrix2 (1, 0, 0, 1, 2, 3, &matrix);
 	points[0].X = 1;
@@ -1275,7 +1327,9 @@ static void test_vectorTransformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 4);
 	assertEqualInt (points[2].X, 5);
 	assertEqualInt (points[2].Y, 6);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Scale only matrix.
 	GdipCreateMatrix2 (2, 0, 0, 4, 0, 0, &matrix);
 	points[0].X = 1;
@@ -1293,7 +1347,9 @@ static void test_vectorTransformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 16);
 	assertEqualInt (points[2].X, 10);
 	assertEqualInt (points[2].Y, 24);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Shear only matrix.
 	GdipCreateMatrix2 (1, 2, 3, 1, 0, 0, &matrix);
 	points[0].X = 1;
@@ -1311,7 +1367,9 @@ static void test_vectorTransformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 10);
 	assertEqualInt (points[2].X, 23);
 	assertEqualInt (points[2].Y, 16);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate and scale only matrix.
 	GdipCreateMatrix2 (2, 0, 0, 4, 2, 3, &matrix);
 	points[0].X = 1;
@@ -1329,7 +1387,9 @@ static void test_vectorTransformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 16);
 	assertEqualInt (points[2].X, 10);
 	assertEqualInt (points[2].Y, 24);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Translate and shear only matrix.
 	GdipCreateMatrix2 (1, 2, 3, 1, 2, 3, &matrix);
 	points[0].X = 1;
@@ -1347,7 +1407,9 @@ static void test_vectorTransformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 10);
 	assertEqualInt (points[2].X, 23);
 	assertEqualInt (points[2].Y, 16);
-	
+
+	GdipDeleteMatrix (matrix);
+
 	// Scale and shear only matrix.
 	GdipCreateMatrix2 (2, 2, 3, 4, 0, 0, &matrix);
 	points[0].X = 1;
@@ -1366,6 +1428,8 @@ static void test_vectorTransformMatrixPointsI ()
 	assertEqualInt (points[2].X, 28);
 	assertEqualInt (points[2].Y, 34);
 
+	GdipDeleteMatrix (matrix);
+
 	// Complex matrix.
 	GdipCreateMatrix2 (1, 2, 3, 4, 5, 6, &matrix);
 	points[0].X = 1;
@@ -1383,6 +1447,8 @@ static void test_vectorTransformMatrixPointsI ()
 	assertEqualInt (points[1].Y, 22);
 	assertEqualInt (points[2].X, 23);
 	assertEqualInt (points[2].Y, 34);
+
+	GdipDeleteMatrix (matrix);
 
 	// Rounding.
 	GdipCreateMatrix2 (1.5, 0, 0, 1.5, 0, 0, &matrix);
@@ -1440,6 +1506,8 @@ static void test_getMatrixElements ()
 
 	status = GdipGetMatrixElements (matrix, NULL);
 	assertEqualInt (status, InvalidParameter);
+
+	GdipDeleteMatrix (matrix);
 }
 
 static void test_isMatrixInvertible ()

--- a/tests/testmetafile.c
+++ b/tests/testmetafile.c
@@ -68,6 +68,10 @@ static void test_createMetafileFromFile ()
 
     status = GdipCreateMetafileFromFile (bitmapFilePath, &metafile);
     assertEqualInt (status, GenericError);
+
+    freeWchar (noSuchFilePath);
+    freeWchar (invalidFilePath);
+    freeWchar (bitmapFilePath);
 }
 
 static void test_createMetafileFromStream ()

--- a/tests/testmetafile.c
+++ b/tests/testmetafile.c
@@ -649,6 +649,7 @@ static void test_recordMetafile ()
     status = GdipRecordMetafile (hdc, EmfTypeEmfPlusDual, &rect, MetafileFrameUnitPixel, wmfFilePath, NULL);
     assertEqualInt (status, InvalidParameter);
 
+    GdipReleaseDC (graphics, hdc);
     GdipDisposeImage (wmfMetafile);
     GdipDisposeImage (emfMetafile);
     GdipDisposeImage (bitmap);

--- a/tests/testpathgradientbrush.c
+++ b/tests/testpathgradientbrush.c
@@ -298,6 +298,8 @@ static void test_createPathGradientI ()
     assertEqualInt (status, Ok);
     verifyPathGradientBrush (brush, 1, 2, 4, 11, 0xFF000000, 3, 7, WrapModeTile);
 
+    GdipDeleteBrush ((GpBrush *) brush);
+
     // Negative tests.
     brush = (GpPathGradient *) 0xCC;
     status = GdipCreatePathGradientI (NULL, 2, WrapModeClamp, &brush);
@@ -430,6 +432,8 @@ static void test_createPathGradientFromPath ()
     assertEqualInt (status, Ok);
     verifyPathGradientBrush (brush, 10, 20, 30, 40, 0xFFFFFFFF, 25, 40, WrapModeClamp);
 
+    GdipDeleteBrush ((GpBrush *) brush);
+
     // Negative tests.
     brush = (GpPathGradient *) 0xCC;
     status = GdipCreatePathGradientFromPath (NULL, &brush);
@@ -450,7 +454,6 @@ static void test_createPathGradientFromPath ()
     status = GdipCreatePathGradientFromPath (emptyPath, NULL);
     assertEqualInt (status, InvalidParameter);
 
-    GdipDeleteBrush ((GpBrush *) brush);
     GdipDeletePath (linePath);
     GdipDeletePath (emptyPath);
 }
@@ -568,6 +571,8 @@ static void test_getPathGradientSurroundColorsWithCount ()
     colors[2] = 0x00000000;
     colors[3] = 0x00000000;
     colors[4] = 0x00000000;
+
+    GdipDeleteBrush ((GpBrush *) brush);
 
     // From path.
     GdipCreatePathGradientFromPath (path, &brush);
@@ -721,6 +726,8 @@ static void test_setPathGradientSurroundColorsWithCount ()
     colors[1] = 0x00000000;
     colors[2] = 0x00000000;
     colors[3] = 0x00000000;
+
+    GdipDeleteBrush ((GpBrush *) brush);
 
     // One surround color.
     GdipCreatePathGradient (threePoints, 3, WrapModeTileFlipX, &brush);
@@ -1809,6 +1816,7 @@ static void test_setPathGradientTransform ()
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (matrix);
+    GdipDeleteMatrix (nonInvertibleMatrix);
     GdipDeleteMatrix (transform);
 }
 
@@ -1837,6 +1845,7 @@ static void test_resetPathGradientTransform ()
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteMatrix (matrix);
+    GdipDeleteMatrix (transform);
 }
 
 static void test_multiplyPathGradientTransform ()
@@ -2360,6 +2369,7 @@ static void test_cloneWithPath ()
 
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDeleteBrush ((GpBrush *) clonedBrush);
+    GdipDeletePath (path);
     GdipDeleteMatrix (transform);
     GdipDeleteMatrix (matrix);
 }

--- a/tests/testpen.c
+++ b/tests/testpen.c
@@ -705,6 +705,7 @@ static void test_setPenStartCap ()
 	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
+	GdipDeletePath (path);
 	GdipDeleteCustomLineCap (penCustomLineCap);
 	GdipDeleteCustomLineCap (customStartCap);
 }
@@ -772,6 +773,7 @@ static void test_setPenEndCap ()
 	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
+	GdipDeletePath (path);
 	GdipDeleteCustomLineCap (penCustomLineCap);
 	GdipDeleteCustomLineCap (customEndCap);
 }
@@ -996,6 +998,7 @@ static void test_setPenCustomStartCap ()
 	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
+	GdipDeletePath (path);
 	GdipDeleteCustomLineCap (penCustomLineCap);
 	GdipDeleteCustomLineCap (customStartCap);
 }
@@ -1055,6 +1058,7 @@ static void test_setPenCustomEndCap ()
 	assertEqualInt (status, InvalidParameter);
 
 	GdipDeletePen (pen);
+	GdipDeletePath (path);
 	GdipDeleteCustomLineCap (penCustomLineCap);
 	GdipDeleteCustomLineCap (customEndCap);
 }
@@ -1738,6 +1742,7 @@ static void test_setPenBrushFill ()
 	GdipDeleteBrush ((GpBrush *) solidBrush);
 	GdipDisposeImage (image);
 	GdipDeleteBrush ((GpBrush *) textureBrush);
+	GdipDeleteBrush ((GpBrush *) brush);
 }
 
 static void test_getPenBrushFill ()
@@ -2342,6 +2347,8 @@ static void test_getPenCompoundArray ()
 
 	status = GdipGetPenCompoundArray (pen, compounds, 1);
 	assertEqualInt (status, InvalidParameter);
+
+	GdipDeletePen (pen);
 }
 
 static void test_deletePen ()

--- a/tests/testregion.c
+++ b/tests/testregion.c
@@ -1412,6 +1412,7 @@ static void test_cloneRegion ()
 	assertEqualInt (status, Ok);
 	verifyRegion (clone, 10, 20, 30, 40, FALSE, FALSE);
 	GdipDeleteRegion (region);
+	GdipDeleteRegion (clone);
 
 	// Path region.
 	GdipCreatePath (FillModeWinding, &path);
@@ -1422,6 +1423,7 @@ static void test_cloneRegion ()
 	assertEqualInt (status, Ok);
 	verifyRegion (clone, 10, 20, 30, 40, FALSE, FALSE);
 	GdipDeleteRegion (region);
+	GdipDeleteRegion (clone);
 	GdipDeletePath (path);
 	
 	// Empty region.
@@ -1471,7 +1473,9 @@ static void test_deleteRegion ()
 	
 	status = GdipDeleteRegion (region);
 	assertEqualInt (status, Ok);
-	
+
+	GdipDeletePath (path);
+
 	// Empty region.
 	GdipCreateRegion (&region);
 	GdipSetEmpty (region);
@@ -1514,7 +1518,8 @@ static void test_setInfinite ()
 	verifyRegion (region, -4194304.0f, -4194304.0f, 8388608.0f, 8388608.0f, FALSE, TRUE);
 	assertEqualInt (status, Ok);
 	GdipDeleteRegion (region);
-	
+	GdipDeletePath (path);
+
 	// Empty region.
 	GdipCreateRegion (&region);
 	GdipSetEmpty (region);
@@ -1561,7 +1566,8 @@ static void test_setEmpty ()
 	verifyRegion (region, 0, 0, 0, 0, TRUE, FALSE);
 	assertEqualInt (status, Ok);
 	GdipDeleteRegion (region);
-	
+	GdipDeletePath (path);
+
 	// Empty region.
 	GdipCreateRegion (&region);
 	GdipSetEmpty (region);
@@ -1601,6 +1607,8 @@ static void test_getRegionBounds ()
 
 	status = GdipGetRegionBounds (region, graphics, NULL);
 	assertEqualInt (status, InvalidParameter);
+
+	GdipDeleteRegion (region);
 }
 
 static void test_isEmptyRegion ()
@@ -1620,6 +1628,8 @@ static void test_isEmptyRegion ()
 
 	status = GdipIsEmptyRegion (region, graphics, NULL);
 	assertEqualInt (status, InvalidParameter);
+
+	GdipDeleteRegion (region);
 }
 
 static void test_isEqualRegion ()
@@ -2633,18 +2643,32 @@ static void test_isEqualRegion ()
 
 	GdipDeleteRegion (infiniteRegion1);
 	GdipDeleteRegion (infiniteRegion2);
-	GdipDeleteRegion (infiniteRectRegion1);
-	GdipDeleteRegion (infiniteRectRegion2);
 	GdipDeleteRegion (emptyRegion1);
 	GdipDeleteRegion (emptyRegion2);
+	GdipDeleteRegion (infiniteRectRegion1);
+	GdipDeleteRegion (infiniteRectRegion2);
 	GdipDeleteRegion (emptyRectRegion1);
 	GdipDeleteRegion (emptyRectRegion2);
+	GdipDeleteRegion (zeroWidthRectRegion1);
+	GdipDeleteRegion (zeroWidthRectRegion2);
+	GdipDeleteRegion (zeroHeightRectRegion1);
+	GdipDeleteRegion (zeroHeightRectRegion2);
+	GdipDeleteRegion (negativeWidthRectRegion1);
+	GdipDeleteRegion (negativeWidthRectRegion2);
+	GdipDeleteRegion (negativeHeightRectRegion1);
+	GdipDeleteRegion (negativeHeightRectRegion2);
 	GdipDeleteRegion (rectRegion1);
 	GdipDeleteRegion (rectRegion2);
 	GdipDeleteRegion (rectRegion3);
 	GdipDeleteRegion (rectRegion4);
 	GdipDeleteRegion (rectRegion5);
 	GdipDeleteRegion (rectRegion6);
+	GdipDeleteRegion (multiRectRegion1);
+	GdipDeleteRegion (multiRectRegion2);
+	GdipDeleteRegion (multiRectRegion3);
+	GdipDeleteRegion (multiRectRegion4);
+	GdipDeleteRegion (multiRectRegion5);
+	GdipDeleteRegion (multiRectRegion6);
 	GdipDeleteRegion (emptyPathRegion1);
 	GdipDeleteRegion (emptyPathRegion2);
 	GdipDeleteRegion (infinitePathRegion1);
@@ -2655,6 +2679,15 @@ static void test_isEqualRegion ()
 	GdipDeleteRegion (pathRegion4);
 	GdipDeleteRegion (pathRegion5);
 	GdipDeleteRegion (pathRegion6);
+
+	GdipDeletePath (emptyPath);
+	GdipDeletePath (infinitePath);
+	GdipDeletePath (path1);
+	GdipDeletePath (path2);
+	GdipDeletePath (path3);
+	GdipDeletePath (path4);
+	GdipDeletePath (path5);
+	GdipDeletePath (path6);
 }
 
 static void test_isInfiniteRegion ()
@@ -2674,6 +2707,8 @@ static void test_isInfiniteRegion ()
 
 	status = GdipIsInfiniteRegion (region, graphics, NULL);
 	assertEqualInt (status, InvalidParameter);
+
+	GdipDeleteRegion (region);
 }
 
 static void test_isVisibleRegionPoint ()
@@ -2757,6 +2792,9 @@ static void test_isVisibleRegionPoint ()
 	status = GdipIsVisibleRegionPoint (region, 10, 19, NULL, &isVisible);
 	assertEqualInt (status, Ok);
 	assertEqualInt (isVisible, FALSE);
+
+	GdipDeleteRegion (region);
+	GdipDeletePath (path);
 
 	// Empty region.
 	GdipCreateRegion (&region);
@@ -2902,6 +2940,9 @@ static void test_isVisibleRegionPointI ()
 	status = GdipIsVisibleRegionPointI (region, 10, 19, graphics, &isVisible);
 	assertEqualInt (status, Ok);
 	assertEqualInt (isVisible, FALSE);
+
+	GdipDeleteRegion (region);
+	GdipDeletePath (path);
 
 	// Empty region.
 	GdipCreateRegion (&region);
@@ -3111,6 +3152,9 @@ static void test_isVisibleRegionRect ()
 	status = GdipIsVisibleRegionRect (region, 10, 20, 1, 0, NULL, &isVisible);
 	assertEqualInt (status, Ok);
 	assertEqualInt (isVisible, FALSE);
+
+	GdipDeleteRegion (region);
+	GdipDeletePath (path);
 
 	// Empty region.
 	GdipCreateRegion (&region);
@@ -3337,6 +3381,9 @@ static void test_isVisibleRegionRectI ()
 	assertEqualInt (status, Ok);
 	assertEqualInt (isVisible, FALSE);
 
+	GdipDeleteRegion (region);
+	GdipDeletePath (path);
+
 	// Empty region.
 	GdipCreateRegion (&region);
 	GdipSetEmpty (region);
@@ -3452,6 +3499,7 @@ static void test_getRegionScansCount ()
 	assertEqualInt (status, Ok);
 	assertEqualInt (count, 1);
 	GdipDeleteRegion (region);
+	GdipDeletePath (path);
 	
 	// Empty region.
 	GdipCreateRegion (&region);
@@ -4423,6 +4471,7 @@ static void test_combineIntersect ()
 		GpRegion *region2;
 		GdipCreateRegionRect (&negativeRect, &region2);
 		verifyCombineRegionWithRegion (region, region2, CombineModeIntersect, 20, 30, -10, -10, TRUE, FALSE, emptyScans, 0);
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual rect. */
@@ -4543,6 +4592,7 @@ static void test_combineIntersect ()
 		GpRegion *region2;
 		GdipCreateRegionRect (&negativeRect, &region2);
 		verifyCombineRegionWithRegion (region, region2, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual rect. */
@@ -4812,6 +4862,7 @@ static void test_combineIntersect ()
 		GpRegion *region2;
 		GdipCreateRegionRect (&negativeRect, &region2);
 		verifyCombineRegionWithRegion (region, region2, CombineModeIntersect, 0, 0, 0, 0, TRUE, FALSE, emptyScans, 0);
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual rect. */
@@ -6056,6 +6107,7 @@ static void test_combineXor ()
 		GpRegion *region2;
 		GdipCreateRegionRect (&negativeRect, &region2);
 		verifyCombineRegionWithRegion (region, region2, CombineModeXor, -4194304, -4194304, 8388608, 8388608, FALSE, TRUE, infiniteScans, sizeof (infiniteScans));
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual rect. */
@@ -6195,6 +6247,7 @@ static void test_combineXor ()
 		GdipCreateRegionRect (&negativeRect, &region2);
 		RectF negativeRectScan = {10, 20, 30, 40};
 		verifyCombineRegionWithRegion (region, region2, CombineModeXor, 10, 20, 30, 40, FALSE, FALSE, &negativeRectScan, sizeof (negativeRectScan));
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual rect. */
@@ -6638,6 +6691,7 @@ static void test_combineXor ()
 		GdipCreateRegionRect (&negativeRect, &region2);
 		RectF negativeRectScan = {10, 20, 30, 40};
 		verifyCombineRegionWithRegion (region, region2, CombineModeXor, 10, 20, 30, 40, FALSE, FALSE, &negativeRectScan, sizeof (negativeRectScan));
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual rect. */
@@ -6979,6 +7033,7 @@ static void test_combineExclude ()
 		GpRegion *region2;
 		GdipCreateRegionRect (&negativeRect, &region2);
 		verifyCombineRegionWithRegion (region, region2, CombineModeExclude, -4194304, -4194304, 8388608, 8388608, FALSE, TRUE, infiniteScans, sizeof (infiniteScans));
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual rect. */
@@ -7059,6 +7114,7 @@ static void test_combineExclude ()
 		GpRegion *region2;
 		GdipCreateRegionRect (&negativeRect, &region2);
 		verifyCombineRegionWithRegion (region, region2, CombineModeExclude, -4194304, -4194304, 8388608, 8388608, FALSE, TRUE, infiniteScans, sizeof (infiniteScans));
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual rect. */
@@ -7135,6 +7191,7 @@ static void test_combineExclude ()
 		GpRegion *region2;
 		GdipCreateRegionRect (&negativeRect, &region2);
 		verifyCombineRegionWithRegion (region, region2, CombineModeXor, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual rect. */
@@ -7281,6 +7338,7 @@ static void test_combineExclude ()
 		GpRegion *region2;
 		GdipCreateRegionRect (&negativeRect, &region2);
 		verifyCombineRegionWithRegion (region, region2, CombineModeExclude, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual path. */
@@ -7458,6 +7516,7 @@ static void test_combineExclude ()
 		GpRegion *region2;
 		GdipCreateRegionRect (&negativeRect, &region2);
 		verifyCombineRegionWithRegion (region, region2, CombineModeExclude, 10, 20, 30, 40, FALSE, FALSE, &rect, sizeof (rect));
+		GdipDeleteRegion (region);
 		GdipDeleteRegion (region2);
 
 		/* Second, test combining with an actual rect. */

--- a/tests/testtexturebrush.c
+++ b/tests/testtexturebrush.c
@@ -1830,6 +1830,7 @@ static void test_resetTextureTransform ()
     GdipDeleteBrush ((GpBrush *) brush);
     GdipDisposeImage (image);
     GdipDeleteMatrix (matrix);
+    GdipDeleteMatrix (transform);
 }
 
 static void test_multiplyTextureTransform ()


### PR DESCRIPTION
This builds up on fixes by @akoeplinger and fixes remaining memory leak errors reported by the ASAN/LSAN tools. It passes the included test suite (`make check`) and gtest suite (`make -C tests run-gtest`) on fully updated Ubuntu Linux 1804.