### PR TITLE
 Clean up memory management of gdip_process_bitmap_attributes

### DIFF
--- a/src/bitmap-private.h
+++ b/src/bitmap-private.h
@@ -156,7 +156,7 @@ BYTE* gdip_bitmap_get_premultiplied_scan0 (GpBitmap *bitmap) GDIP_INTERNAL;
 void gdip_bitmap_get_premultiplied_scan0_inplace (GpBitmap *bitmap, BYTE *premul) GDIP_INTERNAL;
 void gdip_bitmap_get_premultiplied_scan0_reverse (GpBitmap *bitmap, BYTE *premul) GDIP_INTERNAL;
 
-GpStatus gdip_process_bitmap_attributes (GpBitmap *bitmap, void **dest, GpImageAttributes* attr, BOOL *allocated) GDIP_INTERNAL;
+GpStatus gdip_process_bitmap_attributes (GpBitmap *bitmap, GpImageAttributes* attr, GpBitmap **dest_bitmap) GDIP_INTERNAL;
 
 ColorPalette* gdip_create_greyscale_palette (int num_colors) GDIP_INTERNAL;
 


### PR DESCRIPTION
Instead of manually fiddling with various pointers inside the `GpBitmap` structure and using fragile manipulation of the Cairo surface object just keep a full `GpBitmap` object copy when any image attributes are applied.