### PR TITLE
Fix clang warnings around implicit float conversions

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -2644,7 +2644,7 @@ GdipSetPageScale (GpGraphics *graphics, REAL scale)
 		return InvalidParameter;
 	if (graphics->state == GraphicsStateBusy)
 		return ObjectBusy;
-	if (scale <= 0.0 || scale > 1000000032)
+	if (scale <= 0.0 || scale > 1.0E+9)
 		return InvalidParameter;
 	
 	graphics->scale = scale;	


### PR DESCRIPTION
/Users/hugh/Documents/GitHub/libgdiplus/src/graphics.c:2647:30: warning: implicit conversion from 'int' to 'float' changes value from 1000000032 to 1.0E+9 [-Wimplicit-int-float-conversion]
