### PR TITLE
Don't draw the stroke when filling a path

### DIFF
--- a/src/graphics-cairo.c
+++ b/src/graphics-cairo.c
@@ -520,8 +520,7 @@ cairo_FillPath (GpGraphics *graphics, GpBrush *brush, GpPath *path)
 
 	cairo_set_fill_rule (graphics->ct, gdip_convert_fill_mode (path->fill_mode));
 
-	// filled paths includes the stroke
-	return fill_graphics_with_brush (graphics, brush, TRUE);
+	return fill_graphics_with_brush (graphics, brush, FALSE);
 }
 
 static void


### PR DESCRIPTION
When filling a `GraphicsPath`, a 1px stroke is also drawn. From the comment and related commits it seems that this behaviour was needed at some stage in the past, but my testing shows that it is no longer correct.

Test case (in Form Paint event):
```C#
using (var path = new GraphicsPath()) {
    path.AddRectangle(new Rectangle(10, 10, 1, 20));
    path.AddString("hi there", new FontFamily("Arial"), (int)FontStyle.Regular, 20, new Point(14, 10), StringFormat.GenericDefault);
    e.Graphics.FillPath(Brushes.Blue, path);
}

using (var path = new GraphicsPath()) {
    path.AddRectangle(new Rectangle(100, 10, 50, 50));
    e.Graphics.FillPath(Brushes.Green, path);
    using (var pen = new Pen(Color.FromArgb(128, Color.Red), 2))
        e.Graphics.DrawPath(pen, path);

    e.Graphics.TranslateTransform(100, 0);

    using (var brush = new SolidBrush(Color.FromArgb(128, Color.Red)))
        e.Graphics.FillPath(brush, path);
    e.Graphics.TranslateTransform(50, 0);
    using (var brush = new SolidBrush(Color.FromArgb(128, Color.Green)))
        e.Graphics.FillPath(brush, path);
}
```

Unmodified:
![Test showing problems such as overlapping boxes](https://user-images.githubusercontent.com/5079870/91507012-c5d09900-e927-11ea-985f-4fb7575b6cf8.png)

With this change:
![Test without problems](https://user-images.githubusercontent.com/5079870/91507000-bc473100-e927-11ea-806c-86d0ebee26a7.png)

For good measure, .Net Framework on Windows 8.1:
![Test on Windows](https://user-images.githubusercontent.com/5079870/91507322-a2f2b480-e928-11ea-87db-4570ebebc6a1.png)

As you can see above, it really messes up drawing text or anything narrow via a `GraphicsPath`.

After this change `fill_graphics_with_brush` is never called with `stroke` set to `TRUE` so I guess the parameter and code for drawing the stroke should be removed, but I didn't want to add that much noise initially.