### PR TITLE
Vertical text alignment and positioning fix

### DIFF
--- a/tests/testgraphicspath.c
+++ b/tests/testgraphicspath.c
@@ -4018,6 +4018,21 @@ static void test_addPathString ()
 	assertSimilarFloat (rect1.Y + rect1.Height, rect2.Y + rect2.Height, 5.0);
 	GdipDeletePath (path);
 
+	// Check with vertical text
+	GdipSetStringFormatFlags (format, StringFormatFlagsDirectionVertical);
+	GdipCreatePath (FillModeAlternate, &path);
+	status = GdipAddPathString (path, longString, -1, family, 0, fontSize, &longLayoutRect, format);
+	assertEqualInt (status, Ok);
+	status = GdipGetPathWorldBounds (path, &rect1, NULL, NULL);
+	assertEqualInt (status, Ok);
+	status = GdipMeasureString (graphics, longString, -1, font, &longLayoutRect, format, &rect2, NULL, NULL);
+	assertEqualInt (status, Ok);
+	assertSimilarFloat (rect1.X, rect2.X, 10.0);
+	assertSimilarFloat (rect1.Y, rect2.Y, 10.0);
+	assertSimilarFloat (rect1.X + rect1.Width, rect2.X + rect2.Width, 5.0);
+	assertSimilarFloat (rect1.Y + rect1.Height, rect2.Y + rect2.Height, 5.0);
+	GdipDeletePath (path);
+
 	// Dispose the Graphics stuff
 	GdipDeleteGraphics (graphics);
 	GdipDeleteFont (font);

--- a/tests/testtext.c
+++ b/tests/testtext.c
@@ -292,7 +292,6 @@ static void test_measure_string_alignment(void)
 			rect.Width = 200.0 * in_rect;
 			rect.Height = 100.0 * in_rect;
 			set_rect_empty (&bounds);
-			g_warning("in_rect %d, i %d\n", in_rect, i);
 			status = GdipMeasureString (graphics, teststring1, 1, font, &rect, format, &bounds, NULL, NULL);
 			expect (Ok, status);
 			expectf_ (td[i].x_x0 * in_rect + td[i].x_xx * bounds.Width + 5.0, bounds.X, 0.6);


### PR DESCRIPTION
Before fix:
![Screenshot_20200908_152640](https://user-images.githubusercontent.com/5079870/92429989-b420a880-f1e7-11ea-9cd6-fe1614de5784.png)
The vertical text is being drawn off-screen. Note the boxes (from measuring the string) for vertical left-to-right are correct, hence no test failures. `GdipAddPathString()` has much the same issue, so I've added a test there that has vertical text to detect the incorrect drawing location (fails without fix). I've also added tests for alignment when drawing at a point instead of in a box, and drawing with both vertical and right-to-left (which fail without the fix).

Here's a screenshot with only the changes to `pango_DrawString` applied, fixing the drawing location:
![Screenshot_20200908_154720](https://user-images.githubusercontent.com/5079870/92431068-9f91df80-f1ea-11ea-8f32-06bf7c56818d.png)
On vertical text the alignment is opposite what it should be, and on right-to-left it is also significantly offset horizontally. Hence there are also changes dealing with alignment.

With all changes:
![Screenshot_20200908_152509](https://user-images.githubusercontent.com/5079870/92429920-8176b000-f1e7-11ea-8676-a0840ce2d10a.png)
.Net / Windows 8.1 as a comparison:
![screenshot-Windows-text-alignment](https://user-images.githubusercontent.com/5079870/92429939-8fc4cc00-f1e7-11ea-9498-f4191593ad9a.png)

Test application: [text-align.txt](https://github.com/mono/libgdiplus/files/5185921/text-align.txt)
Compiles with `mcs -r:System.Windows.Forms,System.Drawing text-align.txt -unsafe`

Furthermore, as `gdip_pango_setup_layout` transforms the Cairo context on vertical text, `GdipAddPathString()` wasn't getting the correct path points. I've changed it to save and later restore the context to fix this.