### PR TITLE
Don't dispose of GpMetafile if a GpGraphics is using it

### DIFF
--- a/src/graphics-private.h
+++ b/src/graphics-private.h
@@ -126,6 +126,7 @@ typedef struct _Graphics {
 	float			aa_offset_y;
 	/* metafile-specific stuff */
 	EmfType			emf_type;
+	BOOL			own_metafile;	/* true when metafile is owned by the graphics instance */
 	GpMetafile		*metafile;
 	cairo_surface_t		*metasurface;	/* bogus surface to satisfy some API calls */
 	/* common-stuff */

--- a/src/image.c
+++ b/src/image.c
@@ -295,6 +295,9 @@ GdipGetImageGraphicsContext (GpImage *image, GpGraphics **graphics)
 		GpMetafile *mf = (GpMetafile*)image;
 		if (!mf->recording)
 			return OutOfMemory;
+		/* creating more than one graphics instance for a metafile is not supported */
+		if (mf->graphics)
+			return OutOfMemory;
 		*graphics = gdip_metafile_graphics_new (mf);
 		return *graphics ? Ok : OutOfMemory;
 	}

--- a/src/metafile-private.h
+++ b/src/metafile-private.h
@@ -68,6 +68,7 @@ struct _Metafile {
 	BOOL recording;		/* recording into memory (data), file (fp) or user stream (stream) */
 	FILE *fp;
 	void *stream;
+	GpGraphics *graphics;	/* set if GdipGetImageGraphicsContext was called */
 };
 
 typedef struct {


### PR DESCRIPTION
Allow GpGraphics to take ownership of GpMetafile on dispose

The Windows GDI+ allows the metafile instance to be disposed before the graphics instance.

To support that, keep track in the GpGraphics of whether it is responsible for freeing the GpMetafile.

If the graphics instance is deleted first, own_metafile is FALSE and nothing happens.

If the metafile instance is disposed first, set own_metafile to TRUE and don't dispose of the metafile. It will be disposed when the graphics instance is deleted.

---

Also on Windows GDI+ creating more than one graphics instance for a metafile
instance throws an OutOfMemoryException, so do the same in GdipGetImageGraphicsContext


---

This is related to https://github.com/dotnet/runtime/issues/37838