### PR TITLE
[Region Refactoring] Refactor gdip_region_convert_from_path

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -2289,8 +2289,7 @@ GdipGetClip (GpGraphics *graphics, GpRegion *region)
 	if (graphics->state == GraphicsStateBusy)
 		return ObjectBusy;
 
-	gdip_clear_region (region);
-	gdip_copy_region (graphics->clip, region);
+	gdip_region_set_region (region, graphics->clip);
 
 	if (gdip_is_matrix_empty (graphics->clip_matrix))
 		return Ok;

--- a/src/region-private.h
+++ b/src/region-private.h
@@ -76,7 +76,7 @@ BOOL gdip_is_InfiniteRegion (const GpRegion *region) GDIP_INTERNAL;
 BOOL gdip_is_Point_in_RectF_inclusive (float x, float y, GpRectF* rect) GDIP_INTERNAL;
 
 void gdip_clear_region (GpRegion *region) GDIP_INTERNAL;
-GpStatus gdip_copy_region (GpRegion *source, GpRegion *dest) GDIP_INTERNAL;
+GpStatus gdip_region_set_region (GpRegion *region, const GpRegion *other) GDIP_INTERNAL;
 
 #include "region.h"
 

--- a/src/region.c
+++ b/src/region.c
@@ -534,7 +534,7 @@ gdip_copy_region (GpRegion *source, GpRegion *dest)
  * Create a region (path-tree) from a path.
  */
 static GpStatus
-gdip_region_create_from_path (GpRegion *region, GpPath *path)
+gdip_region_set_path (GpRegion *region, const GpPath *path)
 {
 	// Clear the region.
 	gdip_clear_region (region);
@@ -585,7 +585,7 @@ gdip_region_convert_to_path (GpRegion *region)
 		return NotImplemented;
 	}
 	
-	return gdip_region_create_from_path (region, path);
+	return gdip_region_set_path (region, path);
 }
 
 /*
@@ -1515,7 +1515,7 @@ GdipCombineRegionPath (GpRegion *region, GpPath *path, CombineMode combineMode)
 		return InvalidParameter;
 
 	if (combineMode == CombineModeReplace) {
-		return gdip_region_create_from_path (region, path);
+		return gdip_region_set_path (region, path);
 	}
 	
 	BOOL infinite = gdip_is_InfiniteRegion (region);
@@ -1548,7 +1548,7 @@ GdipCombineRegionPath (GpRegion *region, GpPath *path, CombineMode combineMode)
 		switch (combineMode) {
 		case CombineModeIntersect:
 			/* The intersection of the infinite region with X is X */
-			return gdip_region_create_from_path (region, path);
+			return gdip_region_set_path (region, path);
 		case CombineModeUnion:
 			/* The union of the infinite region and X is the infinite region */
 			return GdipSetInfinite (region);
@@ -1576,7 +1576,7 @@ GdipCombineRegionPath (GpRegion *region, GpPath *path, CombineMode combineMode)
 			/* The union of the empty region and X is X */
 			/* The XOR of the empty region and X is X */
 			/* Everything is outside the empty region */
-			return gdip_region_create_from_path (region, path);
+			return gdip_region_set_path (region, path);
 		default:
 			break;
 		}
@@ -2350,7 +2350,7 @@ GdipCreateRegionPath (GpPath *path, GpRegion **region)
 	if (!result)
 		return OutOfMemory;
 
-	status = gdip_region_create_from_path (result, path);
+	status = gdip_region_set_path (result, path);
 	if (status != Ok) {
 		GdipDeleteRegion (result);
 		return status;

--- a/src/region.c
+++ b/src/region.c
@@ -530,6 +530,20 @@ gdip_copy_region (GpRegion *source, GpRegion *dest)
 	return Ok;
 }
 
+/*
+ * Create a region (path-tree) from a path.
+ */
+static GpStatus
+gdip_region_create_from_path (GpRegion *region, GpPath *path)
+{
+	region->type = RegionTypePath;
+	region->tree = (GpPathTree *) GdipAlloc (sizeof (GpPathTree));
+	if (!region->tree)
+		return OutOfMemory;
+
+	return GdipClonePath (path, &region->tree->path);
+}
+
 /* convert a rectangle-based region to a path based region */
 static GpStatus
 gdip_region_convert_to_path (GpRegion *region)
@@ -573,20 +587,6 @@ gdip_region_convert_to_path (GpRegion *region)
 
 	region->type = RegionTypePath;
 	return Ok;
-}
-
-/*
- * Create a region (path-tree) from a path.
- */
-static GpStatus
-gdip_region_create_from_path (GpRegion *region, GpPath *path)
-{
-	region->type = RegionTypePath;
-	region->tree = (GpPathTree *) GdipAlloc (sizeof (GpPathTree));
-	if (!region->tree)
-		return OutOfMemory;
-
-	return GdipClonePath (path, &region->tree->path);
 }
 
 /*

--- a/src/region.c
+++ b/src/region.c
@@ -573,13 +573,18 @@ gdip_region_convert_to_path (GpRegion *region)
 		for (int i = 0; i < region->cnt; i++) {
 			RectF normalized;
 			gdip_normalize_rectangle (&region->rects[i], &normalized);
-			GdipAddPathRectangle (region->tree->path, normalized.X, normalized.Y, normalized.Width, normalized.Height);
+			status = GdipAddPathRectangle (region->tree->path, normalized.X, normalized.Y, normalized.Width, normalized.Height);
+			if (status != Ok) {
+				GdipDeletePath (region->tree->path);
+				return status;
+			}
 		}
 
 		break;
 	}
 	default:
 		g_warning ("unknown type 0x%08X", region->type);
+		GdipDeletePath (region->tree->path);
 		return NotImplemented;
 	}
 

--- a/src/region.c
+++ b/src/region.c
@@ -536,6 +536,10 @@ gdip_copy_region (GpRegion *source, GpRegion *dest)
 static GpStatus
 gdip_region_create_from_path (GpRegion *region, GpPath *path)
 {
+	// Clear the region.
+	gdip_clear_region (region);
+
+	// Set the new data.
 	region->type = RegionTypePath;
 	region->tree = (GpPathTree *) GdipAlloc (sizeof (GpPathTree));
 	if (!region->tree)
@@ -1516,7 +1520,6 @@ GdipCombineRegionPath (GpRegion *region, GpPath *path, CombineMode combineMode)
 		return InvalidParameter;
 
 	if (combineMode == CombineModeReplace) {
-		gdip_clear_region (region);
 		return gdip_region_create_from_path (region, path);
 	}
 	
@@ -1550,7 +1553,6 @@ GdipCombineRegionPath (GpRegion *region, GpPath *path, CombineMode combineMode)
 		switch (combineMode) {
 		case CombineModeIntersect:
 			/* The intersection of the infinite region with X is X */
-			GdipSetEmpty (region);
 			return gdip_region_create_from_path (region, path);
 		case CombineModeUnion:
 			/* The union of the infinite region and X is the infinite region */
@@ -1579,7 +1581,6 @@ GdipCombineRegionPath (GpRegion *region, GpPath *path, CombineMode combineMode)
 			/* The union of the empty region and X is X */
 			/* The XOR of the empty region and X is X */
 			/* Everything is outside the empty region */
-			GdipSetEmpty (region);
 			return gdip_region_create_from_path (region, path);
 		default:
 			break;


### PR DESCRIPTION
- Clear the region in `gdip_region_create_from_path`
- Add missing status checks in calls to `GdipAddPathRectangle`
- Explicitly handle `RegionTypeInfinite` in `gdip_region_convert_to_path`
- Implement `gdip_region_convert_to_path` on top of `gdip_region_create_from_path`
- Rename `gdip_region_create_from_path` to match meaning

This change achieves some things
- Adds missing status checks and memory leaks in the error path where GdipAddPathRectangle fails
- Avoid duplicate code (e.g. creating the path tree and clearing the existing path data) between `gdip_region_convert_from_path` and `gdip_region_create_from_path`
- Avoid duplicate code clearing the path data each time we call `gdip_region_create_from_path`: we should always clear existing data!
- Rename `gdip_region_create_from_path` to `gdip_region_set_path` to better match the meaning of the method - we're not actually creating a region, but rather overwriting existing data

The motivation for this is to avoid duplicate code and enable future refactorings such as lazily creating path tree data

Should be merged BEFORE #675 