### PR TITLE
Keeping track of temporary files created by GdipPrivateAddMemoryFont

### DIFF
--- a/src/fontcollection-private.h
+++ b/src/fontcollection-private.h
@@ -37,12 +37,19 @@
 
 #include "gdiplus-private.h"
 
+struct _StringList {
+	char* 				str;
+	struct _StringList* next;
+};
+typedef struct _StringList StringList;
+
 struct _FontCollection {
 	FcFontSet*	fontset;
 	FcConfig*	config;		/* Only for private collections */
 #ifdef USE_PANGO_RENDERING
 	PangoFontMap*	pango_font_map;
 #endif
+	StringList* tempfiles;
 };
 
 #include "fontcollection.h"


### PR DESCRIPTION
This should fix #690.

I've added a list of strings that should go along with the `GpFontCollection`, this list are the temporary files created by the `GdipPrivateAddMemoryFont` function.

When `Dispose` is called by C# code, `GdipDeletePrivateFontCollection` should go through the list and `remove`s all temp files created.

There are ways to get files associated with an `FcConfig`, however, it will be hard to distinguish between files added using `GdipPrivateAddMemoryFont` or files managed by the user added through `GdipPrivateAddFontFile`, so I guess keeping a list of strings for later deletion is still a good solution.