### PR TITLE
Grouped fonts with same family

### DIFF
--- a/src/fontcollection-private.h
+++ b/src/fontcollection-private.h
@@ -37,12 +37,19 @@
 
 #include "gdiplus-private.h"
 
+struct _StringList {
+	char* 				str;
+	struct _StringList* next;
+};
+typedef struct _StringList StringList;
+
 struct _FontCollection {
 	FcFontSet*	fontset;
 	FcConfig*	config;		/* Only for private collections */
 #ifdef USE_PANGO_RENDERING
 	PangoFontMap*	pango_font_map;
 #endif
+	StringList* tempfiles;
 };
 
 #include "fontcollection.h"

--- a/src/fontfamily-private.h
+++ b/src/fontfamily-private.h
@@ -40,6 +40,7 @@
 struct _FontFamily {
 	struct _FontCollection *collection;
 	FcPattern*	pattern;
+	FcPattern*	relatives[16];
 	BOOL		allocated;
 	short 		height;
 	short 		linespacing;


### PR DESCRIPTION
This should fix #692.

I've changed `GpFontFamily` implementation, so that it keeps tracks of all fonts of the same family. I've also changed FontFamily functions so that they handle style properly like they should on Windows.

This code should work correctly after applying fix:
```
            fontCollection = new PrivateFontCollection();

            var resourceNames = Assembly.GetExecutingAssembly().GetManifestResourceNames()
                .Where((name) => name.StartsWith("UI.Fonts.OpenSans"));
            
            foreach (var resoureName in resourceNames)
            {
                var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resoureName);
                var fontData = new byte[stream.Length];
                stream.Read(fontData, 0, (int)stream.Length);
                stream.Dispose();

                var fontPtr = Marshal.AllocCoTaskMem(fontData.Length);
                Marshal.Copy(fontData, 0, fontPtr, fontData.Length);
                fontCollection.AddMemoryFont(fontPtr, fontData.Length);
                Marshal.FreeCoTaskMem(fontPtr);
            }

            Light = fontCollection.Families.FirstOrDefault(font => font.Name == "Open Sans Light");
            Regular = fontCollection.Families.FirstOrDefault(font => font.Name == "Open Sans");
            ExtraBold = fontCollection.Families.FirstOrDefault(font => font.Name == "Open Sans ExtraBold");
            SemiBold = fontCollection.Families.FirstOrDefault(font => font.Name == "Open Sans SemiBold");

            System.Windows.Forms.MessageBox.Show(string.Join("\n", fontCollection.Families.Select(f => f.Name)));
            Preview(new Font(Regular, 72, FontStyle.Bold | FontStyle.Italic), "ABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^");
```
Before applying fix, with build from head of `master`:
On my Ubuntu 20.04 with latest `mono`, the library seems to pick a random style:
This is output from multiple runs:
First run:
![image](https://user-images.githubusercontent.com/57174311/107386046-0f075480-6b26-11eb-8dda-37820eea2cbd.png)
Second run:
![Screenshot from 2021-02-09 22-29-15](https://user-images.githubusercontent.com/57174311/107386668-a7053e00-6b26-11eb-99a5-04c2e733ff5d.png)

After applying fix, the correct style (Bold Itatlic) is applied:
![Screenshot from 2021-02-09 22-35-27](https://user-images.githubusercontent.com/57174311/107387150-20049580-6b27-11eb-8197-80c607a2e76d.png)
