### PR TITLE
Big-endian fix: Header conversion

### DIFF
--- a/src/bmpcodec.c
+++ b/src/bmpcodec.c
@@ -188,8 +188,8 @@ gdip_bitmap_fill_info_header (GpBitmap *bitmap, PBITMAPINFOHEADER bmi)
 	memset (bmi, 0, sizeof (BITMAPINFOHEADER));
 #ifdef WORDS_BIGENDIAN
 	bmi->biSize = GUINT32_FROM_LE (sizeof (BITMAPINFOHEADER));
-	bmi->biWidth = GULONG_FROM_LE (bitmap->active_bitmap->width);
-	bmi->biHeight = GULONG_FROM_LE (bitmap->active_bitmap->height);
+	bmi->biWidth = GUINT32_FROM_LE (bitmap->active_bitmap->width);
+	bmi->biHeight = GUINT32_FROM_LE (bitmap->active_bitmap->height);
 	bmi->biPlanes = GUINT16_FROM_LE (1);
 	if (format != PixelFormat24bppRGB)
 		bmi->biBitCount = GUINT16_FROM_LE (gdip_get_pixel_format_bpp (bitmap->active_bitmap->pixel_format));
@@ -197,8 +197,8 @@ gdip_bitmap_fill_info_header (GpBitmap *bitmap, PBITMAPINFOHEADER bmi)
 		bmi->biBitCount = GUINT16_FROM_LE (24);
 	bmi->biCompression = GUINT32_FROM_LE (BI_RGB);
 	bmi->biSizeImage =  GUINT32_FROM_LE (0); /* Many tools expect this may be set to zero for BI_RGB bitmaps */
-	bmi->biXPelsPerMeter = GULONG_FROM_LE ((int) (0.5f + ((gdip_get_display_dpi() * 3937) / 100)));
-	bmi->biYPelsPerMeter = GULONG_FROM_LE ((int) (0.5f + ((gdip_get_display_dpi() * 3937) / 100))); /* 1 meter is = 39.37 */       
+	bmi->biXPelsPerMeter = GUINT32_FROM_LE ((int) (0.5f + ((gdip_get_display_dpi() * 3937) / 100)));
+	bmi->biYPelsPerMeter = GUINT32_FROM_LE ((int) (0.5f + ((gdip_get_display_dpi() * 3937) / 100))); /* 1 meter is = 39.37 */
 #else
 	bmi->biSize = sizeof (BITMAPINFOHEADER);
 	bmi->biWidth = bitmap->active_bitmap->width;

--- a/src/metafile.c
+++ b/src/metafile.c
@@ -1268,9 +1268,9 @@ EnhMetaHeaderLE (ENHMETAHEADER3 *emf)
 	emf->nVersion = GUINT32_FROM_LE (emf->nVersion);
 	emf->nBytes = GUINT32_FROM_LE (emf->nBytes);
 	emf->nRecords = GUINT32_FROM_LE (emf->nRecords);
-	emf->nHandles = GUINT32_FROM_LE (emf->nHandles);
+	emf->nHandles = GUINT16_FROM_LE (emf->nHandles);
 
-	emf->sReserved = GUINT32_FROM_LE (emf->sReserved);
+	emf->sReserved = GUINT16_FROM_LE (emf->sReserved);
 	emf->nDescription = GUINT32_FROM_LE (emf->nDescription);
 	emf->offDescription = GUINT32_FROM_LE (emf->offDescription);
 	emf->nPalEntries = GUINT32_FROM_LE (emf->nPalEntries);


### PR DESCRIPTION
On big-endian systems, various file header elements need to be
byte-swapped.  In a few places, current code used the conversion
function for the wrong data type.