### PR TITLE
Big-endian fix: Reading PNG files

### DIFF
--- a/src/pngcodec.c
+++ b/src/pngcodec.c
@@ -299,8 +299,13 @@ gdip_load_png_image_from_file_or_stream (FILE *fp, GetBytesDelegate getBytesFunc
 	if (bit_depth == 16) {
 		png_set_strip_16 (png_ptr);
 		png_set_gray_to_rgb (png_ptr);
+#ifndef WORDS_BIGENDIAN
 		png_set_bgr (png_ptr);
 		png_set_add_alpha (png_ptr, 0xFF, PNG_FILLER_AFTER);
+#else
+		png_set_swap_alpha (png_ptr);
+		png_set_add_alpha (png_ptr, 0xFF, PNG_FILLER_BEFORE);
+#endif
 		channels = 4;
 	}
 
@@ -309,13 +314,23 @@ gdip_load_png_image_from_file_or_stream (FILE *fp, GetBytesDelegate getBytesFunc
 		|| (bit_depth == 8 && original_color_type != PNG_COLOR_TYPE_PALETTE)) {
 		png_set_expand (png_ptr);
 		png_set_gray_to_rgb (png_ptr);
+#ifndef WORDS_BIGENDIAN
 		png_set_bgr (png_ptr);
 		png_set_add_alpha (png_ptr, 0xFF, PNG_FILLER_AFTER);
+#else
+		png_set_swap_alpha (png_ptr);
+		png_set_add_alpha (png_ptr, 0xFF, PNG_FILLER_BEFORE);
+#endif
 	}
 
 	if (bit_depth == 8 && !(channels == 1 && (original_color_type == PNG_COLOR_TYPE_PALETTE || original_color_type == PNG_COLOR_TYPE_GRAY))) {
+#ifndef WORDS_BIGENDIAN
 		png_set_bgr (png_ptr);
 		png_set_add_alpha (png_ptr, 0xFF, PNG_FILLER_AFTER);
+#else
+		png_set_swap_alpha (png_ptr);
+		png_set_add_alpha (png_ptr, 0xFF, PNG_FILLER_BEFORE);
+#endif
 	}
 
 	// Update the image properties after the transformations have been applied.


### PR DESCRIPTION
When reading PNG files, the result must match the Cairo format
CAIRO_FORMAT_ARGB32.  This stores the pixel data as a 32-bit
quantity in native byte order.

Therefore, the PNG decoder must place the bytes in A,R,G,B
order on a big-endian system (as opposed to B,G,R,A on a
little-endian system).  Set up the libpng flags accordingly.