### PR TITLE
Fix Windows build on CI

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -146,7 +146,7 @@ stages:
         value: 'giflib libjpeg-turbo libpng cairo glib tiff libexif glib pango'
       steps:
         - script: |
-            mkdir $(VCPKG_DEFAULT_BINARY_CACHE)
+            md "$(VCPKG_DEFAULT_BINARY_CACHE)"
             vcpkg install $(VCPKG_LIBS_TO_INSTALL) --triplet x86-windows
             vcpkg install $(VCPKG_LIBS_TO_INSTALL) --triplet x64-windows
             vcpkg integrate install

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -14,7 +14,12 @@ stages:
       displayName: Linux x64
       timeoutInMinutes: 120
       pool:
-        vmImage: ubuntu-16.04
+        vmImage: ubuntu-16.04 
+      variables:
+      - name: VCPKG_DEFAULT_BINARY_CACHE
+        value: $(Build.BinariesDirectory)/vcpkg_archives
+      - name: VCPKG_LIBS_TO_INSTALL
+        value: 'giflib libjpeg-turbo libpng cairo glib tiff libexif glib pango'
       steps:
         - bash: |
             sudo apt update
@@ -141,19 +146,26 @@ stages:
         vmImage: windows-2019
       steps:
         - script: |
-            vcpkg install giflib libjpeg-turbo libpng cairo glib tiff libexif glib pango --triplet x86-windows
-            vcpkg install giflib libjpeg-turbo libpng cairo glib tiff libexif glib pango --triplet x64-windows
+            mkdir $(VCPKG_DEFAULT_BINARY_CACHE)
+            vcpkg install $(VCPKG_LIBS_TO_INSTALL) --triplet x86-windows
+            vcpkg install $(VCPKG_LIBS_TO_INSTALL) --triplet x64-windows
             vcpkg integrate install
           displayName: 'Install Windows dependencies'
 
-        - task: MSBuild@1
+        - task: Cache@2
+          displayName: Cache vcpkg binaries
+          inputs:
+            key: '$(VCPKG_LIBS_TO_INSTALL) | $(Agent.OS)'
+            path: '$(VCPKG_DEFAULT_BINARY_CACHE)'
+
+        - task: VSBuild@1
           displayName: 'Build libgdiplus x86'
           inputs:
             solution: libgdiplus.sln
             platform: Win32
             configuration: Release
 
-        - task: MSBuild@1
+        - task: VSBuild@1
           displayName: 'Build libgdiplus x64'
           inputs:
             solution: libgdiplus.sln

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -15,11 +15,6 @@ stages:
       timeoutInMinutes: 120
       pool:
         vmImage: ubuntu-18.04
-      variables:
-      - name: VCPKG_DEFAULT_BINARY_CACHE
-        value: $(Build.BinariesDirectory)/vcpkg_archives
-      - name: VCPKG_LIBS_TO_INSTALL
-        value: 'giflib libjpeg-turbo libpng cairo glib tiff libexif glib pango'
       steps:
         - bash: |
             sudo apt update
@@ -144,6 +139,11 @@ stages:
       timeoutInMinutes: 120
       pool:
         vmImage: windows-2019
+      variables:
+      - name: VCPKG_DEFAULT_BINARY_CACHE
+        value: $(Build.BinariesDirectory)/vcpkg_archives
+      - name: VCPKG_LIBS_TO_INSTALL
+        value: 'giflib libjpeg-turbo libpng cairo glib tiff libexif glib pango'
       steps:
         - script: |
             mkdir $(VCPKG_DEFAULT_BINARY_CACHE)

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -141,9 +141,9 @@ stages:
         vmImage: windows-2019
       steps:
         - script: |
-            vcpkg integrate install
             vcpkg install giflib libjpeg-turbo libpng cairo glib tiff libexif glib pango --triplet x86-windows
             vcpkg install giflib libjpeg-turbo libpng cairo glib tiff libexif glib pango --triplet x64-windows
+            vcpkg integrate install
           displayName: 'Install Windows dependencies'
 
         - task: MSBuild@1

--- a/src/libgdiplus.vcxproj
+++ b/src/libgdiplus.vcxproj
@@ -22,9 +22,9 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{BE724C6E-BF07-4B3E-901B-7584BC7B6C8A}</ProjectGuid>
     <RootNamespace>libgdiplus</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>

--- a/src/libgdiplus.vcxproj
+++ b/src/libgdiplus.vcxproj
@@ -93,6 +93,9 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <!-- Workaround for https://github.com/microsoft/vcpkg/issues/17702 -->
       <AdditionalIncludeDirectories Condition="'$(_ZVcpkgCurrentInstalledDir)' != ''">%(AdditionalIncludeDirectories);$(_ZVcpkgCurrentInstalledDir)\include\glib-2.0;$(_ZVcpkgCurrentInstalledDir)\lib\glib-2.0\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(_ZVcpkgCurrentInstalledDir)' != ''">%(AdditionalIncludeDirectories);$(_ZVcpkgCurrentInstalledDir)\include\pango-1.0</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(_ZVcpkgCurrentInstalledDir)' != ''">%(AdditionalIncludeDirectories);$(_ZVcpkgCurrentInstalledDir)\include\cairo</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(_ZVcpkgCurrentInstalledDir)' != ''">%(AdditionalIncludeDirectories);$(_ZVcpkgCurrentInstalledDir)\include\harfbuzz</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/libgdiplus.vcxproj
+++ b/src/libgdiplus.vcxproj
@@ -91,6 +91,8 @@
       <!-- FIXME: To align with the GDI+ calling convention, this should be StdCall. Only relevant on x86 -->
       <CallingConvention>Cdecl</CallingConvention>
       <AdditionalIncludeDirectories>$(ProjectDir)..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- Workaround for https://github.com/microsoft/vcpkg/issues/17702 -->
+      <AdditionalIncludeDirectories Condition="'$(_ZVcpkgCurrentInstalledDir)' != ''">%(AdditionalIncludeDirectories);$(_ZVcpkgCurrentInstalledDir)\include\glib-2.0;$(_ZVcpkgCurrentInstalledDir)\lib\glib-2.0\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Hopefully a fix for

```
##[error]C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v150\Microsoft.Cpp.WindowsSDK.targets(46,5): Error MSB8036: The Windows SDK version 8.1 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution".
```