### PR TITLE
Notify pango font map when adding another font file

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -243,6 +243,9 @@ GdipPrivateAddFontFile (GpFontCollection *fontCollection, GDIPCONST WCHAR *filen
 
 	fclose (fileHandle);
 	FcConfigAppFontAddFile (fontCollection->config, file);
+#if USE_PANGO_RENDERING
+	pango_fc_font_map_config_changed((PangoFcFontMap *)fontCollection->pango_font_map);
+#endif
 
 	GdipFree (file);
 	return Ok;


### PR DESCRIPTION
Got a bit boggled by `testfont` failing on getting font family props, figured I'd take a look. Turns out you have to slap pango font map whenever config changes.

Looks like it could be the cause for #716