### PR TITLE
Apply PageUnit to clip regions.

### DIFF
--- a/src/graphics-cairo.c
+++ b/src/graphics-cairo.c
@@ -835,11 +835,16 @@ cairo_SetGraphicsClip (GpGraphics *graphics)
 	if (gdip_is_InfiniteRegion (graphics->overall_clip))
 		return Ok;
 
-	if (gdip_is_matrix_empty (graphics->clip_matrix)) {
+	/* Clip region is in device coordinates but we're drawing in page coordinates
+	 * so we need to draw with an inverse page transform */
+	GpMatrix page;
+	gdip_get_inverse_page_transform(graphics, &page);
+
+	if (gdip_is_matrix_empty (&page)) {
 		work = graphics->overall_clip;
 	} else {
 		GdipCloneRegion (graphics->overall_clip, &work);
-		GdipTransformRegion (work, graphics->clip_matrix);
+	 	GdipTransformRegion (work, &page);
 	}
 
 	switch (work->type) {

--- a/src/graphics-private.h
+++ b/src/graphics-private.h
@@ -157,6 +157,8 @@ typedef struct _Graphics {
 } Graphics;
 
 float gdip_unit_conversion (Unit from, Unit to, float dpi, GraphicsType type, float nSrc) GDIP_INTERNAL;
+void gdip_get_page_transform(GpGraphics* graphics, GpMatrix* matrix) GDIP_INTERNAL;
+void gdip_get_inverse_page_transform(GpGraphics* graphics, GpMatrix* matrix) GDIP_INTERNAL;
 
 void gdip_set_cairo_clipping (GpGraphics *graphics) GDIP_INTERNAL;
 GpStatus gdip_calculate_overall_clipping (GpGraphics *graphics) GDIP_INTERNAL;


### PR DESCRIPTION
I know this repo is dead, but maybe this will be useful to someone...

Previously `PageUnit` was being ignored when applying/calculating clips. Adds a `gdip_get_page_transform` function which combines the `clip_matrix` and `PageUnit` scaling (together with its inverse in `gdip_get_inverse_page_transform`) and uses this when setting the clip region and calculating clip bounds.

Also adds tests for these operations.

NOTE: This does not implement support for `PageScale`; I assume this should just be a simple additional scaling step applied to the page transform but I didn't need support for this at this point.